### PR TITLE
fix(SAL-60): webpack 빌드 설정 결함 수정

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,28 +1,28 @@
-import js from '@eslint/js';
-import globals from 'globals';
-import tseslint from 'typescript-eslint';
-import reactHooks from 'eslint-plugin-react-hooks';
-import prettierConfig from 'eslint-config-prettier';
+import js from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import prettierConfig from "eslint-config-prettier";
 
 export default tseslint.config(
-  { ignores: ['dist/', 'node_modules/'] },
+  { ignores: ["dist/", "node_modules/"] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
-  reactHooks.configs.flat['recommended-latest'],
+  reactHooks.configs.flat["recommended-latest"],
   {
-    files: ['src/**/*.{ts,tsx}'],
+    files: ["src/**/*.{ts,tsx}"],
     languageOptions: {
       globals: globals.browser,
     },
   },
   {
-    files: ['webpack/**/*.cjs'],
+    files: ["webpack/**/*.cjs"],
     languageOptions: {
       globals: globals.node,
-      sourceType: 'commonjs',
+      sourceType: "commonjs",
     },
     rules: {
-      '@typescript-eslint/no-require-imports': 'off',
+      "@typescript-eslint/no-require-imports": "off",
     },
   },
   prettierConfig,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@11.20.0",
   "engines": {
-    "node": "^24.0.0"
+    "node": "^24.11.0"
   },
   "browserslist": [
     "defaults"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
     "dev": "webpack serve --config webpack/webpack.dev.cjs",
     "build": "webpack --config webpack/webpack.prod.cjs",
     "typecheck": "tsc --noEmit",
-    "webpack-merge": "^6.0.1",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
@@ -51,6 +50,7 @@
     "typescript-eslint": "^8.66.0",
     "webpack": "^5.109.2",
     "webpack-cli": "^7.2.2",
-    "webpack-dev-server": "^5.2.6"
+    "webpack-dev-server": "^5.2.6",
+    "webpack-merge": "^6.0.1"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       webpack-dev-server:
         specifier: ^5.2.6
         version: 5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack-cli@7.2.2)(webpack@5.109.2)
+      webpack-merge:
+        specifier: ^6.0.1
+        version: 6.0.1
 
 packages:
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 allowBuilds:
   core-js-pure: false
   esbuild: true
+engineStrict: true

--- a/frontend/webpack/webpack.dev.cjs
+++ b/frontend/webpack/webpack.dev.cjs
@@ -13,6 +13,7 @@ module.exports = merge(common, {
         use: {
           loader: "babel-loader",
           options: {
+            envName: "development",
             plugins: ["react-refresh/babel"],
           },
         },

--- a/frontend/webpack/webpack.prod.cjs
+++ b/frontend/webpack/webpack.prod.cjs
@@ -20,7 +20,12 @@ module.exports = merge(common, {
       {
         test: /\.[jt]sx?$/,
         exclude: /node_modules/,
-        use: "babel-loader",
+        use: {
+          loader: "babel-loader",
+          options: {
+            envName: "production",
+          },
+        },
       },
       {
         test: /\.vanilla\.css$/i,


### PR DESCRIPTION
## 작업 내용

- [x] pnpm install 후 typecheck, lint, format:check, build가 모두 통과한다
- [x] 빌드 산출물에서 jsxDEV 호출이 나오지 않는다
- [x] 새로 클론한 사람이 pnpm install과 pnpm dev만으로 개발 서버를 띄운다

## 확인 사항

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 참고 사항

직접 적용 해보고 확인해야합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated supported Node.js requirements and enabled strict package compatibility checks.
  - Improved dependency configuration for more reliable frontend setup and builds.

- **Refactor**
  - Standardized development and production build environment handling.
  - Improved consistency in build tooling configuration without changing application behavior.

- **Style**
  - Aligned linting configuration formatting for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->