### PR TITLE
setup(SAL-77): collector, processor, api 패키지 경계와 Clock을 서울 시간으로 고정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/gustler/backend/api/ApiDomain.java
+++ b/backend/src/main/java/com/gustler/backend/api/ApiDomain.java
@@ -1,0 +1,5 @@
+package com.gustler.backend.api;
+
+// 패키지 의존성 테스트를 위한 임시 클래스입니다. 해당 패키지에 파일이 생기면 삭제해도 됩니다.
+public class ApiDomain {
+}

--- a/backend/src/main/java/com/gustler/backend/collector/CollectorDomain.java
+++ b/backend/src/main/java/com/gustler/backend/collector/CollectorDomain.java
@@ -1,0 +1,5 @@
+package com.gustler.backend.collector;
+
+// 패키지 의존성 테스트를 위한 임시 클래스입니다. 해당 패키지에 파일이 생기면 삭제해도 됩니다.
+public class CollectorDomain {
+}

--- a/backend/src/main/java/com/gustler/backend/config/ClockConfig.java
+++ b/backend/src/main/java/com/gustler/backend/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package com.gustler.backend.config;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/processor/ProcessorDomain.java
+++ b/backend/src/main/java/com/gustler/backend/processor/ProcessorDomain.java
@@ -1,0 +1,5 @@
+package com.gustler.backend.processor;
+
+// 패키지 의존성 테스트를 위한 임시 클래스입니다. 해당 패키지에 파일이 생기면 삭제해도 됩니다.
+public class ProcessorDomain {
+}

--- a/backend/src/test/java/com/gustler/backend/PackageBoundaryTest.java
+++ b/backend/src/test/java/com/gustler/backend/PackageBoundaryTest.java
@@ -1,0 +1,45 @@
+package com.gustler.backend;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+@AnalyzeClasses(
+    packages = "com.gustler.backend",
+    importOptions = ImportOption.DoNotIncludeTests.class
+)
+public class PackageBoundaryTest {
+
+    @ArchTest
+    static final ArchRule apiShouldNotDependOnCollectorOrProcessor = noClasses()
+        .that().resideInAPackage("com.gustler.backend.api..")
+        .should().dependOnClassesThat()
+        .resideInAnyPackage(
+            "com.gustler.backend.collector..",
+            "com.gustler.backend.processor.."
+        )
+        .because("api는 collector나 processor를 모른다");
+
+    @ArchTest
+    static final ArchRule collectorShouldNotDependOnApiOrProcessor = noClasses()
+        .that().resideInAPackage("com.gustler.backend.collector..")
+        .should().dependOnClassesThat()
+        .resideInAnyPackage(
+            "com.gustler.backend.api..",
+            "com.gustler.backend.processor.."
+        )
+        .because("collector는 api나 processor를 모른다");
+
+    @ArchTest
+    static final ArchRule processorShouldNotDependOnApiOrCollector = noClasses()
+        .that().resideInAPackage("com.gustler.backend.processor..")
+        .should().dependOnClassesThat()
+        .resideInAnyPackage(
+            "com.gustler.backend.api..",
+            "com.gustler.backend.collector.."
+        )
+        .because("processor는 api나 collector를 모른다");
+}

--- a/backend/src/test/java/com/gustler/backend/TimeSourceTest.java
+++ b/backend/src/test/java/com/gustler/backend/TimeSourceTest.java
@@ -1,0 +1,30 @@
+package com.gustler.backend;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+@AnalyzeClasses(
+    packages = "com.gustler.backend",
+    importOptions = ImportOption.DoNotIncludeTests.class
+)
+public class TimeSourceTest {
+
+    @ArchTest
+    static final ArchRule timeMustComeFromInjectedClock = noClasses()
+        .should().callMethod(Instant.class, "now")
+        .orShould().callMethod(LocalDate.class, "now")
+        .orShould().callMethod(LocalDateTime.class, "now")
+        .orShould().callMethod(ZonedDateTime.class, "now")
+        .orShould().callMethod(System.class, "currentTimeMillis")
+        .orShould().callConstructor(Date.class)
+        .because("서버 타임존에 따라 값이 달라진다. 시각은 주입받은 Clock 에서만 얻는다");
+}

--- a/backend/src/test/resources/archunit.properties
+++ b/backend/src/test/resources/archunit.properties
@@ -1,0 +1,2 @@
+# ? ?
+archRule.failOnEmptyShould=false

--- a/backend/src/test/resources/archunit.properties
+++ b/backend/src/test/resources/archunit.properties
@@ -1,2 +1,0 @@
-# ? ?
-archRule.failOnEmptyShould=false


### PR DESCRIPTION
## 구현 내용

- `collector` · `processor` · `api` 패키지 위치 구성했습니다.
- 패키지 간 임포트 방지하려고 ArchUnit 규칙을 추가했습니다.
- 시각 기준을 서울(`Asia/Seoul`)로 고정한 `Clock` 빈 추가했습니다.
- `now()` 나 `new Date()` 이런 함수를 호출하지 못하도록 ArchUnit 규칙 추가했습니다.

## 설계 결정

### 패키지 경계를 컴파일러가 아닌 CI 테스트로 검사한다

배치(`collector` + `processor`)와 웹(`api`)을 별도 프로세스로 띄우기로 했는데요.
그러면 코드 레벨에서 이 패키지 간 임포트가 불가능하도록 해야 합니다.

근데 자바 접근제어자로 어떻게 되려나? 했는데 당연한 소리일 수 있지만 불가능해요.
-> `collector 트리끼리는 임포트되고 collector 에서 api 내부 코드 임포트는 안 된다` 가 불가능!

결국 사람이 매번 신경 써야 하는데, 그건... 너무 어렵습니다.
규칙을 어기는 경우도 많을 코로구요.

<br/>

처음에는 Gradle 멀티모듈을 고민했는데요.

장점은 컴파일 단계에서 패키지 임포트가 불가능합니다. 코로굳굳
근데 저희는 세 패키지가 DB 하나를 같이 쓰는데요, 마이그레이션을 어느 모듈에 둘지가 애매하더라고요.
그렇다고 공용 모듈을 만들면 그 모듈이 collector, processor 스키마를 전부 알게 되는 것도 불편했습니다.

<br/>

그래서 단일 모듈로 가는 걸 제안합니다!
대신 CI 단계에서 패키지 간 임포트 시 잡아낼 수 있는 방법을 활용했습니다.
ArchUnit 을 활용하면 api, collector, processor 패키지 간 임포트가 존재하면 테스트가 터지도록 만들어 뒀습니다.

그럼 머지되기 전에 pr 단계에서 잡아낼 수 있습니다!

<br/>

### JVM 시각을 서울로 설정

기본 설정인 `Clock.systemDefaultZone()` 은 JVM 타임존을 따라가고, JVM 은 OS 설정을 따라갑니다.

서버 타임존 자체를 KST 로 바꾸는 방법도 있는데요,
우선 서버 설정은 안 건드리고, 빈으로 Clock 을 서울 시간으로 등록했습니다.
서버가 어느 타임존이든 결과가 같습니다.

앞으로 실시간 차량 응답에 관측 시각을 내보낼 거라 더 중요해지고요.

나중에 개발 중에 시각 정보가 필요하면 Clock 을 주입받아서 사용해주세요!

```java
@Service
@AllArgsConstructor
public class SomeService {

    private final Clock clock;   // ← 이렇게!
}
```

## 확인 사항

- [x] 패키지 경계 테스트가 실제로 동작하는지 일부러 임포트 어겨서 확인했습니다~ 정상 작동 중.
