### PR TITLE
chore(SAL-89): CI 빌드 캐시와 중복 실행 취소, 테스트 결과 노출 추가

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -6,12 +6,17 @@ on:
   pull_request:
     branches: [ "dev", "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   backend-build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
+      checks: write
 
     defaults:
       run:
@@ -28,5 +33,16 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
       - name: Build with Gradle
         run: ./gradlew build
+
+      - name: Publish test report
+        if: ${{ !cancelled() }}
+        uses: mikepenz/action-junit-report@v6
+        with:
+          report_paths: backend/build/test-results/test/TEST-*.xml
+          check_name: 'BE 테스트 결과'
+          detailed_summary: true

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -40,10 +40,9 @@ jobs:
         run: ./gradlew build
 
       - name: Publish test report
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && hashFiles('backend/build/test-results/test/TEST-*.xml') != '' }}
         uses: mikepenz/action-junit-report@v6
         with:
           report_paths: backend/build/test-results/test/TEST-*.xml
           check_name: 'BE 테스트 결과'
           detailed_summary: true
-          require_tests: true

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -46,3 +46,4 @@ jobs:
           report_paths: backend/build/test-results/test/TEST-*.xml
           check_name: 'BE 테스트 결과'
           detailed_summary: true
+          require_tests: true


### PR DESCRIPTION
## 구현 내용

- 빌드할 때마다 의존성을 새로 받던 걸 캐시하도록 했습니다.
- 같은 PR에 연달아 푸시하면 이전 실행이 자동으로 취소되게 했습니다.
- 테스트 결과를 PR 화면에서 바로 볼 수 있게 했습니다.

## 설계 결정

### 캐시 추가했습니다

원래는 캐시 설정을 해두지 않았기 때문에
지금 워크플로를 보면 JDK 깔고 바로 `./gradlew build` 를 실행합니다.

그래서 PR 올릴 때마다 `Spring Boot`나 `ArchUnit` 등의 의존성을 처음부터 전부 다시 내려받고 있습니다.

앞으로 코드가 기하급수로 늘 예정이고, 빌드/테스트 쪽에 신경을 많이 쓰지 못할 것 같아서 미리 작업해두려고 합니다.

<br/>

방법이 두 가지였는데,

첫 번째는 이미 쓰고 있는 `setup-java` 에 캐시 옵션을 추가하는 것입니다.

```yaml
- name: Set up JDK 21
  uses: actions/setup-java@v4
  with:
    java-version: '21'
    distribution: 'temurin'
    cache: 'gradle'   # <<<<<< 여기
```

제일 간단한데, 이건 내려받은 의존성만 캐시합니다.

<br/>

두 번째는 Gradle 이 만든 공식 액션을 사용하는 것입니다.

```yaml
- name: Set up Gradle
  uses: gradle/actions/setup-gradle@v6
```

이러면 의존성도 캐시하고, Gradle 빌드도 같이 캐시한다고 합니다.
(안 바뀐 부분은 아예 다시 안 돌림.)

덤으로 Actions 화면에 빌드 요약도 남겨준다네요. 코로굳굳

어차피 스텝 한 줄 추가라 이 방향을 제안합니다!

<br/>

근데 솔직히...지금 당장 확 빨라지진 않음...

최근 실행만 따지면 44~57초 밖에 안 돼서 급한 건 아니었는데,
앞으로 의존성이랑 테스트가 늘어날 수록 효과가 커질 겁니다!

<br/>

### 같은 PR에 연달아 푸시하면 앞 실행을 버리기

PR에 커밋이 추가될 때마다 CI 워크플로우가 도는 구조인데요.
문제는 커밋을 연달아 올리면, 순차적으로 모든 버전에 돌게 됩니다.

이건 `concurrency` 설정 해두면 막을 수 있어요.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

`group` 단위로 하나의 플로우만 도는 겁니다.
워크플로우 이름 + 브랜치로 잡으면
같은 브랜치(`dev` or `main`)의 `BACKEND-CI`끼리 한 그룹이 됩니다.

만약 같은 브랜치에 새 커밋이 올라와서 워크플로우 실행이 들어오면
앞 커밋 버전에서 돌아가던 워크플로우가 취소됩니다.

<br/>

`cancel-in-progress` 에 이 취소 조건을 걸 수 있는데, PR 대상만 취소하고 싶어서 위처럼 조건을 걸었습니다.

- PR에서 온 실행이면 → `true` → 앞 실행 취소
- `dev` or `main` 푸시면 → `false` → 취소 안 함

<br/>

### 테스트 결과를 PR에서 볼 수 있습니다

Gradle이 테스트 돌고 나면 결과를 XML로 만들어 둡니다.

```
backend/build/test-results/test/
├── TEST-com.gustler.backend.PackageBoundaryTest.xml
├── TEST-com.gustler.backend.TimeSourceTest.xml
└── TEST-com.gustler.backend.BackendApplicationTests.xml
```

이걸 읽어서 PR 체크로 띄워주는 액션을 붙였습니다.

```yaml
- name: Publish test report
  if: ${{ !cancelled() }}
  uses: mikepenz/action-junit-report@v6
  with:
    report_paths: backend/build/test-results/test/TEST-*.xml
    check_name: 'BE 테스트 결과'
    detailed_summary: true
```

각 요소 설명 첨부합니다.

- `report_paths` - XML 경로입니다. 레포 최상단 기준이라 `backend/` 내부의 테스트 파일만 대상이 됩니다.
- `check_name` - PR 체크 목록에 이 제목으로 뜹니다
- `detailed_summary` - 테스트별로 펼쳐서 보여줍니다

<br/>

`if` 조건은 보통 빌드가 실패해도 리포트는 띄워야 해서 `always()` 를 쓰는데요.
취소된 실행은 테스트가 돌다 말아서 XML이 없거나 미완성 상태입니다.
이걸 리포트로 만들면 또 거기서 실패가 뜬다고 하네요..!

그래서 `!cancelled()` 로 뒀습니다.

<br/>

### 리포트 액션 때문에 write 권한 추가했습니다

```yaml
permissions:
  contents: read
  checks: write   # ← 추가
```

테스트 리포트 액션이 PR에 체크를 만들려면 쓰기 권한이 필요합니다.
GitHub Actions는 기본이 최소 권한이라 명시해줘야 한다고 하네요.


## 추가 사항

현재 BE 관련 라벨이 부족한 것 같아서 몇개 추가해보려고 합니다!