### PR TITLE
chore(SAL-90): 백엔드 변경이 있을 때만 Backend CI가 실행되도록 paths 필터 추가

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -3,8 +3,14 @@ name: BACKEND-CI
 on:
   push:
     branches: [ "dev", "main" ]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
   pull_request:
     branches: [ "dev", "main" ]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## 구현 내용

- 프론트 파일만 바뀐 PR에서는 `BACKEND-CI` 가 아예 안 돌게 했습니다.

## 설계 결정

### 프론트 PR에서 백엔드 CI 워크플로우가 돌고 있었습니다

루~멘이 FE PR에서도 백엔드 CI가 돈다고 말해주었는데,
저는 분명 job에 디렉토리 설정을 backend로 걸어뒀거든요..!

```yaml
defaults:
  run:
    working-directory: backend
```

알고보니 `working-directory` 조건이 안 먹히고 있었습니다

<br/>

### 근데 왜..?

이 설정이 `run` 스텝이 어느 폴더에서 실행되는지만 정하는 거라서 **언제 도는지랑은 관계가 없었습니다**.
(+ 그리고 `run` 에만 적용되고 `uses` 액션에는 또 적용이 안 된다고 하네요.)

<br/>

### 그럼 어디에??

그래서 결론은 실제 트리거를 여기서 정해야 합니다.

```yaml
on:
  pull_request:
    branches: [ "dev", "main" ]
    paths: # <<<<<< 여기
      - 'backend/**'
      - '.github/workflows/backend-ci.yml'
```

`backend/` 폴더가  변경된 PR에서만 BACKEND-CI 워크플로우가 돕니다.

<br/>

### 워크플로우 파일 자체를 넣은 이유...?

CI 파일이 /backend 폴더 바깥에 있는데요.
백엔드 CI 워크플로우를 수정하는 PR에서 CI가 제대로 도는지 확인해야 해서 넣었습니다.

<br/>

### 그럼 다른 문제는? 없는지???

나중에 브랜치 룰셋에 'CI나 CD를 무조건 통과해야 한다' 같은 규칙을 붙이게 되면 문제가 됩니다.
(지금은 룰셋 없음)

예를 들어 `required_status_checks` 룰에 job 의 키인 `backend-build` 를 넣어두면,
이 job이 무조건 통과해야 머지되는 규칙을 추가할 수 있습니다.

근데 FE PR에서는 `backend-build` 가 돌지 않기 때문에 규칙이 `Waiting for status` 상태로 머지 버튼이 안 열립니다.

<br/>

나중에 만약 룰셋에 넣고싶다면 이 방식은 못 쓰고, 
job은 항상 돌리는데 안쪽 스텝에 if문으로 건너뛰게 하는 방식 등을 고려해보면 좋을 것 같습니다.

지금 상황에선 충분한 것 같습니다!