### PR TITLE
chore(SAL-79): 프론트엔드 CI 워크플로우 추가

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,61 @@
+name: FRONTEND-CI
+
+on:
+  push:
+    branches: ["dev", "main"]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+
+  pull_request:
+    branches: ["dev", "main"]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  frontend-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js and pnpm
+        uses: pnpm/setup@v1
+        with:
+          version: 11.20.0
+          runtime: node@24
+          cache: true
+          cache-dependency-path: frontend/pnpm-lock.yaml
+          package-json-file: frontend/package.json
+          install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Check formatting
+        run: pnpm format:check
+
+      - name: Type check
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## 작업 내용

- 프론트엔드 CI 워크플로우(‎`frontend-ci.yml`) 추가
- ‎`dev`, ‎`main` 대상 push / PR에서 ‎`lint → format:check → typecheck → build` 순으로 실행

## 확인 사항

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 참고 사항

- @korogoo 의 [PR](https://github.com/woowacourse-teams/2026-salmonbus/pull/22#event-29792699736)에서 알게된 path 설정의 도움을 받아 `/frontend`의 파일 변경시에만 CI가 트리거 되도록 진행했습니다.
- 아직 테스트 전략과 환경 세팅이 마련되지 않아, 추후 test 단계를 추가할 예정입니다.
- 추후 브랜치 룰셋(필수 status check 등)이 적용된다면 현재 ‎`paths` 필터 방식은 다시 논의가 필요할 거 같습니다.