### PR TITLE
setup(SAL-83): DB 연결과 Flyway 기반 구축

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,13 +18,26 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom 'org.testcontainers:testcontainers-bom:1.21.3' // Spring Boot 4.1 BOM 이 관리하지 않는다.
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-restclient'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-flyway'
+    runtimeOnly 'org.flywaydb:flyway-database-postgresql'
+    runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:17
+    image: postgres:18
     container_name: salmonbus-db
     environment:
       POSTGRES_DB: salmonbus

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,6 +7,15 @@ spring:
       connect-timeout: 3s # Open API 실측: 0.04~0.15초 (2026-08-19, 10회).
       read-timeout: 5s
 
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/salmonbus} # 기본값은 compose.yml 과 같다.
+    username: ${DB_USERNAME:salmonbus}
+    password: ${DB_PASSWORD:salmonbus}
+
+  jpa:
+    hibernate:
+      ddl-auto: validate # 스키마의 주인은 Flyway 다. Hibernate 는 대조만 한다.
+
 gbis:
   base-url: https://apis.data.go.kr/6410000 # 경기도 버스정보시스템(GBIS) 실시간 조회 API
   service-key: ${GBIS_SERVICE_KEY}  # 공공데이터포털에서 발급받은 Decoding 인증키

--- a/backend/src/main/resources/db/migration/V1__collector.sql
+++ b/backend/src/main/resources/db/migration/V1__collector.sql
@@ -1,0 +1,164 @@
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+CREATE TABLE call_ledger (
+    quota_provider  varchar(30) NOT NULL,
+    quota_scope_id  varchar(60) NOT NULL,
+    kst_date        date        NOT NULL,
+    reserved_calls  integer     NOT NULL DEFAULT 0,
+    daily_limit     integer     NOT NULL,
+    CONSTRAINT pk_call_ledger PRIMARY KEY (quota_provider, quota_scope_id, kst_date),
+    CONSTRAINT ck_ledger_reserved_within_limit CHECK (reserved_calls BETWEEN 0 AND daily_limit)
+);
+
+CREATE TABLE route_reference_version (
+    id                          bigserial    NOT NULL,
+    reference_version_id        varchar(60)  NOT NULL,
+    public_route_id             varchar(30)  NOT NULL,
+    source_id                   varchar(40)  NOT NULL,
+    source_route_id             varchar(30)  NOT NULL,
+    display_name                varchar(40)  NOT NULL,
+    start_stop_name             varchar(60)  NOT NULL,
+    end_stop_name               varchar(60)  NOT NULL,
+    turn_sequence               integer,
+    up_first_departure_time     varchar(5),
+    up_last_departure_time      varchar(5),
+    down_first_departure_time   varchar(5),
+    down_last_departure_time    varchar(5),
+    content_digest              char(64)     NOT NULL,
+    valid_from                  timestamptz  NOT NULL,
+    valid_to                    timestamptz,
+    CONSTRAINT pk_route_reference_version PRIMARY KEY (id),
+    CONSTRAINT ux_rrv_reference_version_id UNIQUE (reference_version_id),
+    CONSTRAINT ux_rrv_route_content UNIQUE (public_route_id, content_digest),
+    CONSTRAINT ux_rrv_route_identity UNIQUE (id, source_id, source_route_id, public_route_id),
+    CONSTRAINT ck_rrv_turn_sequence_positive CHECK (turn_sequence IS NULL OR turn_sequence >= 1),
+    CONSTRAINT ck_rrv_validity_ordered CHECK (valid_to IS NULL OR valid_from < valid_to),
+    CONSTRAINT ck_rrv_up_first_departure_time CHECK (up_first_departure_time ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'),
+    CONSTRAINT ck_rrv_up_last_departure_time CHECK (up_last_departure_time ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'),
+    CONSTRAINT ck_rrv_down_first_departure_time CHECK (down_first_departure_time ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'),
+    CONSTRAINT ck_rrv_down_last_departure_time CHECK (down_last_departure_time ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'),
+    CONSTRAINT ex_rrv_validity_no_overlap EXCLUDE USING gist (
+        public_route_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    )
+);
+
+CREATE TABLE route_stop (
+    route_reference_version_id  bigint      NOT NULL,
+    stop_order                  integer     NOT NULL,
+    stop_id                     varchar(20) NOT NULL,
+    name                        varchar(60) NOT NULL,
+    direction                   varchar(4)  NOT NULL,
+    boarding_allowed            boolean     NOT NULL,
+    CONSTRAINT pk_route_stop PRIMARY KEY (route_reference_version_id, stop_order),
+    CONSTRAINT fk_route_stop_version FOREIGN KEY (route_reference_version_id)
+        REFERENCES route_reference_version (id),
+    CONSTRAINT ux_route_stop_context UNIQUE (route_reference_version_id, stop_order, stop_id),
+    CONSTRAINT ck_route_stop_order_positive CHECK (stop_order >= 1),
+    CONSTRAINT ck_route_stop_direction CHECK (direction IN ('UP', 'DOWN'))
+);
+
+CREATE TABLE location_poll (
+    id                          bigserial    NOT NULL,
+    source_id                   varchar(40)  NOT NULL,
+    source_route_id             varchar(30)  NOT NULL,
+    public_route_id             varchar(30)  NOT NULL,
+    route_reference_version_id  bigint       NOT NULL,
+    collection_strategy_version varchar(30)  NOT NULL,
+    source_contract_version     varchar(30)  NOT NULL,
+    normalization_version       integer      NOT NULL,
+    scheduled_at                timestamptz  NOT NULL,
+    attempt_no                  integer      NOT NULL,
+    stable_attempt_key          varchar(160) NOT NULL,
+    requested_at                timestamptz  NOT NULL,
+    response_received_at        timestamptz,
+    forecast_completed_at       timestamptz,
+    completed_at                timestamptz,
+    http_status                 integer,
+    result_code                 integer,
+    outcome                     varchar(32)  NOT NULL,
+    failure_code                varchar(32),
+    provider_rows               integer,
+    stored_rows                 integer,
+    excluded_rows               integer,
+    evidence_payload_sha256     char(64),
+    completion_digest           char(64),
+    fence_version               integer      NOT NULL DEFAULT 0,
+    CONSTRAINT pk_location_poll PRIMARY KEY (id),
+    CONSTRAINT fk_poll_route_version FOREIGN KEY (route_reference_version_id, source_id, source_route_id, public_route_id)
+        REFERENCES route_reference_version (id, source_id, source_route_id, public_route_id),
+    CONSTRAINT ux_poll_attempt UNIQUE (source_id, stable_attempt_key),
+    CONSTRAINT ux_poll_context UNIQUE (id, route_reference_version_id),
+    CONSTRAINT ck_poll_outcome CHECK (outcome IN (
+        'RESERVED', 'DISPATCHING', 'SUCCESS_ROWS', 'SUCCESS_EMPTY', 'BUSINESS_ERROR',
+        'INCOMPLETE_ENVELOPE', 'TRANSPORT_ERROR', 'ABANDONED_BEFORE_SEND', 'UNKNOWN_AFTER_DISPATCH'
+    )),
+    CONSTRAINT ck_poll_completed_at_matches_outcome CHECK (
+        (outcome IN ('RESERVED', 'DISPATCHING') AND completed_at IS NULL)
+        OR (outcome NOT IN ('RESERVED', 'DISPATCHING') AND completed_at IS NOT NULL)
+    ),
+    CONSTRAINT ck_poll_rows_sum CHECK (
+        provider_rows IS NULL OR stored_rows IS NULL OR excluded_rows IS NULL
+        OR provider_rows = stored_rows + excluded_rows
+    ),
+    CONSTRAINT ck_poll_attempt_no_positive CHECK (attempt_no >= 1),
+    CONSTRAINT ck_poll_forecast_needs_response CHECK (
+        forecast_completed_at IS NULL OR response_received_at IS NOT NULL
+    ),
+    CONSTRAINT ck_poll_rows_non_negative CHECK (
+        (provider_rows IS NULL OR provider_rows >= 0)
+        AND (stored_rows IS NULL OR stored_rows >= 0)
+        AND (excluded_rows IS NULL OR excluded_rows >= 0)
+    )
+);
+
+CREATE INDEX ix_poll_forecast_ready
+    ON location_poll (route_reference_version_id, response_received_at DESC)
+    WHERE outcome IN ('SUCCESS_ROWS', 'SUCCESS_EMPTY') AND forecast_completed_at IS NOT NULL;
+
+CREATE TABLE vehicle_observation (
+    id                          bigserial    NOT NULL,
+    poll_id                     bigint       NOT NULL,
+    source_id                   varchar(40)  NOT NULL,
+    source_route_id             varchar(30)  NOT NULL,
+    public_route_id             varchar(30)  NOT NULL,
+    route_reference_version_id  bigint       NOT NULL,
+    source_row_no               integer      NOT NULL,
+    observed_at                 timestamptz  NOT NULL,
+    vehicle_id                  varchar(40),
+    vehicle_trip_key            varchar(120),
+    plate_number                varchar(20),
+    stop_order                  integer      NOT NULL,
+    stop_id                     varchar(20)  NOT NULL,
+    phase                       varchar(12)  NOT NULL,
+    remaining_seats             integer,
+    seat_unavailable_reason     varchar(16),
+    crowded_code                integer,
+    low_plate_code              integer,
+    CONSTRAINT pk_vehicle_observation PRIMARY KEY (id),
+    CONSTRAINT fk_obs_poll FOREIGN KEY (poll_id, route_reference_version_id)
+        REFERENCES location_poll (id, route_reference_version_id),
+    CONSTRAINT fk_obs_route_stop FOREIGN KEY (route_reference_version_id, stop_order, stop_id)
+        REFERENCES route_stop (route_reference_version_id, stop_order, stop_id),
+    CONSTRAINT ux_obs_source_row UNIQUE (poll_id, source_row_no),
+    CONSTRAINT ux_obs_context UNIQUE (id, route_reference_version_id),
+    CONSTRAINT ck_obs_source_row_no_non_negative CHECK (source_row_no >= 0),
+    CONSTRAINT ck_obs_phase CHECK (phase IN ('IN_TRANSIT', 'ARRIVING', 'DEPARTED')),
+    CONSTRAINT ck_obs_trip_key_needs_vehicle CHECK (vehicle_id IS NOT NULL OR vehicle_trip_key IS NULL),
+    CONSTRAINT ck_obs_seat_xor_reason CHECK ((remaining_seats IS NULL) <> (seat_unavailable_reason IS NULL)),
+    CONSTRAINT ck_obs_remaining_seats_non_negative CHECK (remaining_seats IS NULL OR remaining_seats >= 0),
+    CONSTRAINT ck_obs_seat_unavailable_reason CHECK (
+        seat_unavailable_reason IS NULL OR seat_unavailable_reason IN ('MINUS_ONE', 'FIELD_ABSENT')
+    ),
+    CONSTRAINT ck_obs_crowded_code CHECK (crowded_code IS NULL OR crowded_code BETWEEN 1 AND 4)
+);
+
+CREATE UNIQUE INDEX ux_obs_vehicle_per_poll
+    ON vehicle_observation (poll_id, vehicle_id)
+    WHERE vehicle_id IS NOT NULL;
+
+CREATE INDEX ix_obs_last_arrival
+    ON vehicle_observation (route_reference_version_id, stop_order, observed_at DESC);
+
+CREATE INDEX ix_obs_trip_progress
+    ON vehicle_observation (route_reference_version_id, vehicle_trip_key, stop_order);

--- a/backend/src/main/resources/db/migration/V1__collector.sql
+++ b/backend/src/main/resources/db/migration/V1__collector.sql
@@ -1,164 +1,152 @@
+-- 수집기가 쓰는 여섯 표.
+-- 제약은 키(PK · UNIQUE · FK)와 배타 범위까지만 건다.
+-- 값의 범위 규칙(CHECK)은 그 규칙을 실제로 쓰는 티켓에서 조인다 — SAL-82 · SAL-85 · SAL-88.
+--
+-- 아직 못 정한 것 셋
+--   1. observation_batch 라는 이름이 확정이 아니다. fleet_snapshot · collection_attempt 가 후보다.
+--   2. route.public_route_id 를 둘지 못 정했다 — route 표 위 주석 참고.
+--   3. vehicle_observation → route_stop 복합 FK 가 관측을 버린다 — 그 FK 위 주석 참고.
+
 CREATE EXTENSION IF NOT EXISTS btree_gist;
 
-CREATE TABLE call_ledger (
-    quota_provider  varchar(30) NOT NULL,
-    quota_scope_id  varchar(60) NOT NULL,
-    kst_date        date        NOT NULL,
+CREATE TABLE daily_call_quota (
+    provider        varchar(30) NOT NULL, -- GBIS · 경기데이터드림
+    api_service     varchar(60) NOT NULL, -- 한도는 서비스키 단위로 걸린다
+    kst_date        date        NOT NULL, -- 한도는 한국 자정에 리셋된다
     reserved_calls  integer     NOT NULL DEFAULT 0,
-    daily_limit     integer     NOT NULL,
-    CONSTRAINT pk_call_ledger PRIMARY KEY (quota_provider, quota_scope_id, kst_date),
-    CONSTRAINT ck_ledger_reserved_within_limit CHECK (reserved_calls BETWEEN 0 AND daily_limit)
+    daily_limit     integer     NOT NULL, -- 운영계정 기준 10,000
+    CONSTRAINT pk_daily_call_quota PRIMARY KEY (provider, api_service, kst_date)
 );
 
-CREATE TABLE route_reference_version (
-    id                          bigserial    NOT NULL,
-    reference_version_id        varchar(60)  NOT NULL,
-    public_route_id             varchar(30)  NOT NULL,
-    source_id                   varchar(40)  NOT NULL,
-    source_route_id             varchar(30)  NOT NULL,
-    display_name                varchar(40)  NOT NULL,
-    start_stop_name             varchar(60)  NOT NULL,
-    end_stop_name               varchar(60)  NOT NULL,
-    turn_sequence               integer,
-    up_first_departure_time     varchar(5),
-    up_last_departure_time      varchar(5),
-    down_first_departure_time   varchar(5),
-    down_last_departure_time    varchar(5),
-    content_digest              char(64)     NOT NULL,
-    valid_from                  timestamptz  NOT NULL,
-    valid_to                    timestamptz,
-    CONSTRAINT pk_route_reference_version PRIMARY KEY (id),
-    CONSTRAINT ux_rrv_reference_version_id UNIQUE (reference_version_id),
-    CONSTRAINT ux_rrv_route_content UNIQUE (public_route_id, content_digest),
-    CONSTRAINT ux_rrv_route_identity UNIQUE (id, source_id, source_route_id, public_route_id),
-    CONSTRAINT ck_rrv_turn_sequence_positive CHECK (turn_sequence IS NULL OR turn_sequence >= 1),
-    CONSTRAINT ck_rrv_validity_ordered CHECK (valid_to IS NULL OR valid_from < valid_to),
-    CONSTRAINT ck_rrv_up_first_departure_time CHECK (up_first_departure_time ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'),
-    CONSTRAINT ck_rrv_up_last_departure_time CHECK (up_last_departure_time ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'),
-    CONSTRAINT ck_rrv_down_first_departure_time CHECK (down_first_departure_time ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'),
-    CONSTRAINT ck_rrv_down_last_departure_time CHECK (down_last_departure_time ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'),
-    CONSTRAINT ex_rrv_validity_no_overlap EXCLUDE USING gist (
-        public_route_id WITH =,
+-- public_route_id 를 두고 팀 문서 둘이 어긋난다. 지금은 source_route_id 와 같은 값이 들어간다.
+--   결정 기록 08-17 : 합성 ID(gg-3330)를 안 만들고 상류 원문을 공개 ID 로 쓴다
+--   개발 요청서     : publicRouteId 는 gg-3330 이고 도입 여부가 미결이다.
+--                     지금 응답의 route.id 로 나가는 것은 source_route_id 다
+-- 공개 ID 가 확정되면 둘 중 하나를 지운다.
+CREATE TABLE route (
+    id               bigint      GENERATED ALWAYS AS IDENTITY,
+    public_route_id  varchar(30) NOT NULL, -- Open API 원문 routeId. 9자리
+    source_id        varchar(40) NOT NULL,
+    source_route_id  varchar(30) NOT NULL, -- 상류 호출 · API 경로 파라미터 · 응답 route.id
+    display_name     varchar(40) NOT NULL, -- 표시명 3330. 모델 노선 키와 글자가 같아도 다른 개념이다
+    start_stop_name  varchar(60) NOT NULL,
+    end_stop_name    varchar(60) NOT NULL,
+    CONSTRAINT pk_route PRIMARY KEY (id),
+    CONSTRAINT ux_route_public_route_id UNIQUE (public_route_id)
+);
+
+-- 응답의 route.referenceVersionId("3330-v5")는 이 표의 id 를 그대로 내보낸다.
+-- 별도 열을 두지 않는 이유 —
+--   판본이 새로 생기면 새 행이라 id 가 바뀌고, 그것이 곧 클라이언트의
+--   "개편 중이니 화면을 다시 받아라" 신호다. 계약은 String 이라는 것 외에 형식을 정하지 않았고,
+--   상류 GBIS 도 판본 개념을 주지 않는다(노선정보 응답 43개 항목 어디에도 없다).
+--   시간표(첫차·막차 4열)만 바뀌면 판본을 새로 안 끊고 같은 행을 UPDATE 하므로 id 도 안 움직인다.
+CREATE TABLE route_version (
+    id                         bigint      GENERATED ALWAYS AS IDENTITY,
+    route_id                   bigint      NOT NULL,
+    turn_sequence              integer,              -- 회차 지점의 순번
+    up_first_departure_time    varchar(5),           -- KST HH:MM
+    up_last_departure_time     varchar(5),
+    down_first_departure_time  varchar(5),
+    down_last_departure_time   varchar(5),           -- 1650 은 상행 22:35 · 하행 23:55
+    content_digest             char(64)    NOT NULL, -- 상류가 개편을 안 알려주니 내용 해시로 감지한다
+    valid_from                 timestamptz NOT NULL,
+    valid_to                   timestamptz,          -- NULL = 지금 쓰는 판본
+    CONSTRAINT pk_route_version PRIMARY KEY (id),
+    CONSTRAINT fk_route_version_route FOREIGN KEY (route_id)
+        REFERENCES route (id),
+    CONSTRAINT ux_route_version_content UNIQUE (route_id, content_digest),
+    CONSTRAINT ex_route_version_no_overlap EXCLUDE USING gist (
+        route_id WITH =,
         tstzrange(valid_from, valid_to) WITH &&
     )
 );
 
 CREATE TABLE route_stop (
-    route_reference_version_id  bigint      NOT NULL,
-    stop_order                  integer     NOT NULL,
-    stop_id                     varchar(20) NOT NULL,
-    name                        varchar(60) NOT NULL,
-    direction                   varchar(4)  NOT NULL,
-    boarding_allowed            boolean     NOT NULL,
-    CONSTRAINT pk_route_stop PRIMARY KEY (route_reference_version_id, stop_order),
-    CONSTRAINT fk_route_stop_version FOREIGN KEY (route_reference_version_id)
-        REFERENCES route_reference_version (id),
-    CONSTRAINT ux_route_stop_context UNIQUE (route_reference_version_id, stop_order, stop_id),
-    CONSTRAINT ck_route_stop_order_positive CHECK (stop_order >= 1),
-    CONSTRAINT ck_route_stop_direction CHECK (direction IN ('UP', 'DOWN'))
+    route_version_id  bigint      NOT NULL,
+    stop_order        integer     NOT NULL, -- stationSeq. 회차로 같은 정류소가 두 번 나와 이것이 정체성이다
+    stop_id           varchar(20) NOT NULL, -- stationId. UNIQUE 를 안 건다 — 같은 정류소를 두 번 지나면 적재가 막힌다
+    name              varchar(60) NOT NULL,
+    direction         varchar(4)  NOT NULL, -- UP · DOWN
+    boarding_allowed  boolean     NOT NULL, -- NOT stop_id LIKE '277%'. 1650 24곳 · 3330 7곳이 불가
+    CONSTRAINT pk_route_stop PRIMARY KEY (route_version_id, stop_order),
+    CONSTRAINT fk_route_stop_version FOREIGN KEY (route_version_id)
+        REFERENCES route_version (id),
+    CONSTRAINT ux_route_stop_context UNIQUE (route_version_id, stop_order, stop_id)
 );
 
-CREATE TABLE location_poll (
-    id                          bigserial    NOT NULL,
-    source_id                   varchar(40)  NOT NULL,
-    source_route_id             varchar(30)  NOT NULL,
-    public_route_id             varchar(30)  NOT NULL,
-    route_reference_version_id  bigint       NOT NULL,
-    collection_strategy_version varchar(30)  NOT NULL,
-    source_contract_version     varchar(30)  NOT NULL,
-    normalization_version       integer      NOT NULL,
-    scheduled_at                timestamptz  NOT NULL,
-    attempt_no                  integer      NOT NULL,
-    stable_attempt_key          varchar(160) NOT NULL,
-    requested_at                timestamptz  NOT NULL,
-    response_received_at        timestamptz,
-    forecast_completed_at       timestamptz,
-    completed_at                timestamptz,
-    http_status                 integer,
-    result_code                 integer,
-    outcome                     varchar(32)  NOT NULL,
-    failure_code                varchar(32),
-    provider_rows               integer,
-    stored_rows                 integer,
-    excluded_rows               integer,
-    evidence_payload_sha256     char(64),
-    completion_digest           char(64),
-    fence_version               integer      NOT NULL DEFAULT 0,
-    CONSTRAINT pk_location_poll PRIMARY KEY (id),
-    CONSTRAINT fk_poll_route_version FOREIGN KEY (route_reference_version_id, source_id, source_route_id, public_route_id)
-        REFERENCES route_reference_version (id, source_id, source_route_id, public_route_id),
-    CONSTRAINT ux_poll_attempt UNIQUE (source_id, stable_attempt_key),
-    CONSTRAINT ux_poll_context UNIQUE (id, route_reference_version_id),
-    CONSTRAINT ck_poll_outcome CHECK (outcome IN (
-        'RESERVED', 'DISPATCHING', 'SUCCESS_ROWS', 'SUCCESS_EMPTY', 'BUSINESS_ERROR',
-        'INCOMPLETE_ENVELOPE', 'TRANSPORT_ERROR', 'ABANDONED_BEFORE_SEND', 'UNKNOWN_AFTER_DISPATCH'
-    )),
-    CONSTRAINT ck_poll_completed_at_matches_outcome CHECK (
-        (outcome IN ('RESERVED', 'DISPATCHING') AND completed_at IS NULL)
-        OR (outcome NOT IN ('RESERVED', 'DISPATCHING') AND completed_at IS NOT NULL)
-    ),
-    CONSTRAINT ck_poll_rows_sum CHECK (
-        provider_rows IS NULL OR stored_rows IS NULL OR excluded_rows IS NULL
-        OR provider_rows = stored_rows + excluded_rows
-    ),
-    CONSTRAINT ck_poll_attempt_no_positive CHECK (attempt_no >= 1),
-    CONSTRAINT ck_poll_forecast_needs_response CHECK (
-        forecast_completed_at IS NULL OR response_received_at IS NOT NULL
-    ),
-    CONSTRAINT ck_poll_rows_non_negative CHECK (
-        (provider_rows IS NULL OR provider_rows >= 0)
-        AND (stored_rows IS NULL OR stored_rows >= 0)
-        AND (excluded_rows IS NULL OR excluded_rows >= 0)
-    )
+CREATE TABLE observation_batch (
+    id                     bigint       GENERATED ALWAYS AS IDENTITY,
+    route_version_id       bigint       NOT NULL,
+    scheduled_at           timestamptz  NOT NULL,
+    attempt_number         integer      NOT NULL,
+    attempt_key            varchar(160) NOT NULL, -- 재시도해도 값이 같아 묶음이 두 개 안 생긴다
+    requested_at           timestamptz  NOT NULL,
+    response_received_at   timestamptz,           -- 응답 observedAt 의 권위. queryTime 이 아니다
+    forecast_completed_at  timestamptz,           -- 차가 0대라 예보 행이 없어도 찍는다
+    completed_at           timestamptz,
+    http_status            integer,
+    result_code            integer,               -- Open API resultCode 원문
+    outcome                varchar(32)  NOT NULL,
+    failure_code           varchar(32),
+    provider_rows          integer,               -- 실측 17
+    stored_rows            integer,               -- 응답 vehiclesInService
+    excluded_rows          integer,
+    CONSTRAINT pk_observation_batch PRIMARY KEY (id),
+    CONSTRAINT fk_batch_route_version FOREIGN KEY (route_version_id)
+        REFERENCES route_version (id),
+    CONSTRAINT ux_batch_attempt UNIQUE (route_version_id, attempt_key),
+    CONSTRAINT ux_batch_context UNIQUE (id, route_version_id)
 );
 
-CREATE INDEX ix_poll_forecast_ready
-    ON location_poll (route_reference_version_id, response_received_at DESC)
+-- 예보까지 끝난 마지막 판 — /board 스냅샷을 인덱스 스캔 한 번으로 고른다
+CREATE INDEX ix_batch_forecast_ready
+    ON observation_batch (route_version_id, response_received_at DESC)
     WHERE outcome IN ('SUCCESS_ROWS', 'SUCCESS_EMPTY') AND forecast_completed_at IS NOT NULL;
 
 CREATE TABLE vehicle_observation (
-    id                          bigserial    NOT NULL,
-    poll_id                     bigint       NOT NULL,
-    source_id                   varchar(40)  NOT NULL,
-    source_route_id             varchar(30)  NOT NULL,
-    public_route_id             varchar(30)  NOT NULL,
-    route_reference_version_id  bigint       NOT NULL,
-    source_row_no               integer      NOT NULL,
-    observed_at                 timestamptz  NOT NULL,
-    vehicle_id                  varchar(40),
-    vehicle_trip_key            varchar(120),
-    plate_number                varchar(20),
-    stop_order                  integer      NOT NULL,
-    stop_id                     varchar(20)  NOT NULL,
-    phase                       varchar(12)  NOT NULL,
-    remaining_seats             integer,
-    seat_unavailable_reason     varchar(16),
-    crowded_code                integer,
-    low_plate_code              integer,
+    id                    bigint       GENERATED ALWAYS AS IDENTITY,
+    observation_batch_id  bigint       NOT NULL,
+    route_version_id      bigint       NOT NULL, -- 순번의 뜻을 정하는 판본
+    source_row_number     integer      NOT NULL,
+    observed_at           timestamptz  NOT NULL, -- queryTime. 같은 묶음은 밀리초까지 같다
+    vehicle_id            varchar(40),           -- vehId. 해시하지 않는다 — 차량별 정원 조회에 원문이 필요하다
+    vehicle_trip_key      varchar(120),          -- 회차해 돌아온 차와 아직 안 온 차를 가른다
+    plate_number          varchar(20),           -- plateNo
+    stop_order            integer      NOT NULL, -- 통과 순번. stationSeq 원문이 아니다
+    stop_id               varchar(20)  NOT NULL, -- stationId
+    running_state         integer,               -- stateCd. 실측 0 · 1 · 2
+    remaining_seats       integer,               -- remainSeatCnt. 실측에 -1(미제공) 섞임
+    crowd_level           integer,               -- crowded. 실측 0 · 1 — 0 이 나온다
+    vehicle_type          integer,               -- lowPlate. 정원이 여기서 유도된다(2층 68 · 저상 40 · 그 밖 45)
+    route_type            integer,               -- routeTypeCd. 실측 전건 11
+    tagless               integer,               -- taglessCd. 실측 0 · 1
     CONSTRAINT pk_vehicle_observation PRIMARY KEY (id),
-    CONSTRAINT fk_obs_poll FOREIGN KEY (poll_id, route_reference_version_id)
-        REFERENCES location_poll (id, route_reference_version_id),
-    CONSTRAINT fk_obs_route_stop FOREIGN KEY (route_reference_version_id, stop_order, stop_id)
-        REFERENCES route_stop (route_reference_version_id, stop_order, stop_id),
-    CONSTRAINT ux_obs_source_row UNIQUE (poll_id, source_row_no),
-    CONSTRAINT ux_obs_context UNIQUE (id, route_reference_version_id),
-    CONSTRAINT ck_obs_source_row_no_non_negative CHECK (source_row_no >= 0),
-    CONSTRAINT ck_obs_phase CHECK (phase IN ('IN_TRANSIT', 'ARRIVING', 'DEPARTED')),
-    CONSTRAINT ck_obs_trip_key_needs_vehicle CHECK (vehicle_id IS NOT NULL OR vehicle_trip_key IS NULL),
-    CONSTRAINT ck_obs_seat_xor_reason CHECK ((remaining_seats IS NULL) <> (seat_unavailable_reason IS NULL)),
-    CONSTRAINT ck_obs_remaining_seats_non_negative CHECK (remaining_seats IS NULL OR remaining_seats >= 0),
-    CONSTRAINT ck_obs_seat_unavailable_reason CHECK (
-        seat_unavailable_reason IS NULL OR seat_unavailable_reason IN ('MINUS_ONE', 'FIELD_ABSENT')
-    ),
-    CONSTRAINT ck_obs_crowded_code CHECK (crowded_code IS NULL OR crowded_code BETWEEN 1 AND 4)
+    CONSTRAINT fk_observation_batch FOREIGN KEY (observation_batch_id, route_version_id)
+        REFERENCES observation_batch (id, route_version_id),
+    -- 이 FK 가 관측을 버린다. 드문 일이 아니다 — 개발 요청서 B19 :
+    --   통과 순번은 stateCd=1(도착)이면 stationSeq-1 이라, stationSeq=1 이고 stateCd=1 이면 0 이 나온다.
+    --   route_stop.stop_order 는 1 부터라 그 행은 적재가 실패한다. 첫 정류소에 도착하는 버스마다 걸린다.
+    --   노선 개편으로 순번이 밀린 동안에도 같은 일이 난다.
+    -- FK 를 빼는 것으로는 안 풀린다 — seat_forecast 의 FK 는 (판본, 순번)만 보고 stop_id 는 안 봐서,
+    --   빼면 어긋난 관측이 저장되고 틀린 정류소에 예보가 붙는다.
+    -- SAL-82(정규화) · SAL-84(관측 저장)가 같이 정한다. SAL-83 범위 밖이다.
+    CONSTRAINT fk_observation_route_stop FOREIGN KEY (route_version_id, stop_order, stop_id)
+        REFERENCES route_stop (route_version_id, stop_order, stop_id),
+    CONSTRAINT ux_observation_source_row UNIQUE (observation_batch_id, source_row_number),
+    CONSTRAINT ux_observation_context UNIQUE (id, route_version_id)
 );
 
-CREATE UNIQUE INDEX ux_obs_vehicle_per_poll
-    ON vehicle_observation (poll_id, vehicle_id)
+-- 재시도가 같은 차량을 한 묶음에 두 번 쌓는 것을 막는다
+CREATE UNIQUE INDEX ux_observation_vehicle_per_batch
+    ON vehicle_observation (observation_batch_id, vehicle_id)
     WHERE vehicle_id IS NOT NULL;
 
-CREATE INDEX ix_obs_last_arrival
-    ON vehicle_observation (route_reference_version_id, stop_order, observed_at DESC);
+-- 그 정류소에 직전 도착한 차량
+CREATE INDEX ix_observation_stop_recent
+    ON vehicle_observation (route_version_id, stop_order, observed_at DESC);
 
-CREATE INDEX ix_obs_trip_progress
-    ON vehicle_observation (route_reference_version_id, vehicle_trip_key, stop_order);
+-- 같은 여정의 앞선 관측 — 좌석 기울기
+CREATE INDEX ix_observation_trip
+    ON vehicle_observation (route_version_id, vehicle_trip_key, stop_order)
+    WHERE vehicle_trip_key IS NOT NULL;

--- a/backend/src/main/resources/db/migration/V1__collector.sql
+++ b/backend/src/main/resources/db/migration/V1__collector.sql
@@ -1,11 +1,11 @@
 -- 수집기가 쓰는 여섯 표.
 -- 제약은 키(PK · UNIQUE · FK)와 배타 범위까지만 건다.
--- 값의 범위 규칙(CHECK)은 그 규칙을 실제로 쓰는 티켓에서 조인다 — SAL-82 · SAL-85 · SAL-88.
+-- 값의 범위 규칙(CHECK)은 그 규칙을 실제로 쓰는 티켓에서 조인다. SAL-82 · SAL-85 · SAL-88.
 --
 -- 아직 못 정한 것 셋
 --   1. observation_batch 라는 이름이 확정이 아니다. fleet_snapshot · collection_attempt 가 후보다.
---   2. route.public_route_id 를 둘지 못 정했다 — route 표 위 주석 참고.
---   3. vehicle_observation → route_stop 복합 FK 가 관측을 버린다 — 그 FK 위 주석 참고.
+--   2. route.public_route_id 를 둘지 못 정했다. route 표 위 주석 참고.
+--   3. vehicle_observation 이 route_stop 을 보는 복합 FK 가 관측을 버린다. 그 FK 위 주석 참고.
 
 CREATE EXTENSION IF NOT EXISTS btree_gist;
 
@@ -36,7 +36,7 @@ CREATE TABLE route (
 );
 
 -- 응답의 route.referenceVersionId("3330-v5")는 이 표의 id 를 그대로 내보낸다.
--- 별도 열을 두지 않는 이유 —
+-- 별도 열을 두지 않는 이유.
 --   판본이 새로 생기면 새 행이라 id 가 바뀌고, 그것이 곧 클라이언트의
 --   "개편 중이니 화면을 다시 받아라" 신호다. 계약은 String 이라는 것 외에 형식을 정하지 않았고,
 --   상류 GBIS 도 판본 개념을 주지 않는다(노선정보 응답 43개 항목 어디에도 없다).
@@ -49,13 +49,17 @@ CREATE TABLE route_version (
     up_last_departure_time     varchar(5),
     down_first_departure_time  varchar(5),
     down_last_departure_time   varchar(5),           -- 1650 은 상행 22:35 · 하행 23:55
-    content_digest             char(64)    NOT NULL, -- 상류가 개편을 안 알려주니 내용 해시로 감지한다
+    -- 상류가 개편을 알려주지 않아 정류소 목록을 해시해 바뀐 것을 알아낸다.
+    -- UNIQUE 를 걸지 않는다. 공사로 A 에서 B 로 갔다가 다시 A 로 돌아오면 해시가 되풀이되는데,
+    -- 그때도 새 판본을 끊어야 한다. 기간이 다르고, 관측이 판본에 매달리고,
+    -- 무엇보다 id 가 그대로면 클라이언트가 개편을 못 알아챈다.
+    -- "직전과 같으면 새로 안 만든다"는 가장 최근 판본과만 비교하는 규칙이라 적재 로직에서 본다.
+    content_digest             char(64)    NOT NULL,
     valid_from                 timestamptz NOT NULL,
     valid_to                   timestamptz,          -- NULL = 지금 쓰는 판본
     CONSTRAINT pk_route_version PRIMARY KEY (id),
     CONSTRAINT fk_route_version_route FOREIGN KEY (route_id)
         REFERENCES route (id),
-    CONSTRAINT ux_route_version_content UNIQUE (route_id, content_digest),
     CONSTRAINT ex_route_version_no_overlap EXCLUDE USING gist (
         route_id WITH =,
         tstzrange(valid_from, valid_to) WITH &&
@@ -65,7 +69,7 @@ CREATE TABLE route_version (
 CREATE TABLE route_stop (
     route_version_id  bigint      NOT NULL,
     stop_order        integer     NOT NULL, -- stationSeq. 회차로 같은 정류소가 두 번 나와 이것이 정체성이다
-    stop_id           varchar(20) NOT NULL, -- stationId. UNIQUE 를 안 건다 — 같은 정류소를 두 번 지나면 적재가 막힌다
+    stop_id           varchar(20) NOT NULL, -- stationId. UNIQUE 를 안 건다. 같은 정류소를 두 번 지나면 적재가 막힌다
     name              varchar(60) NOT NULL,
     direction         varchar(4)  NOT NULL, -- UP · DOWN
     boarding_allowed  boolean     NOT NULL, -- NOT stop_id LIKE '277%'. 1650 24곳 · 3330 7곳이 불가
@@ -99,7 +103,14 @@ CREATE TABLE observation_batch (
     CONSTRAINT ux_batch_context UNIQUE (id, route_version_id)
 );
 
--- 예보까지 끝난 마지막 판 — /board 스냅샷을 인덱스 스캔 한 번으로 고른다
+-- 확정된 /board 조회가 요청마다 도는 질의다.
+-- "그 판본의, 예보까지 끝난, 가장 최근 묶음" 하나를 고른다.
+-- 이 표는 수집 한 번에 한 행씩 늘어 하루 8,556 행, 한 해 310만 행이 된다.
+-- 부분 조건은 조회의 WHERE 와 글자 그대로 같아야 계획기가 이 인덱스를 고른다.
+--
+-- 다른 조회 경로에는 인덱스를 붙이지 않았다. 읽는 코드가 아직 없어 어떤 질의가 될지 모른다.
+-- 직전 도착 차량(SAL-95), 여정 잇기(SAL-94), 채점 회수(SAL-97) 를 구현할 때
+-- 그쪽에서 자기 질의를 보고 붙이거나 고치면 된다. 그 시점에 한 번 모여 같이 보면 좋겠다.
 CREATE INDEX ix_batch_forecast_ready
     ON observation_batch (route_version_id, response_received_at DESC)
     WHERE outcome IN ('SUCCESS_ROWS', 'SUCCESS_EMPTY') AND forecast_completed_at IS NOT NULL;
@@ -110,25 +121,25 @@ CREATE TABLE vehicle_observation (
     route_version_id      bigint       NOT NULL, -- 순번의 뜻을 정하는 판본
     source_row_number     integer      NOT NULL,
     observed_at           timestamptz  NOT NULL, -- queryTime. 같은 묶음은 밀리초까지 같다
-    vehicle_id            varchar(40),           -- vehId. 해시하지 않는다 — 차량별 정원 조회에 원문이 필요하다
+    vehicle_id            varchar(40),           -- vehId. 해시하지 않는다. 차량별 정원 조회에 원문이 필요하다
     vehicle_trip_key      varchar(120),          -- 회차해 돌아온 차와 아직 안 온 차를 가른다
     plate_number          varchar(20),           -- plateNo
     stop_order            integer      NOT NULL, -- 통과 순번. stationSeq 원문이 아니다
     stop_id               varchar(20)  NOT NULL, -- stationId
     running_state         integer,               -- stateCd. 실측 0 · 1 · 2
     remaining_seats       integer,               -- remainSeatCnt. 실측에 -1(미제공) 섞임
-    crowd_level           integer,               -- crowded. 실측 0 · 1 — 0 이 나온다
+    crowd_level           integer,               -- crowded. 실측 0 · 1. 0 이 나온다
     vehicle_type          integer,               -- lowPlate. 정원이 여기서 유도된다(2층 68 · 저상 40 · 그 밖 45)
     route_type            integer,               -- routeTypeCd. 실측 전건 11
     tagless               integer,               -- taglessCd. 실측 0 · 1
     CONSTRAINT pk_vehicle_observation PRIMARY KEY (id),
     CONSTRAINT fk_observation_batch FOREIGN KEY (observation_batch_id, route_version_id)
         REFERENCES observation_batch (id, route_version_id),
-    -- 이 FK 가 관측을 버린다. 드문 일이 아니다 — 개발 요청서 B19 :
+    -- 이 FK 가 관측을 버린다. 드문 일이 아니다. 개발 요청서 B19 :
     --   통과 순번은 stateCd=1(도착)이면 stationSeq-1 이라, stationSeq=1 이고 stateCd=1 이면 0 이 나온다.
     --   route_stop.stop_order 는 1 부터라 그 행은 적재가 실패한다. 첫 정류소에 도착하는 버스마다 걸린다.
     --   노선 개편으로 순번이 밀린 동안에도 같은 일이 난다.
-    -- FK 를 빼는 것으로는 안 풀린다 — seat_forecast 의 FK 는 (판본, 순번)만 보고 stop_id 는 안 봐서,
+    -- FK 를 빼는 것으로는 안 풀린다. seat_forecast 의 FK 는 (판본, 순번)만 보고 stop_id 는 안 봐서,
     --   빼면 어긋난 관측이 저장되고 틀린 정류소에 예보가 붙는다.
     -- SAL-82(정규화) · SAL-84(관측 저장)가 같이 정한다. SAL-83 범위 밖이다.
     CONSTRAINT fk_observation_route_stop FOREIGN KEY (route_version_id, stop_order, stop_id)
@@ -141,12 +152,3 @@ CREATE TABLE vehicle_observation (
 CREATE UNIQUE INDEX ux_observation_vehicle_per_batch
     ON vehicle_observation (observation_batch_id, vehicle_id)
     WHERE vehicle_id IS NOT NULL;
-
--- 그 정류소에 직전 도착한 차량
-CREATE INDEX ix_observation_stop_recent
-    ON vehicle_observation (route_version_id, stop_order, observed_at DESC);
-
--- 같은 여정의 앞선 관측 — 좌석 기울기
-CREATE INDEX ix_observation_trip
-    ON vehicle_observation (route_version_id, vehicle_trip_key, stop_order)
-    WHERE vehicle_trip_key IS NOT NULL;

--- a/backend/src/main/resources/db/migration/V2__model.sql
+++ b/backend/src/main/resources/db/migration/V2__model.sql
@@ -1,34 +1,34 @@
+-- 어떤 계수 묶음이 지금 도는가.
+-- 상태 전이 규칙(STAGED → ACTIVE → RETIRED)은 승격 로직과 함께 와야 뜻이 있어서 SAL-93 이 조인다.
+--
+-- 아직 못 정한 것
+--   deployment_key · release_id · model_key · model_version 넷이 서로 무엇이 다른지 설명되지 않는다.
+--   문서에서 그대로 가져왔고, 셋 중 둘은 지울 수 있어 보인다. SAL-93 이 배포 절차를 짜면서 정한다.
+
 CREATE TABLE model_deployment (
-    id                          bigserial   NOT NULL,
-    deployment_key              uuid        NOT NULL,
-    release_id                  varchar(80) NOT NULL,
-    model_key                   varchar(40) NOT NULL,
-    model_version               varchar(60) NOT NULL,
-    bundle_digest               char(64)    NOT NULL,
-    manifest_digest             char(64)    NOT NULL,
-    bundle_format_version       varchar(30) NOT NULL,
-    prediction_target_version   varchar(40) NOT NULL,
-    feature_contract_version    varchar(40) NOT NULL,
-    label_policy_version        varchar(40) NOT NULL,
-    trained_through             timestamptz NOT NULL,
-    supported_scope_digest      char(64)    NOT NULL,
-    state                       varchar(12) NOT NULL,
-    predecessor_deployment_id   bigint,
-    activated_at                timestamptz,
-    retired_at                  timestamptz,
+    id                         bigint      GENERATED ALWAYS AS IDENTITY,
+    deployment_key             uuid        NOT NULL,
+    release_id                 varchar(80) NOT NULL, -- 응답 model.releaseId
+    model_key                  varchar(40) NOT NULL,
+    model_version              varchar(60) NOT NULL, -- 학습된 계수 묶음. 코드의 git 식별자
+    bundle_digest              char(64)    NOT NULL,
+    prediction_target_version  varchar(40) NOT NULL,
+    calculation_version        varchar(40) NOT NULL, -- 입력값을 만드는 규칙. 모델 버전과 다른 층이다
+    supported_scope_digest     char(64)    NOT NULL, -- state 와 함께 응답 route.status 를 판정한다.
+                                                     -- 이 노선 판본을 담으면 FORECAST_READY,
+                                                     -- 안 담으면 MODEL_OUT_OF_SCOPE 다. 유도할 수 없어 열로 둔다
+    data_until                 timestamptz NOT NULL, -- 응답 model.trainedThrough
+    state                      varchar(12) NOT NULL, -- STAGED | ACTIVE | RETIRED
+    predecessor_deployment_id  bigint,
+    activated_at               timestamptz,
+    retired_at                 timestamptz,
     CONSTRAINT pk_model_deployment PRIMARY KEY (id),
-    CONSTRAINT ux_deployment_key UNIQUE (deployment_key),
-    CONSTRAINT fk_deployment_predecessor FOREIGN KEY (predecessor_deployment_id)
-        REFERENCES model_deployment (id),
-    CONSTRAINT ck_deployment_state CHECK (state IN ('STAGED', 'ACTIVE', 'RETIRED')),
-    CONSTRAINT ck_deployment_state_timestamps CHECK (
-        (state = 'STAGED'  AND activated_at IS NULL     AND retired_at IS NULL)
-        OR (state = 'ACTIVE'  AND activated_at IS NOT NULL AND retired_at IS NULL)
-        OR (state = 'RETIRED' AND activated_at IS NOT NULL AND retired_at IS NOT NULL)
-    ),
-    CONSTRAINT ck_deployment_retired_after_activated CHECK (retired_at IS NULL OR activated_at < retired_at)
+    CONSTRAINT ux_model_deployment_key UNIQUE (deployment_key),
+    CONSTRAINT fk_model_deployment_predecessor FOREIGN KEY (predecessor_deployment_id)
+        REFERENCES model_deployment (id)
 );
 
-CREATE UNIQUE INDEX ux_deployment_single_active
+-- 도는 모델은 언제나 하나뿐이다
+CREATE UNIQUE INDEX ux_model_deployment_single_active
     ON model_deployment ((state))
     WHERE state = 'ACTIVE';

--- a/backend/src/main/resources/db/migration/V2__model.sql
+++ b/backend/src/main/resources/db/migration/V2__model.sql
@@ -1,0 +1,34 @@
+CREATE TABLE model_deployment (
+    id                          bigserial   NOT NULL,
+    deployment_key              uuid        NOT NULL,
+    release_id                  varchar(80) NOT NULL,
+    model_key                   varchar(40) NOT NULL,
+    model_version               varchar(60) NOT NULL,
+    bundle_digest               char(64)    NOT NULL,
+    manifest_digest             char(64)    NOT NULL,
+    bundle_format_version       varchar(30) NOT NULL,
+    prediction_target_version   varchar(40) NOT NULL,
+    feature_contract_version    varchar(40) NOT NULL,
+    label_policy_version        varchar(40) NOT NULL,
+    trained_through             timestamptz NOT NULL,
+    supported_scope_digest      char(64)    NOT NULL,
+    state                       varchar(12) NOT NULL,
+    predecessor_deployment_id   bigint,
+    activated_at                timestamptz,
+    retired_at                  timestamptz,
+    CONSTRAINT pk_model_deployment PRIMARY KEY (id),
+    CONSTRAINT ux_deployment_key UNIQUE (deployment_key),
+    CONSTRAINT fk_deployment_predecessor FOREIGN KEY (predecessor_deployment_id)
+        REFERENCES model_deployment (id),
+    CONSTRAINT ck_deployment_state CHECK (state IN ('STAGED', 'ACTIVE', 'RETIRED')),
+    CONSTRAINT ck_deployment_state_timestamps CHECK (
+        (state = 'STAGED'  AND activated_at IS NULL     AND retired_at IS NULL)
+        OR (state = 'ACTIVE'  AND activated_at IS NOT NULL AND retired_at IS NULL)
+        OR (state = 'RETIRED' AND activated_at IS NOT NULL AND retired_at IS NOT NULL)
+    ),
+    CONSTRAINT ck_deployment_retired_after_activated CHECK (retired_at IS NULL OR activated_at < retired_at)
+);
+
+CREATE UNIQUE INDEX ux_deployment_single_active
+    ON model_deployment ((state))
+    WHERE state = 'ACTIVE';

--- a/backend/src/main/resources/db/migration/V3__forecast.sql
+++ b/backend/src/main/resources/db/migration/V3__forecast.sql
@@ -1,66 +1,70 @@
-CREATE TABLE demand_profile (
-    route_reference_version_id  bigint           NOT NULL,
-    stop_order                  integer          NOT NULL,
-    time_cell_id                varchar(40)      NOT NULL,
-    feature_contract_version    varchar(40)      NOT NULL,
-    revision                    integer          NOT NULL,
-    occupancy_mean              double precision NOT NULL,
-    net_demand_mean             double precision NOT NULL,
-    sample_count                integer          NOT NULL,
-    day_count                   integer          NOT NULL,
-    trained_through             timestamptz      NOT NULL,
-    computed_at                 timestamptz      NOT NULL,
-    CONSTRAINT pk_demand_profile PRIMARY KEY (route_reference_version_id, stop_order, time_cell_id, feature_contract_version),
-    CONSTRAINT fk_profile_route_stop FOREIGN KEY (route_reference_version_id, stop_order)
-        REFERENCES route_stop (route_reference_version_id, stop_order),
-    CONSTRAINT ck_profile_revision_positive CHECK (revision >= 1),
-    CONSTRAINT ck_profile_occupancy_mean CHECK (occupancy_mean BETWEEN 0 AND 1),
-    CONSTRAINT ck_profile_net_demand_mean CHECK (net_demand_mean BETWEEN -1 AND 1),
-    CONSTRAINT ck_profile_sample_count_non_negative CHECK (sample_count >= 0),
-    CONSTRAINT ck_profile_day_count_within_samples CHECK (day_count BETWEEN 0 AND sample_count)
-);
+-- 예보가 읽고 쓰는 두 표.
+-- 발행 계층(forecast_publication · stop_prediction)은 v4 계약에서 빠졌고,
+-- 이 DB 에는 발행본이 쌓인 적이 없어 만들지 않는다.
+--
+-- CHECK 은 둘만 남긴다.
+--   NaN 가드 — double precision 은 NaN 을 담을 수 있고 응답이 1 - NaN 이 되면 안 된다.
+--              범위 규칙과 달리 모델이 바뀌어도 안 바뀌는 값이다. x = x 가 거짓인 값은 NaN 하나뿐이다.
+--   지평 상한 — 계약이 정한 범위라 모델과 무관하다.
 
-CREATE TABLE vehicle_stop_prediction (
-    vehicle_observation_id      bigint           NOT NULL,
-    route_reference_version_id  bigint           NOT NULL,
-    target_stop_order           integer          NOT NULL,
-    horizon_stops               integer          NOT NULL,
-    model_deployment_id         bigint           NOT NULL,
-    cell_profile_revision       integer          NOT NULL,
-    p_full_raw                  double precision NOT NULL,
-    p_full                      double precision NOT NULL,
-    expected_seats              double precision,
-    generated_at                timestamptz      NOT NULL,
-    settlement                  varchar(16)      NOT NULL,
-    outcome_observation_id      bigint,
-    arrived_seats               integer,
-    settled_at                  timestamptz,
-    CONSTRAINT pk_vehicle_stop_prediction PRIMARY KEY (vehicle_observation_id, target_stop_order),
-    CONSTRAINT fk_vsp_obs FOREIGN KEY (vehicle_observation_id, route_reference_version_id)
-        REFERENCES vehicle_observation (id, route_reference_version_id),
-    CONSTRAINT fk_vsp_target_stop FOREIGN KEY (route_reference_version_id, target_stop_order)
-        REFERENCES route_stop (route_reference_version_id, stop_order),
-    CONSTRAINT fk_vsp_deployment FOREIGN KEY (model_deployment_id)
-        REFERENCES model_deployment (id),
-    CONSTRAINT fk_vsp_outcome FOREIGN KEY (outcome_observation_id)
-        REFERENCES vehicle_observation (id),
-    CONSTRAINT ck_vsp_target_stop_order_positive CHECK (target_stop_order >= 1),
-    CONSTRAINT ck_vsp_horizon CHECK (horizon_stops BETWEEN 1 AND 12),
-    CONSTRAINT ck_vsp_cell_profile_revision_positive CHECK (cell_profile_revision >= 1),
-    CONSTRAINT ck_vsp_p_full_raw_range CHECK (p_full_raw BETWEEN 0 AND 1),
-    CONSTRAINT ck_vsp_p_full_range CHECK (p_full BETWEEN 0 AND 1),
-    CONSTRAINT ck_vsp_expected_seats_non_negative CHECK (expected_seats IS NULL OR expected_seats >= 0),
-    CONSTRAINT ck_vsp_settlement CHECK (settlement IN ('PENDING', 'SETTLED', 'SKIPPED', 'LOST', 'SEAT_MISSING')),
-    CONSTRAINT ck_vsp_outcome_obs_matches_settlement CHECK (
-        (settlement IN ('SETTLED', 'SEAT_MISSING') AND outcome_observation_id IS NOT NULL)
-        OR (settlement NOT IN ('SETTLED', 'SEAT_MISSING') AND outcome_observation_id IS NULL)
-    ),
-    CONSTRAINT ck_vsp_arrived_seats_matches_settlement CHECK (
-        (settlement = 'SETTLED' AND arrived_seats IS NOT NULL AND arrived_seats >= 0)
-        OR (settlement <> 'SETTLED' AND arrived_seats IS NULL)
-    ),
-    CONSTRAINT ck_vsp_settled_at_matches_settlement CHECK (
-        (settlement = 'PENDING' AND settled_at IS NULL)
-        OR (settlement <> 'PENDING' AND settled_at IS NOT NULL AND generated_at <= settled_at)
+CREATE TABLE stop_demand_statistics (
+    route_version_id           bigint           NOT NULL,
+    stop_order                 integer          NOT NULL,
+    time_slot                  varchar(40)      NOT NULL, -- morning | evening | other
+    calculation_version        varchar(40)      NOT NULL, -- 정원 상수가 바뀌면 값의 뜻이 달라져 키에 넣는다
+    revision                   integer          NOT NULL, -- 몇 번째 배치 산출물인가. 덮어쓸 때마다 오른다
+    average_fill_rate          double precision NOT NULL, -- 도착 시 자리가 찬 비율의 평균
+    average_net_boarding_rate  double precision NOT NULL, -- (탄 사람 - 내린 사람) / 정원. 음수가 정상
+    sample_count               integer          NOT NULL,
+    data_until                 timestamptz      NOT NULL,
+    computed_at                timestamptz      NOT NULL,
+    CONSTRAINT pk_stop_demand_statistics PRIMARY KEY (route_version_id, stop_order, time_slot, calculation_version),
+    CONSTRAINT fk_statistics_route_stop FOREIGN KEY (route_version_id, stop_order)
+        REFERENCES route_stop (route_version_id, stop_order),
+    CONSTRAINT ck_statistics_not_nan CHECK (
+        average_fill_rate = average_fill_rate
+        AND average_net_boarding_rate = average_net_boarding_rate
     )
 );
+
+CREATE TABLE seat_forecast (
+    vehicle_observation_id      bigint           NOT NULL,
+    target_stop_order           integer          NOT NULL,
+    route_version_id            bigint           NOT NULL,
+    stops_to_target             integer          NOT NULL, -- target_stop_order - 관측 stop_order
+    model_deployment_id         bigint           NOT NULL,
+    demand_statistics_revision  integer          NOT NULL, -- 통계는 덮어써진다. 몇 번째 판을 읽었는지 남긴다
+    seat_full_chance_raw        double precision NOT NULL, -- 만석일 확률. 사전확률 이동 전
+    seat_full_chance            double precision NOT NULL, -- 응답에는 1 - 이 값이 나간다
+    expected_seats              double precision,
+    generated_at                timestamptz      NOT NULL,
+    scoring_state               varchar(16)      NOT NULL, -- PENDING | SETTLED | SKIPPED | LOST | SEAT_MISSING
+    arrival_observation_id      bigint,                    -- 그 정류소에 실제로 도착했을 때의 관측
+    seats_on_arrival            integer,                   -- 도착했을 때 남은 자리. 0 이면 만석
+    scored_at                   timestamptz,
+    CONSTRAINT pk_seat_forecast PRIMARY KEY (vehicle_observation_id, target_stop_order),
+    CONSTRAINT fk_forecast_observation FOREIGN KEY (vehicle_observation_id, route_version_id)
+        REFERENCES vehicle_observation (id, route_version_id),
+    CONSTRAINT fk_forecast_target_stop FOREIGN KEY (route_version_id, target_stop_order)
+        REFERENCES route_stop (route_version_id, stop_order),
+    CONSTRAINT fk_forecast_deployment FOREIGN KEY (model_deployment_id)
+        REFERENCES model_deployment (id),
+    -- 아직 못 정한 것 — 개발 요청서 BE N17 :
+    --   위 fk_forecast_observation 은 판본을 같이 보는데 이것은 (id) 하나뿐이라,
+    --   도착 관측이 다른 판본의 행이어도 DB 가 막지 않는다. 복합으로 바꾸면 회수 배치가
+    --   판본을 같이 넘겨야 한다. 여정 키에 판본이 들어 있어 실무상 잘 안 나므로 급하지 않다.
+    CONSTRAINT fk_forecast_arrival FOREIGN KEY (arrival_observation_id)
+        REFERENCES vehicle_observation (id),
+    CONSTRAINT ck_forecast_not_nan CHECK (
+        seat_full_chance_raw = seat_full_chance_raw
+        AND seat_full_chance = seat_full_chance
+        AND (expected_seats IS NULL OR expected_seats = expected_seats)
+    ),
+    -- 계약이 정한 범위다. 모델이 바뀌어도 안 바뀐다
+    CONSTRAINT ck_forecast_stops_to_target CHECK (stops_to_target BETWEEN 1 AND 12)
+);
+
+-- 아직 안 닫힌 예보 — 채점 배치가 집는 경로
+CREATE INDEX ix_forecast_pending
+    ON seat_forecast (route_version_id, generated_at)
+    WHERE scoring_state = 'PENDING';

--- a/backend/src/main/resources/db/migration/V3__forecast.sql
+++ b/backend/src/main/resources/db/migration/V3__forecast.sql
@@ -1,0 +1,66 @@
+CREATE TABLE demand_profile (
+    route_reference_version_id  bigint           NOT NULL,
+    stop_order                  integer          NOT NULL,
+    time_cell_id                varchar(40)      NOT NULL,
+    feature_contract_version    varchar(40)      NOT NULL,
+    revision                    integer          NOT NULL,
+    occupancy_mean              double precision NOT NULL,
+    net_demand_mean             double precision NOT NULL,
+    sample_count                integer          NOT NULL,
+    day_count                   integer          NOT NULL,
+    trained_through             timestamptz      NOT NULL,
+    computed_at                 timestamptz      NOT NULL,
+    CONSTRAINT pk_demand_profile PRIMARY KEY (route_reference_version_id, stop_order, time_cell_id, feature_contract_version),
+    CONSTRAINT fk_profile_route_stop FOREIGN KEY (route_reference_version_id, stop_order)
+        REFERENCES route_stop (route_reference_version_id, stop_order),
+    CONSTRAINT ck_profile_revision_positive CHECK (revision >= 1),
+    CONSTRAINT ck_profile_occupancy_mean CHECK (occupancy_mean BETWEEN 0 AND 1),
+    CONSTRAINT ck_profile_net_demand_mean CHECK (net_demand_mean BETWEEN -1 AND 1),
+    CONSTRAINT ck_profile_sample_count_non_negative CHECK (sample_count >= 0),
+    CONSTRAINT ck_profile_day_count_within_samples CHECK (day_count BETWEEN 0 AND sample_count)
+);
+
+CREATE TABLE vehicle_stop_prediction (
+    vehicle_observation_id      bigint           NOT NULL,
+    route_reference_version_id  bigint           NOT NULL,
+    target_stop_order           integer          NOT NULL,
+    horizon_stops               integer          NOT NULL,
+    model_deployment_id         bigint           NOT NULL,
+    cell_profile_revision       integer          NOT NULL,
+    p_full_raw                  double precision NOT NULL,
+    p_full                      double precision NOT NULL,
+    expected_seats              double precision,
+    generated_at                timestamptz      NOT NULL,
+    settlement                  varchar(16)      NOT NULL,
+    outcome_observation_id      bigint,
+    arrived_seats               integer,
+    settled_at                  timestamptz,
+    CONSTRAINT pk_vehicle_stop_prediction PRIMARY KEY (vehicle_observation_id, target_stop_order),
+    CONSTRAINT fk_vsp_obs FOREIGN KEY (vehicle_observation_id, route_reference_version_id)
+        REFERENCES vehicle_observation (id, route_reference_version_id),
+    CONSTRAINT fk_vsp_target_stop FOREIGN KEY (route_reference_version_id, target_stop_order)
+        REFERENCES route_stop (route_reference_version_id, stop_order),
+    CONSTRAINT fk_vsp_deployment FOREIGN KEY (model_deployment_id)
+        REFERENCES model_deployment (id),
+    CONSTRAINT fk_vsp_outcome FOREIGN KEY (outcome_observation_id)
+        REFERENCES vehicle_observation (id),
+    CONSTRAINT ck_vsp_target_stop_order_positive CHECK (target_stop_order >= 1),
+    CONSTRAINT ck_vsp_horizon CHECK (horizon_stops BETWEEN 1 AND 12),
+    CONSTRAINT ck_vsp_cell_profile_revision_positive CHECK (cell_profile_revision >= 1),
+    CONSTRAINT ck_vsp_p_full_raw_range CHECK (p_full_raw BETWEEN 0 AND 1),
+    CONSTRAINT ck_vsp_p_full_range CHECK (p_full BETWEEN 0 AND 1),
+    CONSTRAINT ck_vsp_expected_seats_non_negative CHECK (expected_seats IS NULL OR expected_seats >= 0),
+    CONSTRAINT ck_vsp_settlement CHECK (settlement IN ('PENDING', 'SETTLED', 'SKIPPED', 'LOST', 'SEAT_MISSING')),
+    CONSTRAINT ck_vsp_outcome_obs_matches_settlement CHECK (
+        (settlement IN ('SETTLED', 'SEAT_MISSING') AND outcome_observation_id IS NOT NULL)
+        OR (settlement NOT IN ('SETTLED', 'SEAT_MISSING') AND outcome_observation_id IS NULL)
+    ),
+    CONSTRAINT ck_vsp_arrived_seats_matches_settlement CHECK (
+        (settlement = 'SETTLED' AND arrived_seats IS NOT NULL AND arrived_seats >= 0)
+        OR (settlement <> 'SETTLED' AND arrived_seats IS NULL)
+    ),
+    CONSTRAINT ck_vsp_settled_at_matches_settlement CHECK (
+        (settlement = 'PENDING' AND settled_at IS NULL)
+        OR (settlement <> 'PENDING' AND settled_at IS NOT NULL AND generated_at <= settled_at)
+    )
+);

--- a/backend/src/main/resources/db/migration/V3__forecast.sql
+++ b/backend/src/main/resources/db/migration/V3__forecast.sql
@@ -2,10 +2,13 @@
 -- 발행 계층(forecast_publication · stop_prediction)은 v4 계약에서 빠졌고,
 -- 이 DB 에는 발행본이 쌓인 적이 없어 만들지 않는다.
 --
--- CHECK 은 둘만 남긴다.
---   NaN 가드 — double precision 은 NaN 을 담을 수 있고 응답이 1 - NaN 이 되면 안 된다.
---              범위 규칙과 달리 모델이 바뀌어도 안 바뀌는 값이다. x = x 가 거짓인 값은 NaN 하나뿐이다.
---   지평 상한 — 계약이 정한 범위라 모델과 무관하다.
+-- CHECK 은 값의 정의가 정한 것만 남긴다. 모델이 바뀌어도 안 바뀌는 값들이다.
+-- 확률은 0 에서 1 사이이고, 앞으로 지날 정류소 수는 api 문서가 12 로 막았다.
+--
+-- PostgreSQL 은 NaN 을 정렬하고 인덱스에 넣을 수 있게 하려고 NaN = NaN 을 참으로 본다.
+-- 그래서 x = x 로는 NaN 이 안 걸러진다(postgres 18 실측). 대신 NaN 을 모든 수보다 크게
+-- 다루므로 BETWEEN 이 NaN 과 Infinity 를 둘 다 막는다.
+-- 상한이 없는 expected_seats 만 <> 'NaN' 을 따로 건다.
 
 CREATE TABLE stop_demand_statistics (
     route_version_id           bigint           NOT NULL,
@@ -21,10 +24,8 @@ CREATE TABLE stop_demand_statistics (
     CONSTRAINT pk_stop_demand_statistics PRIMARY KEY (route_version_id, stop_order, time_slot, calculation_version),
     CONSTRAINT fk_statistics_route_stop FOREIGN KEY (route_version_id, stop_order)
         REFERENCES route_stop (route_version_id, stop_order),
-    CONSTRAINT ck_statistics_not_nan CHECK (
-        average_fill_rate = average_fill_rate
-        AND average_net_boarding_rate = average_net_boarding_rate
-    )
+    CONSTRAINT ck_statistics_fill_rate CHECK (average_fill_rate BETWEEN 0 AND 1),
+    CONSTRAINT ck_statistics_net_boarding_rate CHECK (average_net_boarding_rate BETWEEN -1 AND 1)
 );
 
 CREATE TABLE seat_forecast (
@@ -49,22 +50,17 @@ CREATE TABLE seat_forecast (
         REFERENCES route_stop (route_version_id, stop_order),
     CONSTRAINT fk_forecast_deployment FOREIGN KEY (model_deployment_id)
         REFERENCES model_deployment (id),
-    -- 아직 못 정한 것 — 개발 요청서 BE N17 :
+    -- 아직 못 정한 것. 개발 요청서 BE N17 :
     --   위 fk_forecast_observation 은 판본을 같이 보는데 이것은 (id) 하나뿐이라,
     --   도착 관측이 다른 판본의 행이어도 DB 가 막지 않는다. 복합으로 바꾸면 회수 배치가
     --   판본을 같이 넘겨야 한다. 여정 키에 판본이 들어 있어 실무상 잘 안 나므로 급하지 않다.
     CONSTRAINT fk_forecast_arrival FOREIGN KEY (arrival_observation_id)
         REFERENCES vehicle_observation (id),
-    CONSTRAINT ck_forecast_not_nan CHECK (
-        seat_full_chance_raw = seat_full_chance_raw
-        AND seat_full_chance = seat_full_chance
-        AND (expected_seats IS NULL OR expected_seats = expected_seats)
+    CONSTRAINT ck_forecast_chance_raw CHECK (seat_full_chance_raw BETWEEN 0 AND 1),
+    CONSTRAINT ck_forecast_chance CHECK (seat_full_chance BETWEEN 0 AND 1),
+    CONSTRAINT ck_forecast_expected_seats CHECK (
+        expected_seats IS NULL
+        OR (expected_seats >= 0 AND expected_seats <> 'NaN'::double precision)
     ),
-    -- 계약이 정한 범위다. 모델이 바뀌어도 안 바뀐다
     CONSTRAINT ck_forecast_stops_to_target CHECK (stops_to_target BETWEEN 1 AND 12)
 );
-
--- 아직 안 닫힌 예보 — 채점 배치가 집는 경로
-CREATE INDEX ix_forecast_pending
-    ON seat_forecast (route_version_id, generated_at)
-    WHERE scoring_state = 'PENDING';

--- a/backend/src/test/java/com/gustler/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/gustler/backend/BackendApplicationTests.java
@@ -1,9 +1,9 @@
 package com.gustler.backend;
 
+import com.gustler.backend.support.IntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@IntegrationTest
 class BackendApplicationTests {
 
     @Test

--- a/backend/src/test/java/com/gustler/backend/DatabaseConnectionTest.java
+++ b/backend/src/test/java/com/gustler/backend/DatabaseConnectionTest.java
@@ -4,54 +4,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gustler.backend.support.IntegrationTest;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.simple.JdbcClient;
 
 @IntegrationTest
 class DatabaseConnectionTest {
 
-    private static final Instant NINE_AM_IN_SEOUL = Instant.parse("2026-08-20T00:00:00Z");
-    private static final LocalDateTime SEOUL_WALL_CLOCK = LocalDateTime.of(2026, 8, 20, 9, 0);
+    private static final int PRODUCTION_MAJOR_VERSION = 18;
 
     @Autowired
     private DataSource dataSource;
 
-    @Autowired
-    private JdbcClient jdbcClient;
-
     @Test
-    void PostgreSQL_에_연결된다() throws SQLException {
+    void 테스트는_운영과_같은_PostgreSQL_18에서_돈다() throws SQLException {
         try (Connection connection = dataSource.getConnection()) {
-            final String actual = connection.getMetaData().getDatabaseProductName();
+            // when
+            final DatabaseMetaData actual = connection.getMetaData();
 
-            assertThat(actual).isEqualTo("PostgreSQL");
+            // then
+            assertThat(actual.getDatabaseProductName()).isEqualTo("PostgreSQL");
+            assertThat(actual.getDatabaseMajorVersion()).isEqualTo(PRODUCTION_MAJOR_VERSION);
         }
-    }
-
-    @Test
-    void 넣은_순간이_JVM_시간대와_무관하게_그대로_돌아온다() {
-        final OffsetDateTime actual = jdbcClient.sql("SELECT CAST(? AS timestamptz)")
-            .param(NINE_AM_IN_SEOUL.atOffset(ZoneOffset.UTC))
-            .query(OffsetDateTime.class)
-            .single();
-
-        assertThat(actual.toInstant()).isEqualTo(NINE_AM_IN_SEOUL);
-    }
-
-    @Test
-    void 같은_순간을_서울_벽시계로_읽으면_오전_아홉시다() {
-        final LocalDateTime actual = jdbcClient.sql("SELECT CAST(? AS timestamptz) AT TIME ZONE 'Asia/Seoul'")
-            .param(NINE_AM_IN_SEOUL.atOffset(ZoneOffset.UTC))
-            .query(LocalDateTime.class)
-            .single();
-
-        assertThat(actual).isEqualTo(SEOUL_WALL_CLOCK);
     }
 }

--- a/backend/src/test/java/com/gustler/backend/DatabaseConnectionTest.java
+++ b/backend/src/test/java/com/gustler/backend/DatabaseConnectionTest.java
@@ -1,0 +1,57 @@
+package com.gustler.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gustler.backend.support.IntegrationTest;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+@IntegrationTest
+class DatabaseConnectionTest {
+
+    private static final Instant NINE_AM_IN_SEOUL = Instant.parse("2026-08-20T00:00:00Z");
+    private static final LocalDateTime SEOUL_WALL_CLOCK = LocalDateTime.of(2026, 8, 20, 9, 0);
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private JdbcClient jdbcClient;
+
+    @Test
+    void PostgreSQL_에_연결된다() throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            final String actual = connection.getMetaData().getDatabaseProductName();
+
+            assertThat(actual).isEqualTo("PostgreSQL");
+        }
+    }
+
+    @Test
+    void 넣은_순간이_JVM_시간대와_무관하게_그대로_돌아온다() {
+        final OffsetDateTime actual = jdbcClient.sql("SELECT CAST(? AS timestamptz)")
+            .param(NINE_AM_IN_SEOUL.atOffset(ZoneOffset.UTC))
+            .query(OffsetDateTime.class)
+            .single();
+
+        assertThat(actual.toInstant()).isEqualTo(NINE_AM_IN_SEOUL);
+    }
+
+    @Test
+    void 같은_순간을_서울_벽시계로_읽으면_오전_아홉시다() {
+        final LocalDateTime actual = jdbcClient.sql("SELECT CAST(? AS timestamptz) AT TIME ZONE 'Asia/Seoul'")
+            .param(NINE_AM_IN_SEOUL.atOffset(ZoneOffset.UTC))
+            .query(LocalDateTime.class)
+            .single();
+
+        assertThat(actual).isEqualTo(SEOUL_WALL_CLOCK);
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/SchemaMigrationTest.java
+++ b/backend/src/test/java/com/gustler/backend/SchemaMigrationTest.java
@@ -1,0 +1,21 @@
+package com.gustler.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gustler.backend.support.IntegrationTest;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+class SchemaMigrationTest {
+
+    @Autowired
+    private Flyway flyway;
+
+    @Test
+    void 마이그레이션이_남김없이_적용된다() {
+        assertThat(flyway.info().applied()).isNotEmpty();
+        assertThat(flyway.info().pending()).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/SchemaMigrationTest.java
+++ b/backend/src/test/java/com/gustler/backend/SchemaMigrationTest.java
@@ -3,7 +3,11 @@ package com.gustler.backend;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gustler.backend.support.IntegrationTest;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationInfo;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -14,8 +18,33 @@ class SchemaMigrationTest {
     private Flyway flyway;
 
     @Test
-    void 마이그레이션이_남김없이_적용된다() {
-        assertThat(flyway.info().applied()).isNotEmpty();
+    void 앱_부팅_시_Flyway가_마이그레이션을_V1부터_순차적으로_모두_실행한다() {
+        // when
+        final MigrationInfo[] actual = flyway.info().applied();
+
+        // then
+        assertThat(actual)
+            .extracting(info -> info.getVersion().getVersion())
+            .containsExactly("1", "2", "3");
         assertThat(flyway.info().pending()).isEmpty();
+    }
+
+    @Test
+    void 앱을_다시_띄우면_기존에_돌았던_V1_V2_V3은_처음_실행됐던_시각을_유지하고_실행되지_않는다() {
+        // given
+        final List<Date> firstRun = installedOn();
+
+        // when
+        flyway.migrate();
+
+        // then
+        final List<Date> actual = installedOn();
+        assertThat(actual).isEqualTo(firstRun);
+    }
+
+    private List<Date> installedOn() {
+        return Arrays.stream(flyway.info().applied())
+            .map(MigrationInfo::getInstalledOn)
+            .toList();
     }
 }

--- a/backend/src/test/java/com/gustler/backend/VehicleObservationTableTest.java
+++ b/backend/src/test/java/com/gustler/backend/VehicleObservationTableTest.java
@@ -1,0 +1,157 @@
+package com.gustler.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gustler.backend.support.IntegrationTest;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.transaction.annotation.Transactional;
+
+@IntegrationTest
+@Transactional
+class VehicleObservationTableTest {
+
+    private static final String SOURCE_ID = "GBIS";
+    private static final String ROUTE_204000057 = "204000057";
+    private static final String STOP_205000217 = "205000217";
+    private static final int STOP_ORDER = 6;
+    private static final String VEHICLE_204000206 = "204000206";
+    private static final String VEHICLE_204003542 = "204003542";
+    private static final long MISSING_BATCH_ID = 9_999_999L;
+    private static final String CONTENT_DIGEST = "0".repeat(64);
+    private static final OffsetDateTime OBSERVED_AT = OffsetDateTime.parse("2026-08-19T11:14:04.911+09:00");
+    private static final LocalDateTime SEOUL_WALL_CLOCK = LocalDateTime.of(2026, 8, 19, 11, 14, 4, 911_000_000);
+
+    @Autowired
+    private JdbcClient jdbcClient;
+
+    private long routeVersionId;
+    private long batchId;
+
+    @BeforeEach
+    void 노선_판본과_정류소와_수집_묶음을_먼저_저장한다() {
+        final long routeId = insertRoute();
+        routeVersionId = insertRouteVersion(routeId);
+        insertRouteStop(routeVersionId);
+        batchId = insertObservationBatch(routeVersionId);
+    }
+
+    @Test
+    void 차량_관측은_수집_묶음이_먼저_있어야_저장된다() {
+        // when & then
+        assertThatThrownBy(() -> insertObservation(MISSING_BATCH_ID, VEHICLE_204000206, 0, OBSERVED_AT))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void 수집이_재시도되어도_같은_묶음의_같은_버스는_한_번만_저장된다() {
+        // given
+        insertObservation(batchId, VEHICLE_204000206, 0, OBSERVED_AT);
+
+        // when & then
+        assertThatThrownBy(() -> insertObservation(batchId, VEHICLE_204000206, 1, OBSERVED_AT))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void KST로_넣든_UTC로_넣든_한국_시간으로_조회할_수_있다() {
+        // given
+        final OffsetDateTime inKst = OffsetDateTime.parse("2026-08-19T11:14:04.911+09:00");
+        final OffsetDateTime inUtc = OffsetDateTime.parse("2026-08-19T02:14:04.911Z");
+
+        // when
+        insertObservation(batchId, VEHICLE_204000206, 0, inKst);
+        insertObservation(batchId, VEHICLE_204003542, 1, inUtc);
+        final List<LocalDateTime> actual = jdbcClient
+            .sql("""
+                SELECT observed_at AT TIME ZONE 'Asia/Seoul'
+                FROM vehicle_observation
+                WHERE observation_batch_id = ?
+                ORDER BY source_row_number
+                """)
+            .param(batchId)
+            .query(LocalDateTime.class)
+            .list();
+
+        // then
+        assertThat(actual).containsExactly(SEOUL_WALL_CLOCK, SEOUL_WALL_CLOCK);
+    }
+
+    private long insertRoute() {
+        return jdbcClient.sql("""
+                INSERT INTO route (
+                    public_route_id, source_id, source_route_id,
+                    display_name, start_stop_name, end_stop_name
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                RETURNING id
+                """)
+            .params(ROUTE_204000057, SOURCE_ID, ROUTE_204000057, "3330", "범계역", "강남역")
+            .query(Long.class)
+            .single();
+    }
+
+    private long insertRouteVersion(
+        final long routeId
+    ) {
+        return jdbcClient.sql("""
+                INSERT INTO route_version (route_id, content_digest, valid_from)
+                VALUES (?, ?, ?)
+                RETURNING id
+                """)
+            .params(routeId, CONTENT_DIGEST, OBSERVED_AT)
+            .query(Long.class)
+            .single();
+    }
+
+    private void insertRouteStop(
+        final long versionId
+    ) {
+        jdbcClient.sql("""
+                INSERT INTO route_stop (
+                    route_version_id, stop_order, stop_id, name, direction, boarding_allowed
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """)
+            .params(versionId, STOP_ORDER, STOP_205000217, "범계역", "UP", true)
+            .update();
+    }
+
+    private long insertObservationBatch(
+        final long versionId
+    ) {
+        return jdbcClient.sql("""
+                INSERT INTO observation_batch (
+                    route_version_id, scheduled_at, attempt_number, attempt_key, requested_at, outcome
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                RETURNING id
+                """)
+            .params(versionId, OBSERVED_AT, 1, "204000057-2026-08-19T11:14", OBSERVED_AT, "SUCCESS_ROWS")
+            .query(Long.class)
+            .single();
+    }
+
+    private void insertObservation(
+        final long targetBatchId,
+        final String vehicleId,
+        final int sourceRowNumber,
+        final OffsetDateTime observedAt
+    ) {
+        jdbcClient.sql("""
+                INSERT INTO vehicle_observation (
+                    observation_batch_id, route_version_id, source_row_number,
+                    observed_at, vehicle_id, stop_order, stop_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """)
+            .params(
+                targetBatchId, routeVersionId, sourceRowNumber,
+                observedAt, vehicleId, STOP_ORDER, STOP_205000217
+            )
+            .update();
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/support/IntegrationTest.java
+++ b/backend/src/test/java/com/gustler/backend/support/IntegrationTest.java
@@ -1,0 +1,17 @@
+package com.gustler.backend.support;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest
+@Import(PostgresTestContainer.class)
+public @interface IntegrationTest {
+}

--- a/backend/src/test/java/com/gustler/backend/support/PostgresTestContainer.java
+++ b/backend/src/test/java/com/gustler/backend/support/PostgresTestContainer.java
@@ -1,0 +1,18 @@
+package com.gustler.backend.support;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class PostgresTestContainer {
+
+    private static final String POSTGRES_IMAGE = "postgres:18";
+
+    @Bean
+    @ServiceConnection
+    PostgreSQLContainer<?> postgres() {
+        return new PostgreSQLContainer<>(POSTGRES_IMAGE);
+    }
+}


### PR DESCRIPTION
# 스키마부터 봐주시면 감사드리옵니다

테이블 스키마(8개), DB 연결 설정을 한 PR에 같이 넣었습니다!

**스키마 쪽만 먼저 리뷰 부탁드립니다.** 연결·테스트 쪽 결정은 아직 정리 중이라,
끝나는 대로 본문을 다시 써서 올리겠습니다.

## 구현 내용

- flyway 규칙으로 테이블 8개 생성합니다!
- 테스트는 Testcontainers가 띄운 PostgreSQL 18에서 돕니다
- 로컬 DB 이미지를 `postgres:17` → `18`로 올렸습니다. 배포에 쓸 RDS 버전과 맞췄습니다

<br/>

## 스키마 쪽에서 봐주셨으면 하는 것!

### 1. v4 기준으로 짰습니다

동키가 일주일 정도 쌓은 관측값이랑 좌석 예보와 탑승 확률을 계산해준 덕분에 배포 전에 더 정교한 모델로 바꿀 수 있었는데요!  
그렇게 모델을 수정한 이후로 v4로 팀 내 합의를 한 것으로 알고있습니다.

모델이 바뀌어서 DB 스키마도 일부 수정되었는데요.
API v3랑 달라진 부분은  
발행 계층(`forecast_publication` · `stop_prediction`)이 빠지고 `demand_profile` · `vehicle_stop_prediction` 이 추가됐습니다.

<br/>

### 2. 정류장 ID 컬럼을 `stop_id` 로 통일했습니다

기존에는 DB에서 `station_id`, 응답에서 `stopId` 로 다르게 사용했었는데,  
저희가 팀회의에서 이야기했던대로 stop 으로 모두 통일했습니다.

<br/>

### 3. `vehicle_observation` 에 `plate_number` 컬럼을 만들었습니다

모델이 언제든 갈아끼워지고 실시간 값은 복구가 안 되기 때문에 일단 다 저장합니다!

컬럼 이름은 `plate_no` 로 뒀다가 `plate_number` 로 풀었습니다.  
응답 계약이 `plateNo` 라 api 조립에서 한 번 이름이 바뀌는데, 그건 감수하기로 했습니다.

<br/>

## 마이그레이션을 3파일로 나눴습니다

가독성을 위해 패키지 경계랑 동일하게 나눴습니다.

```
V1__collector.sql   call_ledger · route_reference_version · route_stop
                    location_poll · vehicle_observation
V2__model.sql       model_deployment
V3__forecast.sql    demand_profile · vehicle_stop_prediction
```

파일 버저닝이나 스키마간 순서는 의존도에 따라 정했습니다.

`vehicle_observation` 이 `route_stop` 과 `location_poll` 을 둘 다 참조해서 V1 안에서 순서가 고정됩니다.  
`vehicle_stop_prediction` 도 앞의 둘을 참조하니 V1, V2가 먼저 돌아야 합니다.

<br/>

이 외 수정사항은 본문과 커밋 업데이트 후 DM 혹은 리뷰 재요청 하겠습니다!
