### PR TITLE
feat(SAL-100): S3 + CloudFront 배포 환경 구축

### DIFF
--- a/frontend/webpack/webpack.common.cjs
+++ b/frontend/webpack/webpack.common.cjs
@@ -1,6 +1,19 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const { VanillaExtractPlugin } = require("@vanilla-extract/webpack-plugin");
+const { execSync } = require("child_process");
+
+// CodePipeline sources arrive without .git, so buildspec injects APP_VERSION
+function resolveAppVersion() {
+  if (process.env.APP_VERSION) {
+    return process.env.APP_VERSION;
+  }
+  try {
+    return execSync("git rev-parse --short HEAD").toString().trim();
+  } catch {
+    return "unknown";
+  }
+}
 
 module.exports = {
   entry: path.resolve(__dirname, "../src/index.tsx"),
@@ -25,6 +38,9 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, "../public/index.html"),
+      meta: {
+        "app-version": resolveAppVersion(),
+      },
     }),
     new VanillaExtractPlugin(),
   ],


### PR DESCRIPTION
안녕하세요 루멘, 레스입니다.

SAL-100(S3 + CloudFront 배포 환경 구축)의 저장소 쪽 변경분입니다.

배포 환경 구축은 AWS 콘솔에서 진행한 작업이라 코드에는 남지 않습니다. S3 업로드, CloudFront 구성, 2차 배포까지 마쳤고 현재 https://d1cpbqmn5fp05e.cloudfront.net/ 에서 dev가 서빙되고 있습니다. 전체 설계와 결정 근거는 [테크스펙](https://higgs95.atlassian.net/wiki/x/AgDk)에 정리해 두었습니다.

이 PR에 담긴 저장소 변경은 버전 표시 주입 하나입니다. 빌드할 때 index.html의 head에 배포 버전을 식별하는 meta 태그를 넣습니다.

<meta name="app-version" content="a570111">

배포된 화면이 어느 커밋인지 원격에서 확인할 수 없으면 재배포와 롤백이 성공했는지 판정할 수 없습니다. 아래 명령 한 줄로 바로 확인할 수 있도록 태그를 추가했습니다.

curl -s https://d1cpbqmn5fp05e.cloudfront.net/ | grep -o '<meta name="app-version"[^>]*>'

이 값은 이후 에러 트래킹 (자율)미션에서 release 식별자로 재사용해도 좋을 것 같습니다.

### 설계

SHA는 APP_VERSION 환경 변수 → git rev-parse → unknown 순서로 가져옵니다.

환경 변수를 가장 먼저 보는 이유는 SAL-101(자동화 티켓) 때문입니다. CodePipeline의 GitHub 버전 1 소스는 .git 없이 zip으로 내려오기 때문에 CodeBuild 안에서는 git 명령이 실패합니다. buildspec이 CODEBUILD_RESOLVED_SOURCE_VERSION을 APP_VERSION으로 넘겨줄 예정이고, webpack 설정이 CodeBuild 전용 변수명을 직접 알 필요가 없도록 일반적인 이름으로 한 겹 감쌌습니다.

로컬 수동 배포에서는 git 폴백이 동작하고, 둘 다 실패하면 unknown으로 빌드를 계속 진행합니다. 버전 표시 때문에 빌드가 실패할 이유는 없다고 판단했습니다.

### 검증
pnpm typecheck / lint / build 통과
빌드 후 dist/index.html에서 <meta name="app-version" content="a570111"> 확인

---

테크스펙 제목: [SETUP/SAL-100] S3 + CloudFront 배포 환경과 버전 표시 v1
테크스펙 링크: https://higgs95.atlassian.net/wiki/x/AgDk
Jira 티켓: SAL-100