### PR TITLE
feat(SAL-49): Client API v4 계약 타입과 샘플 정의

### DIFF
--- a/frontend/src/shared/api/routeForecast.mock.ts
+++ b/frontend/src/shared/api/routeForecast.mock.ts
@@ -1,0 +1,293 @@
+import type { Board, ErrorCode, ErrorResponse, LiveVehicles, RouteListResponse } from "./routeForecast.types";
+
+export const routeListMock = {
+  routes: [
+    {
+      id: "204000057",
+      displayName: "3330",
+      startStopName: "도촌동9단지앞",
+      endStopName: "안양역",
+      status: "FORECAST_READY",
+    },
+    {
+      id: "234000050",
+      displayName: "1650",
+      startStopName: "구리수택차고지",
+      endStopName: "안양역",
+      status: "PREPARING",
+    },
+  ],
+} satisfies RouteListResponse;
+
+export const boardMock = {
+  route: {
+    id: "204000057",
+    displayName: "3330",
+    startStopName: "도촌동9단지앞",
+    endStopName: "안양역",
+    status: "FORECAST_READY",
+    turnSequence: 43,
+    referenceVersionId: "204000057-20260818",
+    directions: [
+      {
+        id: "UP",
+        name: "안양 방면",
+        originStopName: "도촌동9단지앞",
+        terminalStopName: "안양역",
+        firstDepartureTime: "04:50",
+        lastDepartureTime: "23:00",
+      },
+      {
+        id: "DOWN",
+        name: "도촌 방면",
+        originStopName: "안양역",
+        terminalStopName: "도촌동9단지앞",
+        firstDepartureTime: "05:40",
+        lastDepartureTime: "23:55",
+      },
+    ],
+  },
+  observedAt: "2026-08-18T08:12:40+09:00",
+  model: {
+    releaseId: "A18",
+    trainedThrough: "2026-08-18",
+  },
+  vehiclesInService: 5,
+  stops: [
+    {
+      sequence: 5,
+      stopId: "224000059",
+      name: "도촌동주공1단지",
+      direction: "UP",
+      boardingAllowed: true,
+      approachingVehicles: [],
+    },
+    {
+      sequence: 18,
+      stopId: "224000132",
+      name: "야탑역",
+      direction: "UP",
+      boardingAllowed: true,
+      approachingVehicles: [
+        {
+          vehicleId: "V-3330-01",
+          horizonStops: 3,
+          seatAvailableProbability: 0.82,
+          expectedSeats: 21,
+        },
+        {
+          vehicleId: null,
+          horizonStops: 11,
+          seatAvailableProbability: 0.44,
+        },
+      ],
+    },
+    {
+      sequence: 30,
+      stopId: "277101995",
+      name: "판교테크노밸리(경유)",
+      direction: "UP",
+      boardingAllowed: false,
+      approachingVehicles: [],
+    },
+    {
+      sequence: 44,
+      stopId: "233001855",
+      name: "인덕원역",
+      direction: "DOWN",
+      boardingAllowed: true,
+      approachingVehicles: [
+        {
+          vehicleId: "V-3330-02",
+          horizonStops: 1,
+          seatAvailableProbability: 0.91,
+          expectedSeats: 30,
+        },
+        {
+          vehicleId: "V-3330-03",
+          horizonStops: 6,
+          seatAvailableProbability: 0.55,
+          expectedSeats: 9,
+        },
+        {
+          vehicleId: "V-3330-04",
+          horizonStops: 12,
+          seatAvailableProbability: 0.18,
+        },
+      ],
+    },
+    {
+      sequence: 52,
+      stopId: "233002110",
+      name: "범계역",
+      direction: "DOWN",
+      boardingAllowed: true,
+      approachingVehicles: [],
+    },
+  ],
+} satisfies Board;
+
+export const boardClosedMock = {
+  route: boardMock.route,
+  observedAt: "2026-08-18T23:58:20+09:00",
+  model: boardMock.model,
+  vehiclesInService: 0,
+  stops: [
+    {
+      sequence: 18,
+      stopId: "224000132",
+      name: "야탑역",
+      direction: "UP",
+      boardingAllowed: true,
+      approachingVehicles: [],
+    },
+    {
+      sequence: 44,
+      stopId: "233001855",
+      name: "인덕원역",
+      direction: "DOWN",
+      boardingAllowed: true,
+      approachingVehicles: [],
+    },
+  ],
+} satisfies Board;
+
+export const boardQuietMock = {
+  route: boardMock.route,
+  observedAt: "2026-08-18T05:03:11+09:00",
+  model: boardMock.model,
+  vehiclesInService: 1,
+  stops: [
+    {
+      sequence: 18,
+      stopId: "224000132",
+      name: "야탑역",
+      direction: "UP",
+      boardingAllowed: true,
+      approachingVehicles: [],
+    },
+    {
+      sequence: 44,
+      stopId: "233001855",
+      name: "인덕원역",
+      direction: "DOWN",
+      boardingAllowed: true,
+      approachingVehicles: [],
+    },
+  ],
+} satisfies Board;
+
+export const liveVehiclesMock = {
+  routeId: "234000050",
+  referenceVersionId: "234000050-20260818",
+  observation: {
+    state: "VEHICLES_PRESENT",
+    observedAt: "2026-08-18T08:12:31+09:00",
+    staleAt: "2026-08-18T08:13:31+09:00",
+  },
+  vehicles: [
+    {
+      vehicleId: "V-1650-07",
+      direction: "UP",
+      currentStopSequence: 21,
+      stopId: "228000601",
+      stopName: "구리역",
+      phase: "DEPARTED",
+      seat: { kind: "EXACT", remaining: 12 },
+    },
+    {
+      vehicleId: "V-1650-11",
+      direction: "DOWN",
+      currentStopSequence: 58,
+      stopId: "233001855",
+      stopName: "인덕원역",
+      phase: "ARRIVING",
+      seat: { kind: "EXACT", remaining: 0 },
+    },
+    {
+      vehicleId: null,
+      direction: "UP",
+      currentStopSequence: 35,
+      stopId: "228000733",
+      stopName: "장자못사거리",
+      phase: "IN_TRANSIT",
+      seat: { kind: "UNKNOWN" },
+    },
+  ],
+} satisfies LiveVehicles;
+
+export const liveVehiclesEmptyMock = {
+  routeId: "234000050",
+  referenceVersionId: "234000050-20260818",
+  observation: {
+    state: "NO_VEHICLES_OBSERVED",
+    observedAt: "2026-08-18T23:59:02+09:00",
+    staleAt: "2026-08-19T00:09:02+09:00",
+  },
+  vehicles: [],
+} satisfies LiveVehicles;
+
+export const liveVehiclesUnknownMock = {
+  routeId: "234000050",
+  referenceVersionId: "234000050-20260818",
+  observation: {
+    state: "UNKNOWN",
+    observedAt: null,
+    staleAt: null,
+  },
+  vehicles: [],
+} satisfies LiveVehicles;
+
+export const liveVehiclesRevisedMock = {
+  routeId: "234000050",
+  referenceVersionId: "234000050-20260825",
+  observation: {
+    state: "VEHICLES_PRESENT",
+    observedAt: "2026-08-25T09:40:12+09:00",
+    staleAt: "2026-08-25T09:41:12+09:00",
+  },
+  vehicles: [
+    {
+      vehicleId: "V-1650-02",
+      direction: "UP",
+      currentStopSequence: 8,
+      stopId: "228000544",
+      stopName: "수택고개",
+      phase: "IN_TRANSIT",
+      seat: { kind: "EXACT", remaining: 27 },
+    },
+  ],
+} satisfies LiveVehicles;
+
+export const errorResponseMocks = {
+  INVALID_ROUTE_ID: {
+    code: "INVALID_ROUTE_ID",
+    message: "노선 ID 형식이 올바르지 않다",
+    requestId: "req-0f3c1a",
+    retryable: false,
+  },
+  ROUTE_NOT_FOUND: {
+    code: "ROUTE_NOT_FOUND",
+    message: "등록되지 않은 노선이다",
+    requestId: "req-8b21d4",
+    retryable: false,
+  },
+  MODEL_OUT_OF_SCOPE: {
+    code: "MODEL_OUT_OF_SCOPE",
+    message: "이 노선은 아직 예보 대상이 아니다",
+    requestId: "req-c77e02",
+    retryable: false,
+  },
+  NO_RECENT_OBSERVATION: {
+    code: "NO_RECENT_OBSERVATION",
+    message: "최근 관측이 없어 예보를 만들 수 없다",
+    requestId: "req-53aa9e",
+    retryable: true,
+  },
+  SERVICE_UNAVAILABLE: {
+    code: "SERVICE_UNAVAILABLE",
+    message: "일시적으로 응답할 수 없다",
+    requestId: "req-e19f60",
+    retryable: true,
+  },
+} satisfies Record<ErrorCode, ErrorResponse>;

--- a/frontend/src/shared/api/routeForecast.typeTest.ts
+++ b/frontend/src/shared/api/routeForecast.typeTest.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-unused-vars -- 아래 함수들은 호출용이 아니라 컴파일 검사용이라서 어디서도 쓰지 않는다 */
+import type {
+  ApproachingVehicle,
+  Board,
+  BoardRoute,
+  Observation,
+  SeatInfo,
+  StopState,
+  Vehicle,
+} from "./routeForecast.types";
+
+// 아래 함수들은 일부러 틀리게 쓴 코드이다. 타입이 제대로라면 각 줄에서 에러가 나고, @ts-expect-error가 그걸 삼킨다.
+// 누가 타입을 느슨하게 고쳐서 에러가 사라지면 @ts-expect-error가 거꾸로 에러를 내니, CI 타입 검사에서 바로 걸린다.
+
+function rejectsSeatCountOnUnknown(): SeatInfo {
+  const smuggled = { kind: "UNKNOWN" as const, remaining: 3 };
+  // @ts-expect-error 좌석 모름(UNKNOWN)인데 remaining 값을 채우면 막혀야 한다
+  const seat: SeatInfo = smuggled;
+  return seat;
+}
+
+function rejectsUncheckedExpectedSeats(approaching: ApproachingVehicle): number {
+  // @ts-expect-error expectedSeats는 없을 수 있는 필드라, 있는지 확인 없이 바로 쓰면 막혀야 한다
+  const seats: number = approaching.expectedSeats;
+  return seats;
+}
+
+function rejectsUncheckedVehicleId(vehicle: Vehicle): string {
+  // @ts-expect-error vehicleId는 null일 수 있어서, null 확인 없이 바로 쓰면 막혀야 한다
+  return vehicle.vehicleId.toUpperCase();
+}
+
+function rejectsUncheckedTurnSequence(route: BoardRoute): number {
+  // @ts-expect-error turnSequence도 null일 수 있어서, null 확인 없이 바로 쓰면 막혀야 한다
+  const sequence: number = route.turnSequence;
+  return sequence;
+}
+
+function rejectsUncheckedObservedAt(observation: Observation): string {
+  // @ts-expect-error 관측이 없으면 observedAt이 null이라, null 확인 없이 바로 쓰면 막혀야 한다
+  return observation.observedAt.slice(0, 10);
+}
+
+function rejectsLegacyStationId(stop: StopState): string {
+  // @ts-expect-error stationId는 v3 시절 이름이라 쓰면 막혀야 한다 (v4에서 stopId로 바뀜)
+  return stop.stationId;
+}
+
+function rejectsLegacyForecastMeta(board: Board): unknown {
+  // @ts-expect-error forecastMeta는 v3 시절 필드라 쓰면 막혀야 한다 (v4에서 observedAt과 model로 쪼개짐)
+  return board.forecastMeta;
+}
+
+// 이 함수만 정상 코드다. kind로 분기하면 remaining이 number로 좁혀지는지 확인한다.
+function narrowsSeatByKind(seat: SeatInfo): number {
+  if (seat.kind === "EXACT") {
+    return seat.remaining;
+  }
+  return 0;
+}

--- a/frontend/src/shared/api/routeForecast.types.ts
+++ b/frontend/src/shared/api/routeForecast.types.ts
@@ -1,0 +1,110 @@
+export type ErrorCode =
+  "INVALID_ROUTE_ID" | "ROUTE_NOT_FOUND" | "MODEL_OUT_OF_SCOPE" | "NO_RECENT_OBSERVATION" | "SERVICE_UNAVAILABLE";
+
+export interface ErrorResponse {
+  code: ErrorCode;
+  message: string;
+  requestId: string;
+  retryable: boolean;
+}
+
+export type Direction = "UP" | "DOWN";
+
+export type RouteStatus = "FORECAST_READY" | "PREPARING";
+
+export interface RouteCore {
+  id: string;
+  displayName: string;
+  startStopName: string;
+  endStopName: string;
+  status: RouteStatus;
+}
+
+export type RouteSummary = RouteCore;
+
+export interface RouteListResponse {
+  routes: RouteSummary[];
+}
+
+export interface DirectionInfo {
+  id: Direction;
+  name: string;
+  originStopName: string;
+  terminalStopName: string;
+  firstDepartureTime: string;
+  lastDepartureTime: string;
+}
+
+export interface BoardRoute extends RouteCore {
+  turnSequence: number | null;
+  referenceVersionId: string;
+  directions: DirectionInfo[];
+}
+
+export interface ModelInfo {
+  releaseId: string;
+  trainedThrough: string;
+}
+
+export interface ApproachingVehicle {
+  vehicleId: string | null;
+  horizonStops: number;
+  seatAvailableProbability: number;
+  expectedSeats?: number;
+}
+
+export interface StopState {
+  sequence: number;
+  stopId: string;
+  name: string;
+  direction: Direction;
+  boardingAllowed: boolean;
+  approachingVehicles: ApproachingVehicle[];
+}
+
+export interface Board {
+  route: BoardRoute;
+  observedAt: string;
+  model: ModelInfo;
+  vehiclesInService: number;
+  stops: StopState[];
+}
+
+export interface ExactSeat {
+  kind: "EXACT";
+  remaining: number;
+}
+
+export interface UnknownSeat {
+  kind: "UNKNOWN";
+  remaining?: never;
+}
+
+export type SeatInfo = ExactSeat | UnknownSeat;
+
+export type Phase = "ARRIVING" | "DEPARTED" | "IN_TRANSIT";
+
+export interface Vehicle {
+  vehicleId: string | null;
+  direction: Direction;
+  currentStopSequence: number;
+  stopId: string;
+  stopName: string;
+  phase: Phase;
+  seat: SeatInfo;
+}
+
+export type ObservationState = "VEHICLES_PRESENT" | "NO_VEHICLES_OBSERVED" | "UNKNOWN";
+
+export interface Observation {
+  state: ObservationState;
+  observedAt: string | null;
+  staleAt: string | null;
+}
+
+export interface LiveVehicles {
+  routeId: string;
+  referenceVersionId: string;
+  observation: Observation;
+  vehicles: Vehicle[];
+}


### PR DESCRIPTION
## 작업 내용

Client API v4 계약을 기준으로 프론트엔드에서 사용할 타입을 정의했습니다. /routes, /board, /vehicles 세 엔드포인트의 전체 응답과 에러 응답을 타입으로 옮겼고, 계약에서의 부재 표현도 그대로 반영했습니다. 필드 자체가 존재하지 않을 수 있는 경우에는 ?:를, 필드는 존재하지만 값이 없을 수 있는 경우에는 | null을 사용했습니다. SeatInfo는 kind를 기준으로 판별하는 유니온으로 구성했으며, UnknownSeat에는 remaining?: never를 두어 0석(만석)과 좌석 정보를 모름이 코드상에서 섞이지 않도록 했습니다.

계약에서 발생할 수 있는 경계 상태를 빠짐없이 확인할 수 있도록 satisfies를 활용한 샘플도 작성했습니다. 보드 3종, 차량 3종, 노선 목록과 함께 referenceVersionId가 서로 일치하지 않는 경우, 에러 응답 5종을 포함했습니다. 또한 approachingVehicles가 비어 있는 경우, horizonStops의 경계값, 차량 3대 상한, expectedSeats가 없는 항목, vehicleId: null, EXACT이면서 잔여석이 0인 경우와 UNKNOWN인 경우 등 계약상 구분이 필요한 상태들을 샘플에 담았습니다.

타입이 단순히 문서 역할에 그치지 않고 실제 사용 규칙까지 강제할 수 있도록 컴파일 테스트도 추가했습니다. 총 7개의 잘못된 사용 사례에 @ts-expect-error를 적용해, 이후 타입이 의도치 않게 느슨해질 경우 CI의 타입 검사 단계에서 이를 발견할 수 있도록 했습니다. 여기서는 null 확인 없이 값을 사용하는 경우, UNKNOWN 좌석 정보에 remaining을 넣는 경우, 그리고 v4 계약에서 더 이상 허용되지 않는 v3 기준의 필드나 형태를 사용하는 경우 등이 실제로 차단되는지 확인합니다.

## 확인 사항

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 참고 사항

한 가지 논의가 필요한 부분은 typeTest라는 파일명입니다. 현재 폴더 구조 컨벤션 문서에는 없는 새로운 접미사이므로, 이 이름이 적절한지 확인한 뒤 확정되면 컨벤션 문서에도 추가하려고 합니다. 해당 typeTest 파일은 런타임에서 사용하기 위한 파일이 아니라 컴파일 단계에서 타입 제약을 검증하기 위한 파일이기 때문에 어디에서도 import하지 않는 것이 의도된 상태입니다. 같은 이유로 별도의 export도 두지 않았고, 미사용 검사에 대해서는 파일 상단에서 그 사유를 명시한 뒤 예외 처리했습니다.

이번에 작성한 타입과 컴파일 테스트가 보장하는 범위는 우리가 옮겨 적은 Client API 계약 사본 내부의 일관성까지입니다. 실제 서버 응답이 이 계약을 준수하는지에 대한 런타임 검증은 SAL-63에서 추가할 런타임 스키마가 담당할 예정입니다.