### PR TITLE
feat(SAL-103): 지원 노선 목록 조회 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom 'org.testcontainers:testcontainers-bom:1.21.3' // Spring Boot 4.1 BOM 이 관리하지 않는다.
+        mavenBom 'org.testcontainers:testcontainers-bom:1.21.4' // Spring Boot 4.1 BOM 이 관리하지 않는다.
     }
 }
 

--- a/backend/src/main/java/com/gustler/backend/api/http/ApiExceptionHandler.java
+++ b/backend/src/main/java/com/gustler/backend/api/http/ApiExceptionHandler.java
@@ -5,6 +5,8 @@ import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.transaction.CannotCreateTransactionException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
@@ -23,6 +25,20 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
             headers.set(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfter.toSeconds())));
 
         return new ResponseEntity<>(bodyOf(code, exception.getMessage()), headers, code.status());
+    }
+
+    @ExceptionHandler({
+        CannotCreateTransactionException.class,
+        JpaSystemException.class
+    })
+    public ResponseEntity<ErrorResponse> handleDatabaseUnavailable(
+        final RuntimeException exception
+    ) {
+        return respond(
+            ErrorCode.SERVICE_UNAVAILABLE,
+            ErrorCode.SERVICE_UNAVAILABLE.message(),
+            ErrorCode.SERVICE_UNAVAILABLE.status()
+        );
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/gustler/backend/api/route/application/RouteOverview.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/application/RouteOverview.java
@@ -1,0 +1,18 @@
+package com.gustler.backend.api.route.application;
+
+import com.gustler.backend.api.route.domain.Route;
+import com.gustler.backend.api.route.domain.RouteStatus;
+import java.util.List;
+import java.util.Objects;
+
+public record RouteOverview(
+    List<Route> routes,
+    RouteStatus status
+) {
+
+    public RouteOverview {
+        Objects.requireNonNull(routes, "routes는 null일 수 없습니다.");
+        Objects.requireNonNull(status, "status는 null일 수 없습니다.");
+        routes = List.copyOf(routes);
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/application/RouteQueryRepository.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/application/RouteQueryRepository.java
@@ -1,0 +1,11 @@
+package com.gustler.backend.api.route.application;
+
+import com.gustler.backend.api.route.domain.Route;
+import java.util.List;
+
+public interface RouteQueryRepository {
+
+    List<Route> findAllCurrentRoutes();
+
+    boolean existsActiveModel();
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/application/RouteQueryService.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/application/RouteQueryService.java
@@ -12,13 +12,13 @@ public class RouteQueryService {
 
     private final RouteQueryRepository routeQueryRepository;
 
-    public RouteQueryService(final RouteQueryRepository routeQueryRepository) {
+    public RouteQueryService(RouteQueryRepository routeQueryRepository) {
         this.routeQueryRepository = routeQueryRepository;
     }
 
     public RouteOverview getRouteOverview() {
-        final List<Route> routes = routeQueryRepository.findAllCurrentRoutes();
-        final RouteStatus status = routeQueryRepository.existsActiveModel()
+        List<Route> routes = routeQueryRepository.findAllCurrentRoutes();
+        RouteStatus status = routeQueryRepository.existsActiveModel()
             ? RouteStatus.FORECAST_READY
             : RouteStatus.PREPARING;
 

--- a/backend/src/main/java/com/gustler/backend/api/route/application/RouteQueryService.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/application/RouteQueryService.java
@@ -16,9 +16,7 @@ public class RouteQueryService {
 
     public RouteOverview getRouteOverview() {
         List<Route> routes = routeQueryRepository.findAllCurrentRoutes();
-        RouteStatus status = routeQueryRepository.existsActiveModel()
-            ? RouteStatus.FORECAST_READY
-            : RouteStatus.PREPARING;
+        RouteStatus status = RouteStatus.from(routeQueryRepository.existsActiveModel());
 
         return new RouteOverview(routes, status);
     }

--- a/backend/src/main/java/com/gustler/backend/api/route/application/RouteQueryService.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/application/RouteQueryService.java
@@ -3,18 +3,16 @@ package com.gustler.backend.api.route.application;
 import com.gustler.backend.api.route.domain.Route;
 import com.gustler.backend.api.route.domain.RouteStatus;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RouteQueryService {
 
     private final RouteQueryRepository routeQueryRepository;
-
-    public RouteQueryService(RouteQueryRepository routeQueryRepository) {
-        this.routeQueryRepository = routeQueryRepository;
-    }
 
     public RouteOverview getRouteOverview() {
         List<Route> routes = routeQueryRepository.findAllCurrentRoutes();

--- a/backend/src/main/java/com/gustler/backend/api/route/application/RouteQueryService.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/application/RouteQueryService.java
@@ -1,0 +1,27 @@
+package com.gustler.backend.api.route.application;
+
+import com.gustler.backend.api.route.domain.Route;
+import com.gustler.backend.api.route.domain.RouteStatus;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class RouteQueryService {
+
+    private final RouteQueryRepository routeQueryRepository;
+
+    public RouteQueryService(final RouteQueryRepository routeQueryRepository) {
+        this.routeQueryRepository = routeQueryRepository;
+    }
+
+    public RouteOverview getRouteOverview() {
+        final List<Route> routes = routeQueryRepository.findAllCurrentRoutes();
+        final RouteStatus status = routeQueryRepository.existsActiveModel()
+            ? RouteStatus.FORECAST_READY
+            : RouteStatus.PREPARING;
+
+        return new RouteOverview(routes, status);
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/controller/RouteController.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/controller/RouteController.java
@@ -1,0 +1,36 @@
+package com.gustler.backend.api.route.controller;
+
+import com.gustler.backend.api.route.application.RouteQueryService;
+import com.gustler.backend.api.route.dto.RouteListResponse;
+import java.time.Duration;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/routes")
+public class RouteController {
+
+    private static final CacheControl ROUTE_LIST_CACHE = CacheControl
+        .maxAge(Duration.ofMinutes(5))
+        .cachePublic();
+
+    private final RouteQueryService routeQueryService;
+
+    public RouteController(final RouteQueryService routeQueryService) {
+        this.routeQueryService = routeQueryService;
+    }
+
+    @GetMapping
+    public ResponseEntity<RouteListResponse> listRoutes() {
+        final RouteListResponse response = RouteListResponse.from(
+            routeQueryService.getRouteOverview()
+        );
+
+        return ResponseEntity.ok()
+            .cacheControl(ROUTE_LIST_CACHE)
+            .body(response);
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/controller/RouteController.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/controller/RouteController.java
@@ -3,6 +3,7 @@ package com.gustler.backend.api.route.controller;
 import com.gustler.backend.api.route.application.RouteQueryService;
 import com.gustler.backend.api.route.dto.RouteListResponse;
 import java.time.Duration;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/routes")
 public class RouteController {
 
@@ -18,10 +20,6 @@ public class RouteController {
         .cachePublic();
 
     private final RouteQueryService routeQueryService;
-
-    public RouteController(RouteQueryService routeQueryService) {
-        this.routeQueryService = routeQueryService;
-    }
 
     @GetMapping
     public ResponseEntity<RouteListResponse> listRoutes() {

--- a/backend/src/main/java/com/gustler/backend/api/route/controller/RouteController.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/controller/RouteController.java
@@ -19,13 +19,13 @@ public class RouteController {
 
     private final RouteQueryService routeQueryService;
 
-    public RouteController(final RouteQueryService routeQueryService) {
+    public RouteController(RouteQueryService routeQueryService) {
         this.routeQueryService = routeQueryService;
     }
 
     @GetMapping
     public ResponseEntity<RouteListResponse> listRoutes() {
-        final RouteListResponse response = RouteListResponse.from(
+        RouteListResponse response = RouteListResponse.from(
             routeQueryService.getRouteOverview()
         );
 

--- a/backend/src/main/java/com/gustler/backend/api/route/domain/Route.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/domain/Route.java
@@ -1,0 +1,18 @@
+package com.gustler.backend.api.route.domain;
+
+import java.util.Objects;
+
+public record Route(
+    String id,
+    String displayName,
+    String startStopName,
+    String endStopName
+) {
+
+    public Route {
+        Objects.requireNonNull(id, "id는 null일 수 없습니다.");
+        Objects.requireNonNull(displayName, "displayName은 null일 수 없습니다.");
+        Objects.requireNonNull(startStopName, "startStopName은 null일 수 없습니다.");
+        Objects.requireNonNull(endStopName, "endStopName은 null일 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/domain/RouteStatus.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/domain/RouteStatus.java
@@ -5,4 +5,11 @@ public enum RouteStatus {
     FORECAST_READY,
     PREPARING,
     ;
+
+    public static RouteStatus from(boolean activeModelExists) {
+        if (activeModelExists) {
+            return FORECAST_READY;
+        }
+        return PREPARING;
+    }
 }

--- a/backend/src/main/java/com/gustler/backend/api/route/domain/RouteStatus.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/domain/RouteStatus.java
@@ -1,0 +1,7 @@
+package com.gustler.backend.api.route.domain;
+
+public enum RouteStatus {
+
+    FORECAST_READY,
+    PREPARING
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/domain/RouteStatus.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/domain/RouteStatus.java
@@ -3,5 +3,6 @@ package com.gustler.backend.api.route.domain;
 public enum RouteStatus {
 
     FORECAST_READY,
-    PREPARING
+    PREPARING,
+    ;
 }

--- a/backend/src/main/java/com/gustler/backend/api/route/domain/RouteStatus.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/domain/RouteStatus.java
@@ -6,7 +6,9 @@ public enum RouteStatus {
     PREPARING,
     ;
 
-    public static RouteStatus from(boolean activeModelExists) {
+    public static RouteStatus from(
+        final boolean activeModelExists
+    ) {
         if (activeModelExists) {
             return FORECAST_READY;
         }

--- a/backend/src/main/java/com/gustler/backend/api/route/dto/RouteListResponse.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/dto/RouteListResponse.java
@@ -1,0 +1,24 @@
+package com.gustler.backend.api.route.dto;
+
+import com.gustler.backend.api.route.application.RouteOverview;
+import java.util.List;
+import java.util.Objects;
+
+public record RouteListResponse(
+    List<RouteSummary> routes
+) {
+
+    public RouteListResponse {
+        Objects.requireNonNull(routes, "routes는 null일 수 없습니다.");
+        routes = List.copyOf(routes);
+    }
+
+    public static RouteListResponse from(final RouteOverview overview) {
+        final List<RouteSummary> routes = overview.routes()
+            .stream()
+            .map(route -> RouteSummary.from(route, overview.status()))
+            .toList();
+
+        return new RouteListResponse(routes);
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/dto/RouteListResponse.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/dto/RouteListResponse.java
@@ -13,8 +13,8 @@ public record RouteListResponse(
         routes = List.copyOf(routes);
     }
 
-    public static RouteListResponse from(final RouteOverview overview) {
-        final List<RouteSummary> routes = overview.routes()
+    public static RouteListResponse from(RouteOverview overview) {
+        List<RouteSummary> routes = overview.routes()
             .stream()
             .map(route -> RouteSummary.from(route, overview.status()))
             .toList();

--- a/backend/src/main/java/com/gustler/backend/api/route/dto/RouteSummary.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/dto/RouteSummary.java
@@ -1,6 +1,8 @@
 package com.gustler.backend.api.route.dto;
 
+import com.gustler.backend.api.route.domain.Route;
 import com.gustler.backend.api.route.domain.RouteStatus;
+import java.util.Objects;
 
 public record RouteSummary(
     String id,
@@ -9,4 +11,25 @@ public record RouteSummary(
     String endStopName,
     RouteStatus status
 ) {
+
+    public RouteSummary {
+        Objects.requireNonNull(id, "id는 null일 수 없습니다.");
+        Objects.requireNonNull(displayName, "displayName은 null일 수 없습니다.");
+        Objects.requireNonNull(startStopName, "startStopName은 null일 수 없습니다.");
+        Objects.requireNonNull(endStopName, "endStopName은 null일 수 없습니다.");
+        Objects.requireNonNull(status, "status는 null일 수 없습니다.");
+    }
+
+    public static RouteSummary from(
+        final Route route,
+        final RouteStatus status
+    ) {
+        return new RouteSummary(
+            route.id(),
+            route.displayName(),
+            route.startStopName(),
+            route.endStopName(),
+            status
+        );
+    }
 }

--- a/backend/src/main/java/com/gustler/backend/api/route/dto/RouteSummary.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/dto/RouteSummary.java
@@ -1,0 +1,12 @@
+package com.gustler.backend.api.route.dto;
+
+import com.gustler.backend.api.route.domain.RouteStatus;
+
+public record RouteSummary(
+    String id,
+    String displayName,
+    String startStopName,
+    String endStopName,
+    RouteStatus status
+) {
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/dto/RouteSummary.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/dto/RouteSummary.java
@@ -21,8 +21,8 @@ public record RouteSummary(
     }
 
     public static RouteSummary from(
-        final Route route,
-        final RouteStatus status
+        Route route,
+        RouteStatus status
     ) {
         return new RouteSummary(
             route.id(),

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepository.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepository.java
@@ -5,7 +5,7 @@ import com.gustler.backend.api.route.application.RouteQueryRepository;
 import com.gustler.backend.api.route.domain.Route;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -22,7 +22,7 @@ public class JpaRouteQueryRepository implements RouteQueryRepository {
                 .stream()
                 .map(RouteJpaEntity::toDomain)
                 .toList();
-        } catch (DataAccessException exception) {
+        } catch (DataAccessResourceFailureException exception) {
             throw new ServiceUnavailableException();
         }
     }
@@ -31,7 +31,7 @@ public class JpaRouteQueryRepository implements RouteQueryRepository {
     public boolean existsActiveModel() {
         try {
             return modelDeploymentRepository.existsByState(ModelDeploymentState.ACTIVE);
-        } catch (DataAccessException exception) {
+        } catch (DataAccessResourceFailureException exception) {
             throw new ServiceUnavailableException();
         }
     }

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepository.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepository.java
@@ -4,22 +4,16 @@ import com.gustler.backend.api.http.ServiceUnavailableException;
 import com.gustler.backend.api.route.application.RouteQueryRepository;
 import com.gustler.backend.api.route.domain.Route;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@RequiredArgsConstructor
 public class JpaRouteQueryRepository implements RouteQueryRepository {
 
     private final RouteEntityRepository routeRepository;
     private final ModelDeploymentEntityRepository modelDeploymentRepository;
-
-    public JpaRouteQueryRepository(
-        RouteEntityRepository routeRepository,
-        ModelDeploymentEntityRepository modelDeploymentRepository
-    ) {
-        this.routeRepository = routeRepository;
-        this.modelDeploymentRepository = modelDeploymentRepository;
-    }
 
     @Override
     public List<Route> findAllCurrentRoutes() {

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepository.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepository.java
@@ -14,8 +14,8 @@ public class JpaRouteQueryRepository implements RouteQueryRepository {
     private final ModelDeploymentEntityRepository modelDeploymentRepository;
 
     public JpaRouteQueryRepository(
-        final RouteEntityRepository routeRepository,
-        final ModelDeploymentEntityRepository modelDeploymentRepository
+        RouteEntityRepository routeRepository,
+        ModelDeploymentEntityRepository modelDeploymentRepository
     ) {
         this.routeRepository = routeRepository;
         this.modelDeploymentRepository = modelDeploymentRepository;
@@ -28,7 +28,7 @@ public class JpaRouteQueryRepository implements RouteQueryRepository {
                 .stream()
                 .map(RouteJpaEntity::toDomain)
                 .toList();
-        } catch (final DataAccessException exception) {
+        } catch (DataAccessException exception) {
             throw new ServiceUnavailableException();
         }
     }
@@ -37,7 +37,7 @@ public class JpaRouteQueryRepository implements RouteQueryRepository {
     public boolean existsActiveModel() {
         try {
             return modelDeploymentRepository.existsByState(ModelDeploymentState.ACTIVE);
-        } catch (final DataAccessException exception) {
+        } catch (DataAccessException exception) {
             throw new ServiceUnavailableException();
         }
     }

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepository.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepository.java
@@ -1,0 +1,44 @@
+package com.gustler.backend.api.route.persistence.jpa;
+
+import com.gustler.backend.api.http.ServiceUnavailableException;
+import com.gustler.backend.api.route.application.RouteQueryRepository;
+import com.gustler.backend.api.route.domain.Route;
+import java.util.List;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JpaRouteQueryRepository implements RouteQueryRepository {
+
+    private final RouteEntityRepository routeRepository;
+    private final ModelDeploymentEntityRepository modelDeploymentRepository;
+
+    public JpaRouteQueryRepository(
+        final RouteEntityRepository routeRepository,
+        final ModelDeploymentEntityRepository modelDeploymentRepository
+    ) {
+        this.routeRepository = routeRepository;
+        this.modelDeploymentRepository = modelDeploymentRepository;
+    }
+
+    @Override
+    public List<Route> findAllCurrentRoutes() {
+        try {
+            return routeRepository.findAllCurrentRoutes()
+                .stream()
+                .map(RouteJpaEntity::toDomain)
+                .toList();
+        } catch (final DataAccessException exception) {
+            throw new ServiceUnavailableException();
+        }
+    }
+
+    @Override
+    public boolean existsActiveModel() {
+        try {
+            return modelDeploymentRepository.existsByState(ModelDeploymentState.ACTIVE);
+        } catch (final DataAccessException exception) {
+            throw new ServiceUnavailableException();
+        }
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/ModelDeploymentEntityRepository.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/ModelDeploymentEntityRepository.java
@@ -1,0 +1,9 @@
+package com.gustler.backend.api.route.persistence.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ModelDeploymentEntityRepository
+    extends JpaRepository<ModelDeploymentJpaEntity, Long> {
+
+    boolean existsByState(ModelDeploymentState state);
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/ModelDeploymentJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/ModelDeploymentJpaEntity.java
@@ -1,0 +1,26 @@
+package com.gustler.backend.api.route.persistence.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "model_deployment")
+public class ModelDeploymentJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "state", nullable = false, length = 12)
+    private ModelDeploymentState state;
+
+    protected ModelDeploymentJpaEntity() {
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/ModelDeploymentJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/ModelDeploymentJpaEntity.java
@@ -8,9 +8,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "model_deployment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ModelDeploymentJpaEntity {
 
     @Id
@@ -20,7 +23,4 @@ public class ModelDeploymentJpaEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "state", nullable = false, length = 12)
     private ModelDeploymentState state;
-
-    protected ModelDeploymentJpaEntity() {
-    }
 }

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/ModelDeploymentJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/ModelDeploymentJpaEntity.java
@@ -21,6 +21,6 @@ public class ModelDeploymentJpaEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "state", nullable = false, length = 12)
+    @Column(nullable = false)
     private ModelDeploymentState state;
 }

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/ModelDeploymentState.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/ModelDeploymentState.java
@@ -4,5 +4,6 @@ enum ModelDeploymentState {
 
     STAGED,
     ACTIVE,
-    RETIRED
+    RETIRED,
+    ;
 }

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/ModelDeploymentState.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/ModelDeploymentState.java
@@ -1,0 +1,8 @@
+package com.gustler.backend.api.route.persistence.jpa;
+
+enum ModelDeploymentState {
+
+    STAGED,
+    ACTIVE,
+    RETIRED
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteEntityRepository.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteEntityRepository.java
@@ -1,0 +1,16 @@
+package com.gustler.backend.api.route.persistence.jpa;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface RouteEntityRepository extends JpaRepository<RouteJpaEntity, Long> {
+
+    @Query("""
+        SELECT version.route
+        FROM RouteVersionJpaEntity version
+        WHERE version.validTo IS NULL
+        ORDER BY version.route.id
+        """)
+    List<RouteJpaEntity> findAllCurrentRoutes();
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteJpaEntity.java
@@ -19,22 +19,22 @@ public class RouteJpaEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "public_route_id", nullable = false, length = 30)
+    @Column(nullable = false)
     private String publicRouteId;
 
-    @Column(name = "source_id", nullable = false, length = 40)
+    @Column(nullable = false)
     private String sourceId;
 
-    @Column(name = "source_route_id", nullable = false, length = 30)
+    @Column(nullable = false)
     private String sourceRouteId;
 
-    @Column(name = "display_name", nullable = false, length = 40)
+    @Column(nullable = false)
     private String displayName;
 
-    @Column(name = "start_stop_name", nullable = false, length = 60)
+    @Column(nullable = false)
     private String startStopName;
 
-    @Column(name = "end_stop_name", nullable = false, length = 60)
+    @Column(nullable = false)
     private String endStopName;
 
     Route toDomain() {

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteJpaEntity.java
@@ -7,9 +7,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "route")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RouteJpaEntity {
 
     @Id
@@ -33,9 +36,6 @@ public class RouteJpaEntity {
 
     @Column(name = "end_stop_name", nullable = false, length = 60)
     private String endStopName;
-
-    protected RouteJpaEntity() {
-    }
 
     Route toDomain() {
         return new Route(

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteJpaEntity.java
@@ -1,0 +1,48 @@
+package com.gustler.backend.api.route.persistence.jpa;
+
+import com.gustler.backend.api.route.domain.Route;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "route")
+public class RouteJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "public_route_id", nullable = false, length = 30)
+    private String publicRouteId;
+
+    @Column(name = "source_id", nullable = false, length = 40)
+    private String sourceId;
+
+    @Column(name = "source_route_id", nullable = false, length = 30)
+    private String sourceRouteId;
+
+    @Column(name = "display_name", nullable = false, length = 40)
+    private String displayName;
+
+    @Column(name = "start_stop_name", nullable = false, length = 60)
+    private String startStopName;
+
+    @Column(name = "end_stop_name", nullable = false, length = 60)
+    private String endStopName;
+
+    protected RouteJpaEntity() {
+    }
+
+    Route toDomain() {
+        return new Route(
+            sourceRouteId,
+            displayName,
+            startStopName,
+            endStopName
+        );
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteVersionJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteVersionJpaEntity.java
@@ -1,0 +1,55 @@
+package com.gustler.backend.api.route.persistence.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "route_version")
+public class RouteVersionJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "route_id", nullable = false)
+    private RouteJpaEntity route;
+
+    @Column(name = "turn_sequence")
+    private Integer turnSequence;
+
+    @Column(name = "up_first_departure_time", length = 5)
+    private String upFirstDepartureTime;
+
+    @Column(name = "up_last_departure_time", length = 5)
+    private String upLastDepartureTime;
+
+    @Column(name = "down_first_departure_time", length = 5)
+    private String downFirstDepartureTime;
+
+    @Column(name = "down_last_departure_time", length = 5)
+    private String downLastDepartureTime;
+
+    @JdbcTypeCode(SqlTypes.CHAR)
+    @Column(name = "content_digest", nullable = false, length = 64)
+    private String contentDigest;
+
+    @Column(name = "valid_from", nullable = false)
+    private OffsetDateTime validFrom;
+
+    @Column(name = "valid_to")
+    private OffsetDateTime validTo;
+
+    protected RouteVersionJpaEntity() {
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteVersionJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteVersionJpaEntity.java
@@ -28,28 +28,22 @@ public class RouteVersionJpaEntity {
     @JoinColumn(name = "route_id", nullable = false)
     private RouteJpaEntity route;
 
-    @Column(name = "turn_sequence")
     private Integer turnSequence;
 
-    @Column(name = "up_first_departure_time", length = 5)
     private String upFirstDepartureTime;
 
-    @Column(name = "up_last_departure_time", length = 5)
     private String upLastDepartureTime;
 
-    @Column(name = "down_first_departure_time", length = 5)
     private String downFirstDepartureTime;
 
-    @Column(name = "down_last_departure_time", length = 5)
     private String downLastDepartureTime;
 
     @JdbcTypeCode(SqlTypes.CHAR)
-    @Column(name = "content_digest", nullable = false, length = 64)
+    @Column(nullable = false)
     private String contentDigest;
 
-    @Column(name = "valid_from", nullable = false)
+    @Column(nullable = false)
     private OffsetDateTime validFrom;
 
-    @Column(name = "valid_to")
     private OffsetDateTime validTo;
 }

--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteVersionJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteVersionJpaEntity.java
@@ -10,11 +10,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "route_version")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RouteVersionJpaEntity {
 
     @Id
@@ -49,7 +52,4 @@ public class RouteVersionJpaEntity {
 
     @Column(name = "valid_to")
     private OffsetDateTime validTo;
-
-    protected RouteVersionJpaEntity() {
-    }
 }

--- a/backend/src/test/java/com/gustler/backend/api/http/ApiExceptionHandlerTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/http/ApiExceptionHandlerTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.transaction.CannotCreateTransactionException;
 
 class ApiExceptionHandlerTest {
 
@@ -31,6 +33,13 @@ class ApiExceptionHandlerTest {
             new ModelOutOfScopeException(),
             new NoRecentObservationException(),
             new ServiceUnavailableException()
+        );
+    }
+
+    private static List<RuntimeException> databaseUnavailableExceptions() {
+        return List.of(
+            new CannotCreateTransactionException("DB 연결을 얻지 못했다"),
+            new JpaSystemException(new IllegalStateException("DB 트랜잭션을 종료하지 못했다"))
         );
     }
 
@@ -91,6 +100,25 @@ class ApiExceptionHandlerTest {
 
         // then
         assertThat(actual.getHeaders().getFirst(HttpHeaders.RETRY_AFTER)).isEqualTo("15");
+    }
+
+    @ParameterizedTest
+    @MethodSource("databaseUnavailableExceptions")
+    void DB_트랜잭션을_시작하거나_종료하지_못하면_서비스_불가로_응답한다(
+        final RuntimeException exception
+    ) {
+        // when
+        final ResponseEntity<ErrorResponse> actual =
+            handler.handleDatabaseUnavailable(exception);
+
+        // then
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(actual.getHeaders().getCacheControl()).isEqualTo("no-store");
+        assertThat(actual.getHeaders().getFirst(HttpHeaders.RETRY_AFTER)).isNull();
+        assertThat(actual.getBody()).isNotNull();
+        assertThat(actual.getBody().code()).isEqualTo(ErrorCode.SERVICE_UNAVAILABLE);
+        assertThat(actual.getBody().message()).isEqualTo(ErrorCode.SERVICE_UNAVAILABLE.message());
+        assertThat(actual.getBody().requestId()).isNotBlank();
     }
 
     @ParameterizedTest

--- a/backend/src/test/java/com/gustler/backend/api/route/application/RouteQueryServiceTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/route/application/RouteQueryServiceTest.java
@@ -1,0 +1,61 @@
+package com.gustler.backend.api.route.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.gustler.backend.api.route.domain.Route;
+import com.gustler.backend.api.route.domain.RouteStatus;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RouteQueryServiceTest {
+
+    private static final Route ROUTE = new Route(
+        "204000057",
+        "3330",
+        "도촌동9단지앞",
+        "안양역"
+    );
+
+    @Mock
+    private RouteQueryRepository routeQueryRepository;
+
+    private RouteQueryService routeQueryService;
+
+    @BeforeEach
+    void setUp() {
+        routeQueryService = new RouteQueryService(routeQueryRepository);
+        given(routeQueryRepository.findAllCurrentRoutes()).willReturn(List.of(ROUTE));
+    }
+
+    @Test
+    void 활성_모델이_있으면_모든_노선이_예보_준비_상태다() {
+        // given
+        given(routeQueryRepository.existsActiveModel()).willReturn(true);
+
+        // when
+        final RouteOverview actual = routeQueryService.getRouteOverview();
+
+        // then
+        assertThat(actual.routes()).containsExactly(ROUTE);
+        assertThat(actual.status()).isEqualTo(RouteStatus.FORECAST_READY);
+    }
+
+    @Test
+    void 활성_모델이_없으면_모든_노선이_준비_중_상태다() {
+        // given
+        given(routeQueryRepository.existsActiveModel()).willReturn(false);
+
+        // when
+        final RouteOverview actual = routeQueryService.getRouteOverview();
+
+        // then
+        assertThat(actual.routes()).containsExactly(ROUTE);
+        assertThat(actual.status()).isEqualTo(RouteStatus.PREPARING);
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/api/route/controller/RouteApiContractTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/route/controller/RouteApiContractTest.java
@@ -49,6 +49,7 @@ class RouteApiContractTest {
 
     @Test
     void 현재_판본이_있는_노선을_DB_생성_순서와_계약_필드_순서대로_반환한다() throws Exception {
+        // given
         final long firstRouteId = insertRoute(
             "234000050",
             "1650",
@@ -69,6 +70,7 @@ class RouteApiContractTest {
             {"routes":[{"id":"234000050","displayName":"1650","startStopName":"구리수택차고지","endStopName":"안양역","status":"PREPARING"},{"id":"204000057","displayName":"3330","startStopName":"도촌동9단지앞","endStopName":"안양역","status":"PREPARING"}]}
             """.strip();
 
+        // when & then
         mockMvc.perform(get("/api/v1/routes"))
             .andExpect(status().isOk())
             .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "max-age=300, public"))
@@ -77,6 +79,7 @@ class RouteApiContractTest {
 
     @Test
     void 활성_모델이_있으면_현재_노선을_FORECAST_READY로_반환한다() throws Exception {
+        // given
         final long routeId = insertRoute(
             "204000057",
             "3330",
@@ -86,13 +89,15 @@ class RouteApiContractTest {
         insertCurrentVersionWithStop(routeId, FIRST_DIGEST, "205000001");
         insertModelDeployment("ACTIVE");
 
+        // when & then
         mockMvc.perform(get("/api/v1/routes"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.routes[0].status").value("FORECAST_READY"));
     }
 
     @Test
-    void 판본이_교체되면_종료된_판본을_제외하고_새_현재_판본을_읽는다() throws Exception {
+    void 종료된_판본만_있는_노선은_목록에서_빠진다() throws Exception {
+        // given
         final long routeId = insertRoute(
             "204000057",
             "3330",
@@ -101,12 +106,25 @@ class RouteApiContractTest {
         );
         insertExpiredVersionWithStop(routeId, FIRST_DIGEST, "205000001");
 
+        // when & then
         mockMvc.perform(get("/api/v1/routes"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.routes").isEmpty());
+    }
 
+    @Test
+    void 새_현재_판본이_생기면_목록에_들어온다() throws Exception {
+        // given
+        final long routeId = insertRoute(
+            "204000057",
+            "3330",
+            "도촌동9단지앞",
+            "안양역"
+        );
+        insertExpiredVersionWithStop(routeId, FIRST_DIGEST, "205000001");
         insertCurrentVersionWithStop(routeId, SECOND_DIGEST, "205000002");
 
+        // when & then
         mockMvc.perform(get("/api/v1/routes"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.routes.length()").value(1))

--- a/backend/src/test/java/com/gustler/backend/api/route/controller/RouteApiContractTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/route/controller/RouteApiContractTest.java
@@ -1,0 +1,210 @@
+package com.gustler.backend.api.route.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.gustler.backend.support.IntegrationTest;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+@IntegrationTest
+@Transactional
+class RouteApiContractTest {
+
+    private static final OffsetDateTime FIRST_VERSION_AT = OffsetDateTime.parse(
+        "2026-08-01T00:00:00+09:00"
+    );
+    private static final OffsetDateTime SECOND_VERSION_AT = OffsetDateTime.parse(
+        "2026-08-20T00:00:00+09:00"
+    );
+    private static final String FIRST_DIGEST = "1".repeat(64);
+    private static final String SECOND_DIGEST = "2".repeat(64);
+
+    @Autowired
+    private WebApplicationContext applicationContext;
+
+    @Autowired
+    private JdbcClient jdbcClient;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+            .webAppContextSetup(applicationContext)
+            .build();
+    }
+
+    @Test
+    void 현재_판본이_있는_노선을_DB_생성_순서와_계약_필드_순서대로_반환한다() throws Exception {
+        final long firstRouteId = insertRoute(
+            "234000050",
+            "1650",
+            "구리수택차고지",
+            "안양역"
+        );
+        final long secondRouteId = insertRoute(
+            "204000057",
+            "3330",
+            "도촌동9단지앞",
+            "안양역"
+        );
+        insertCurrentVersionWithStop(firstRouteId, FIRST_DIGEST, "222000001");
+        insertCurrentVersionWithStop(secondRouteId, SECOND_DIGEST, "205000001");
+        insertModelDeployment("STAGED");
+
+        final String expected = """
+            {"routes":[{"id":"234000050","displayName":"1650","startStopName":"구리수택차고지","endStopName":"안양역","status":"PREPARING"},{"id":"204000057","displayName":"3330","startStopName":"도촌동9단지앞","endStopName":"안양역","status":"PREPARING"}]}
+            """.strip();
+
+        mockMvc.perform(get("/api/v1/routes"))
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "max-age=300, public"))
+            .andExpect(content().string(expected));
+    }
+
+    @Test
+    void 활성_모델이_있으면_현재_노선을_FORECAST_READY로_반환한다() throws Exception {
+        final long routeId = insertRoute(
+            "204000057",
+            "3330",
+            "도촌동9단지앞",
+            "안양역"
+        );
+        insertCurrentVersionWithStop(routeId, FIRST_DIGEST, "205000001");
+        insertModelDeployment("ACTIVE");
+
+        mockMvc.perform(get("/api/v1/routes"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.routes[0].status").value("FORECAST_READY"));
+    }
+
+    @Test
+    void 판본이_교체되면_종료된_판본을_제외하고_새_현재_판본을_읽는다() throws Exception {
+        final long routeId = insertRoute(
+            "204000057",
+            "3330",
+            "도촌동9단지앞",
+            "안양역"
+        );
+        insertExpiredVersionWithStop(routeId, FIRST_DIGEST, "205000001");
+
+        mockMvc.perform(get("/api/v1/routes"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.routes").isEmpty());
+
+        insertCurrentVersionWithStop(routeId, SECOND_DIGEST, "205000002");
+
+        mockMvc.perform(get("/api/v1/routes"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.routes.length()").value(1))
+            .andExpect(jsonPath("$.routes[0].id").value("204000057"));
+    }
+
+    private long insertRoute(
+        final String sourceRouteId,
+        final String displayName,
+        final String startStopName,
+        final String endStopName
+    ) {
+        return jdbcClient.sql("""
+                INSERT INTO route (
+                    public_route_id, source_id, source_route_id,
+                    display_name, start_stop_name, end_stop_name
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                RETURNING id
+                """)
+            .params(
+                sourceRouteId,
+                "GBIS",
+                sourceRouteId,
+                displayName,
+                startStopName,
+                endStopName
+            )
+            .query(Long.class)
+            .single();
+    }
+
+    private void insertCurrentVersionWithStop(
+        final long routeId,
+        final String contentDigest,
+        final String stopId
+    ) {
+        final long routeVersionId = jdbcClient.sql("""
+                INSERT INTO route_version (route_id, content_digest, valid_from)
+                VALUES (?, ?, ?)
+                RETURNING id
+                """)
+            .params(routeId, contentDigest, SECOND_VERSION_AT)
+            .query(Long.class)
+            .single();
+        insertRouteStop(routeVersionId, stopId);
+    }
+
+    private void insertExpiredVersionWithStop(
+        final long routeId,
+        final String contentDigest,
+        final String stopId
+    ) {
+        final long routeVersionId = jdbcClient.sql("""
+                INSERT INTO route_version (route_id, content_digest, valid_from, valid_to)
+                VALUES (?, ?, ?, ?)
+                RETURNING id
+                """)
+            .params(routeId, contentDigest, FIRST_VERSION_AT, SECOND_VERSION_AT)
+            .query(Long.class)
+            .single();
+        insertRouteStop(routeVersionId, stopId);
+    }
+
+    private void insertRouteStop(
+        final long routeVersionId,
+        final String stopId
+    ) {
+        jdbcClient.sql("""
+                INSERT INTO route_stop (
+                    route_version_id, stop_order, stop_id,
+                    name, direction, boarding_allowed
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """)
+            .params(routeVersionId, 1, stopId, "테스트 정류장", "UP", true)
+            .update();
+    }
+
+    private void insertModelDeployment(final String state) {
+        jdbcClient.sql("""
+                INSERT INTO model_deployment (
+                    deployment_key, release_id, model_key, model_version,
+                    bundle_digest, prediction_target_version, calculation_version,
+                    supported_scope_digest, data_until, state, activated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """)
+            .params(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                "route-contract-test",
+                "seat-forecast",
+                "test-v1",
+                "3".repeat(64),
+                "target-v1",
+                "calculation-v1",
+                "4".repeat(64),
+                SECOND_VERSION_AT,
+                state,
+                SECOND_VERSION_AT
+            )
+            .update();
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/api/route/controller/RouteControllerTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/route/controller/RouteControllerTest.java
@@ -37,7 +37,8 @@ class RouteControllerTest {
     }
 
     @Test
-    void 지원_노선을_조회_순서대로_반환한다() throws Exception {
+    void 지원_노선을_DB_생성_순서대로_반환한다() throws Exception {
+        // given
         final Route firstRoute = new Route(
             "204000057",
             "3330",
@@ -55,6 +56,7 @@ class RouteControllerTest {
             RouteStatus.FORECAST_READY
         ));
 
+        // when & then
         mockMvc.perform(get("/api/v1/routes"))
             .andExpect(status().isOk())
             .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -70,8 +72,10 @@ class RouteControllerTest {
 
     @Test
     void 서비스_불가_예외는_공통_503_오류_응답으로_반환한다() throws Exception {
+        // given
         given(routeQueryService.getRouteOverview()).willThrow(new ServiceUnavailableException());
 
+        // when & then
         mockMvc.perform(get("/api/v1/routes"))
             .andExpect(status().isServiceUnavailable())
             .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"))

--- a/backend/src/test/java/com/gustler/backend/api/route/controller/RouteControllerTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/route/controller/RouteControllerTest.java
@@ -1,0 +1,84 @@
+package com.gustler.backend.api.route.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.gustler.backend.api.http.ApiExceptionHandler;
+import com.gustler.backend.api.http.ServiceUnavailableException;
+import com.gustler.backend.api.route.application.RouteOverview;
+import com.gustler.backend.api.route.application.RouteQueryService;
+import com.gustler.backend.api.route.domain.Route;
+import com.gustler.backend.api.route.domain.RouteStatus;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class RouteControllerTest {
+
+    private RouteQueryService routeQueryService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        routeQueryService = mock(RouteQueryService.class);
+        mockMvc = MockMvcBuilders
+            .standaloneSetup(new RouteController(routeQueryService))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .build();
+    }
+
+    @Test
+    void 지원_노선을_조회_순서대로_반환한다() throws Exception {
+        final Route firstRoute = new Route(
+            "204000057",
+            "3330",
+            "도촌동9단지앞",
+            "안양역"
+        );
+        final Route secondRoute = new Route(
+            "234000050",
+            "1650",
+            "구리수택차고지",
+            "안양역"
+        );
+        given(routeQueryService.getRouteOverview()).willReturn(new RouteOverview(
+            List.of(firstRoute, secondRoute),
+            RouteStatus.FORECAST_READY
+        ));
+
+        mockMvc.perform(get("/api/v1/routes"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "max-age=300, public"))
+            .andExpect(jsonPath("$.routes.length()").value(2))
+            .andExpect(jsonPath("$.routes[0].id").value("204000057"))
+            .andExpect(jsonPath("$.routes[0].displayName").value("3330"))
+            .andExpect(jsonPath("$.routes[0].startStopName").value("도촌동9단지앞"))
+            .andExpect(jsonPath("$.routes[0].endStopName").value("안양역"))
+            .andExpect(jsonPath("$.routes[0].status").value("FORECAST_READY"))
+            .andExpect(jsonPath("$.routes[1].id").value("234000050"));
+    }
+
+    @Test
+    void DB_장애는_공통_503_오류_응답으로_반환한다() throws Exception {
+        given(routeQueryService.getRouteOverview()).willThrow(new ServiceUnavailableException());
+
+        mockMvc.perform(get("/api/v1/routes"))
+            .andExpect(status().isServiceUnavailable())
+            .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"))
+            .andExpect(header().doesNotExist(HttpHeaders.RETRY_AFTER))
+            .andExpect(jsonPath("$.code").value("SERVICE_UNAVAILABLE"))
+            .andExpect(jsonPath("$.message").value("일시적인 서버 장애가 발생했습니다."))
+            .andExpect(jsonPath("$.requestId").isNotEmpty())
+            .andExpect(jsonPath("$.retryable").doesNotExist());
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/api/route/controller/RouteControllerTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/route/controller/RouteControllerTest.java
@@ -69,7 +69,7 @@ class RouteControllerTest {
     }
 
     @Test
-    void DB_장애는_공통_503_오류_응답으로_반환한다() throws Exception {
+    void 서비스_불가_예외는_공통_503_오류_응답으로_반환한다() throws Exception {
         given(routeQueryService.getRouteOverview()).willThrow(new ServiceUnavailableException());
 
         mockMvc.perform(get("/api/v1/routes"))

--- a/backend/src/test/java/com/gustler/backend/api/route/controller/RouteControllerTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/route/controller/RouteControllerTest.java
@@ -37,7 +37,7 @@ class RouteControllerTest {
     }
 
     @Test
-    void 지원_노선을_DB_생성_순서대로_반환한다() throws Exception {
+    void 지원_노선을_받은_순서_그대로_반환한다() throws Exception {
         // given
         final Route firstRoute = new Route(
             "204000057",

--- a/backend/src/test/java/com/gustler/backend/api/route/controller/RouteDatabaseFailureContractTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/route/controller/RouteDatabaseFailureContractTest.java
@@ -1,0 +1,63 @@
+package com.gustler.backend.api.route.controller;
+
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.gustler.backend.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@IntegrationTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestPropertySource(properties = {
+    "spring.datasource.hikari.connection-timeout=250",
+    "spring.datasource.hikari.maximum-pool-size=1",
+    "spring.datasource.hikari.minimum-idle=0"
+})
+class RouteDatabaseFailureContractTest {
+
+    @Autowired
+    private WebApplicationContext applicationContext;
+
+    @Autowired
+    private PostgreSQLContainer<?> postgres;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+            .webAppContextSetup(applicationContext)
+            .build();
+    }
+
+    @Test
+    void 실행_중_DB_연결을_잃으면_공통_503_오류로_응답한다() throws Exception {
+        // given
+        mockMvc.perform(get("/api/v1/routes"))
+            .andExpect(status().isOk());
+        postgres.stop();
+
+        // when & then
+        mockMvc.perform(get("/api/v1/routes"))
+            .andExpect(status().isServiceUnavailable())
+            .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"))
+            .andExpect(header().doesNotExist(HttpHeaders.RETRY_AFTER))
+            .andExpect(jsonPath("$").value(aMapWithSize(3)))
+            .andExpect(jsonPath("$.code").value("SERVICE_UNAVAILABLE"))
+            .andExpect(jsonPath("$.message").value("일시적인 서버 장애가 발생했습니다."))
+            .andExpect(jsonPath("$.requestId").isNotEmpty())
+            .andExpect(jsonPath("$.retryable").doesNotExist());
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepositoryTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.gustler.backend.api.route.persistence.jpa;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.gustler.backend.api.http.ServiceUnavailableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessResourceFailureException;
+
+class JpaRouteQueryRepositoryTest {
+
+    private RouteEntityRepository routeRepository;
+    private ModelDeploymentEntityRepository modelDeploymentRepository;
+    private JpaRouteQueryRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        routeRepository = mock(RouteEntityRepository.class);
+        modelDeploymentRepository = mock(ModelDeploymentEntityRepository.class);
+        repository = new JpaRouteQueryRepository(routeRepository, modelDeploymentRepository);
+    }
+
+    @Test
+    void 노선_조회_중_DB_장애가_발생하면_서비스_불가_예외로_변환한다() {
+        given(routeRepository.findAllCurrentRoutes())
+            .willThrow(new DataAccessResourceFailureException("database unavailable"));
+
+        assertThatThrownBy(repository::findAllCurrentRoutes)
+            .isInstanceOf(ServiceUnavailableException.class)
+            .hasMessage("일시적인 서버 장애가 발생했습니다.");
+    }
+
+    @Test
+    void 활성_모델_조회_중_DB_장애가_발생하면_서비스_불가_예외로_변환한다() {
+        given(modelDeploymentRepository.existsByState(ModelDeploymentState.ACTIVE))
+            .willThrow(new DataAccessResourceFailureException("database unavailable"));
+
+        assertThatThrownBy(repository::existsActiveModel)
+            .isInstanceOf(ServiceUnavailableException.class)
+            .hasMessage("일시적인 서버 장애가 발생했습니다.");
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepositoryTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepositoryTest.java
@@ -8,6 +8,7 @@ import com.gustler.backend.api.http.ServiceUnavailableException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 
 class JpaRouteQueryRepositoryTest {
 
@@ -30,6 +31,16 @@ class JpaRouteQueryRepositoryTest {
         assertThatThrownBy(repository::findAllCurrentRoutes)
             .isInstanceOf(ServiceUnavailableException.class)
             .hasMessage("일시적인 서버 장애가 발생했습니다.");
+    }
+
+    @Test
+    void 노선_조회_결과_계약_오류는_서비스_불가_예외로_변환하지_않는다() {
+        IncorrectResultSizeDataAccessException exception =
+            new IncorrectResultSizeDataAccessException(1, 2);
+        given(routeRepository.findAllCurrentRoutes()).willThrow(exception);
+
+        assertThatThrownBy(repository::findAllCurrentRoutes)
+            .isSameAs(exception);
     }
 
     @Test

--- a/backend/src/test/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepositoryTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/route/persistence/jpa/JpaRouteQueryRepositoryTest.java
@@ -25,29 +25,35 @@ class JpaRouteQueryRepositoryTest {
 
     @Test
     void 노선_조회_중_DB_장애가_발생하면_서비스_불가_예외로_변환한다() {
+        // given
         given(routeRepository.findAllCurrentRoutes())
             .willThrow(new DataAccessResourceFailureException("database unavailable"));
 
+        // when & then
         assertThatThrownBy(repository::findAllCurrentRoutes)
             .isInstanceOf(ServiceUnavailableException.class)
             .hasMessage("일시적인 서버 장애가 발생했습니다.");
     }
 
     @Test
-    void 노선_조회_결과_계약_오류는_서비스_불가_예외로_변환하지_않는다() {
+    void 노선_조회_결과_계약_오류는_그대로_올려보낸다() {
+        // given
         IncorrectResultSizeDataAccessException exception =
             new IncorrectResultSizeDataAccessException(1, 2);
         given(routeRepository.findAllCurrentRoutes()).willThrow(exception);
 
+        // when & then
         assertThatThrownBy(repository::findAllCurrentRoutes)
             .isSameAs(exception);
     }
 
     @Test
     void 활성_모델_조회_중_DB_장애가_발생하면_서비스_불가_예외로_변환한다() {
+        // given
         given(modelDeploymentRepository.existsByState(ModelDeploymentState.ACTIVE))
             .willThrow(new DataAccessResourceFailureException("database unavailable"));
 
+        // when & then
         assertThatThrownBy(repository::existsActiveModel)
             .isInstanceOf(ServiceUnavailableException.class)
             .hasMessage("일시적인 서버 장애가 발생했습니다.");


### PR DESCRIPTION
<!-- PR 제목: feat(SAL-103): 지원 노선 목록 조회 API 구현 -->

## 개요

프론트엔드가 지원 노선과 예보 준비 상태를 조회할 수 있도록 `GET /api/v1/routes`를 구현했습니다.

- 현재 지원 노선만 반환
- 공급자 노선 ID 원문과 표시명, 기점·종점 제공
- ACTIVE 모델 존재 여부에 따라 `FORECAST_READY`와 `PREPARING` 구분
- DB 생성 순서인 `route.id ASC`로 반환
- `Cache-Control: public, max-age=300` 적용
- DB 장애를 공통 `SERVICE_UNAVAILABLE` 503으로 변환

## 응답 예시

```json
{
  "routes": [
    {
      "id": "234000050",
      "displayName": "1650",
      "startStopName": "구리수택차고지",
      "endStopName": "안양역",
      "status": "FORECAST_READY"
    },
    {
      "id": "204000057",
      "displayName": "3330",
      "startStopName": "도촌동9단지앞",
      "endStopName": "안양역",
      "status": "FORECAST_READY"
    }
  ]
}
```

## 패키지 및 아키텍처 설계

노선 기능이 한곳에 모이도록 기능 우선 패키지 구조를 사용했습니다.

```text
api.route
├── controller
├── dto
├── application
├── domain
└── persistence.jpa
```

조회 흐름은 다음과 같습니다.

```text
RouteController
→ RouteQueryService
→ RouteQueryRepository
→ JpaRouteQueryRepository
→ Spring Data JPA Repository
→ PostgreSQL
```

### 계층별 역할

- `controller`
  - HTTP 경로와 캐시 헤더 처리
  - application 결과를 API 응답 DTO로 변환
- `dto`
  - Client API의 `RouteListResponse`, `RouteSummary` 계약 표현
- `application`
  - 지원 노선 조회 유스케이스 조정
  - 필요한 저장소 기능을 `RouteQueryRepository` 포트로 선언
  - HTTP 응답과 분리된 조회 결과인 `RouteOverview` 반환
- `domain`
  - 순수 `Route`와 `RouteStatus` 표현
- `persistence.jpa`
  - JPA Entity와 Spring Data Repository 구성
  - `RouteQueryRepository` 구현
  - Entity를 도메인 객체로 변환

application이 Spring Data JPA나 Entity를 직접 알지 않도록 Repository 포트와 JPA 어댑터를 분리했습니다.

```text
RouteQueryRepository
        ↑ 구현
JpaRouteQueryRepository
```

### 조회 기준

현재 dev에 병합된 Flyway 스키마를 기준으로 조회합니다.

- `route_version.valid_to IS NULL`인 현재 판본만 선택
- 응답의 `id`는 `route.source_route_id` 사용
- `route.id ASC`로 정렬해 DB 생성 순서 유지
- 현재 범위에서는 전역 ACTIVE 모델 하나가 모든 지원 노선을 지원한다고 가정
  - ACTIVE 존재: `FORECAST_READY`
  - ACTIVE 없음: `PREPARING`
- API 계층에서는 판본 생성이나 digest 계산을 수행하지 않음

## DB 오류 처리

DB 장애가 발생하는 위치에 따라 두 경로로 처리합니다.

### 쿼리 실행 중 장애

```text
Spring Data JPA
→ DataAccessException
→ JpaRouteQueryRepository
→ ServiceUnavailableException
→ ApiExceptionHandler
→ 503
```

JPA 어댑터에서 Spring의 `DataAccessException`을 기존 공통 `ServiceUnavailableException`으로 변환합니다.

### 트랜잭션 시작·종료 중 장애

DB 연결이 끊기면 Service 메서드에 진입하기 전 트랜잭션 시작이 실패하거나, 쿼리 실패 후 rollback도 실패할 수 있습니다.

```text
트랜잭션 시작 실패
→ CannotCreateTransactionException

쿼리 실패 후 rollback 실패
→ JpaSystemException
```

이 두 예외는 Repository 어댑터 바깥에서 발생하므로 기존 `ApiExceptionHandler`에서 공통 503으로 변환했습니다.

```json
{
  "code": "SERVICE_UNAVAILABLE",
  "message": "일시적인 서버 장애가 발생했습니다.",
  "requestId": "..."
}
```

- `Cache-Control: no-store`
- 재시도 시각을 알 수 없어 `Retry-After` 생략
- `retryable` 필드 없음

운영 Hikari의 기본 연결 대기 시간은 이번 작업에서 변경하지 않았습니다.

## 테스트 전략

| 테스트 | 검증 범위 |
|---|---|
| `RouteQueryServiceTest` | ACTIVE 모델에 따른 READY/PREPARING 판정 |
| `RouteControllerTest` | JSON 응답, 캐시 헤더, 공통 503 응답 |
| `JpaRouteQueryRepositoryTest` | DB 조회 예외를 `ServiceUnavailableException`으로 변환 |
| `RouteApiContractTest` | 실제 Flyway 스키마, 노선 순서, 현재 판본, 상태 전환 |
| `RouteDatabaseFailureContractTest` | PostgreSQL을 실제로 중단한 뒤 503 계약 검증 |

### Testcontainers 계약 테스트

PostgreSQL 18 컨테이너에 Flyway V1~V3을 실제로 적용하고 fixture를 삽입합니다.

검증 항목:

- 계약 필드와 JSON 순서
- `route.id ASC` 노선 순서
- STAGED 모델만 있으면 `PREPARING`
- ACTIVE 모델이 있으면 `FORECAST_READY`
- 종료된 판본 제외
- 새 현재 판본 즉시 반영
- `Cache-Control: public, max-age=300`

### DB 단절 테스트

다른 통합 테스트와 분리된 Spring 컨텍스트에서 전용 PostgreSQL 컨테이너를 중단합니다.

```text
정상 /routes 요청 → 200
PostgreSQL 중단
/routes 재요청 → 503 SERVICE_UNAVAILABLE
```
## 개발 환경

Docker 29 환경에서 별도 개인 설정 없이 Testcontainers가 동작하도록 Testcontainers BOM을 `1.21.4`로 업데이트했습니다.

## 테스트 결과

- [x] `./gradlew test`
- [x] 전체 74개 테스트 통과
- [x] PostgreSQL 18 Testcontainers 계약 테스트 통과
- [x] 실제 Tomcat 포트에서 정상 응답 확인
- [x] 실제 DB 종료 후 503 응답 확인

## 리뷰 포인트

1. 기능 우선 패키지와 Repository 포트/JPA 어댑터 분리가 적절한지
2. 현재 범위에서 ACTIVE 모델을 전역 준비 상태로 사용하는 정책이 적절한지
3. 트랜잭션 시작·rollback 실패를 공통 503으로 변환하는 범위가 적절한지
4. DB 단절 테스트를 별도 Spring 컨텍스트로 격리한 방식이 적절한지
