### PR TITLE
feat(SAL-82): Open API 원문을 관측 값으로 정규화

### DIFF
--- a/backend/src/main/java/com/gustler/backend/collector/RemainingSeats.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RemainingSeats.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 public sealed interface RemainingSeats {
 
     static RemainingSeats from(
-        final Integer remainingSeatCount
+        Integer remainingSeatCount
     ) {
         if (remainingSeatCount == null) {
             return new Unknown(SeatUnknownReason.NOT_REPORTED);

--- a/backend/src/main/java/com/gustler/backend/collector/RemainingSeats.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RemainingSeats.java
@@ -1,0 +1,38 @@
+package com.gustler.backend.collector;
+
+import java.util.Objects;
+
+public sealed interface RemainingSeats {
+
+    static RemainingSeats from(
+        final Integer remainingSeatCount
+    ) {
+        if (remainingSeatCount == null) {
+            return new Unknown(SeatUnknownReason.NOT_REPORTED);
+        }
+        if (remainingSeatCount < 0) {
+            return new Unknown(SeatUnknownReason.REPORTED_UNKNOWN);
+        }
+        return new Known(remainingSeatCount);
+    }
+
+    record Known(
+        int seats
+    ) implements RemainingSeats {
+
+        public Known {
+            if (seats < 0) {
+                throw new IllegalArgumentException("아는 잔여석은 음수일 수 없다: " + seats);
+            }
+        }
+    }
+
+    record Unknown(
+        SeatUnknownReason reason
+    ) implements RemainingSeats {
+
+        public Unknown {
+            Objects.requireNonNull(reason, "잔여석을 모르면 사유가 있어야 한다");
+        }
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/SeatUnknownReason.java
+++ b/backend/src/main/java/com/gustler/backend/collector/SeatUnknownReason.java
@@ -1,0 +1,8 @@
+package com.gustler.backend.collector;
+
+public enum SeatUnknownReason {
+
+    REPORTED_UNKNOWN,
+    NOT_REPORTED,
+    ;
+}

--- a/backend/src/main/java/com/gustler/backend/collector/VehicleObservation.java
+++ b/backend/src/main/java/com/gustler/backend/collector/VehicleObservation.java
@@ -1,0 +1,50 @@
+package com.gustler.backend.collector;
+
+import com.gustler.backend.collector.dto.BusLocationResponse.BusLocation;
+import java.util.Objects;
+
+public record VehicleObservation(
+    String vehicleId,
+    String plateNumber,
+    Integer stopOrder,
+    String stopId,
+    Integer runningState,
+    RemainingSeats remainingSeats,
+    Integer crowdLevel,
+    Integer vehicleType,
+    Integer routeType,
+    Integer tagless
+) {
+
+    private static final int LOWEST_CROWD_LEVEL = 1;
+    private static final int HIGHEST_CROWD_LEVEL = 4;
+
+    public VehicleObservation {
+        Objects.requireNonNull(remainingSeats, "잔여석은 아는 것이든 모르는 것이든 있어야 한다");
+    }
+
+    public static VehicleObservation from(
+        final BusLocation bus
+    ) {
+        return new VehicleObservation(
+            bus.vehicleId(),
+            bus.plateNumber(),
+            bus.stopSequence(),
+            bus.stopId(),
+            bus.runningStatus(),
+            RemainingSeats.from(bus.remainingSeatCount()),
+            crowdLevelOf(bus.crowdLevel()),
+            bus.vehicleType(),
+            bus.routeType(),
+            bus.taglessCode());
+    }
+
+    private static Integer crowdLevelOf(
+        final Integer crowdLevel
+    ) {
+        if (crowdLevel == null || crowdLevel < LOWEST_CROWD_LEVEL || crowdLevel > HIGHEST_CROWD_LEVEL) {
+            return null;
+        }
+        return crowdLevel;
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/VehicleObservation.java
+++ b/backend/src/main/java/com/gustler/backend/collector/VehicleObservation.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 public record VehicleObservation(
     String vehicleId,
     String plateNumber,
-    Integer stopOrder,
+    Integer stopSequence,
     String stopId,
     Integer runningState,
     RemainingSeats remainingSeats,
@@ -18,13 +18,14 @@ public record VehicleObservation(
 
     private static final int LOWEST_CROWD_LEVEL = 1;
     private static final int HIGHEST_CROWD_LEVEL = 4;
+    private static final int ARRIVED_AT_STOP = 1;
 
     public VehicleObservation {
         Objects.requireNonNull(remainingSeats, "잔여석은 아는 것이든 모르는 것이든 있어야 한다");
     }
 
     public static VehicleObservation from(
-        final BusLocation bus
+        BusLocation bus
     ) {
         return new VehicleObservation(
             bus.vehicleId(),
@@ -39,8 +40,19 @@ public record VehicleObservation(
             bus.taglessCode());
     }
 
+    /** 이 버스가 지나온 정류소의 순번. 도착 중이면 그 정류소는 아직 안 지났다. */
+    public Integer passedStopOrder() {
+        if (stopSequence == null || runningState == null) {
+            return null;
+        }
+        if (runningState == ARRIVED_AT_STOP) {
+            return stopSequence - 1;
+        }
+        return stopSequence;
+    }
+
     private static Integer crowdLevelOf(
-        final Integer crowdLevel
+        Integer crowdLevel
     ) {
         if (crowdLevel == null || crowdLevel < LOWEST_CROWD_LEVEL || crowdLevel > HIGHEST_CROWD_LEVEL) {
             return null;

--- a/backend/src/main/resources/db/migration/V1__collector.sql
+++ b/backend/src/main/resources/db/migration/V1__collector.sql
@@ -1,33 +1,24 @@
--- 수집기가 쓰는 여섯 표.
 -- 제약은 키(PK · UNIQUE · FK)와 배타 범위까지만 건다.
 -- 값의 범위 규칙(CHECK)은 그 규칙을 실제로 쓰는 티켓에서 조인다. SAL-82 · SAL-85 · SAL-88.
---
--- 아직 못 정한 것 셋
---   1. observation_batch 라는 이름이 확정이 아니다. fleet_snapshot · collection_attempt 가 후보다.
---   2. route.public_route_id 를 둘지 못 정했다. route 표 위 주석 참고.
---   3. vehicle_observation 이 route_stop 을 보는 복합 FK 가 관측을 버린다. 그 FK 위 주석 참고.
 
 CREATE EXTENSION IF NOT EXISTS btree_gist;
 
 CREATE TABLE daily_call_quota (
     provider        varchar(30) NOT NULL, -- GBIS · 경기데이터드림
-    api_service     varchar(60) NOT NULL, -- 한도는 서비스키 단위로 걸린다
+    api_service     varchar(60) NOT NULL, -- 한도는 활용신청한 API 마다 따로 걸린다
     kst_date        date        NOT NULL, -- 한도는 한국 자정에 리셋된다
     reserved_calls  integer     NOT NULL DEFAULT 0,
     daily_limit     integer     NOT NULL, -- 운영계정 기준 10,000
     CONSTRAINT pk_daily_call_quota PRIMARY KEY (provider, api_service, kst_date)
 );
 
--- public_route_id 를 두고 팀 문서 둘이 어긋난다. 지금은 source_route_id 와 같은 값이 들어간다.
---   결정 기록 08-17 : 합성 ID(gg-3330)를 안 만들고 상류 원문을 공개 ID 로 쓴다
---   개발 요청서     : publicRouteId 는 gg-3330 이고 도입 여부가 미결이다.
---                     지금 응답의 route.id 로 나가는 것은 source_route_id 다
+-- public_route_id 는 결정 기록(08-17)과 개발 요청서가 어긋나 있다. 지금은 source_route_id 와 같은 값이다.
 -- 공개 ID 가 확정되면 둘 중 하나를 지운다.
 CREATE TABLE route (
     id               bigint      GENERATED ALWAYS AS IDENTITY,
     public_route_id  varchar(30) NOT NULL, -- Open API 원문 routeId. 9자리
     source_id        varchar(40) NOT NULL,
-    source_route_id  varchar(30) NOT NULL, -- 상류 호출 · API 경로 파라미터 · 응답 route.id
+    source_route_id  varchar(30) NOT NULL,
     display_name     varchar(40) NOT NULL, -- 표시명 3330. 모델 노선 키와 글자가 같아도 다른 개념이다
     start_stop_name  varchar(60) NOT NULL,
     end_stop_name    varchar(60) NOT NULL,
@@ -35,12 +26,8 @@ CREATE TABLE route (
     CONSTRAINT ux_route_public_route_id UNIQUE (public_route_id)
 );
 
--- 응답의 route.referenceVersionId("3330-v5")는 이 표의 id 를 그대로 내보낸다.
--- 별도 열을 두지 않는 이유.
---   판본이 새로 생기면 새 행이라 id 가 바뀌고, 그것이 곧 클라이언트의
---   "개편 중이니 화면을 다시 받아라" 신호다. 계약은 String 이라는 것 외에 형식을 정하지 않았고,
---   상류 GBIS 도 판본 개념을 주지 않는다(노선정보 응답 43개 항목 어디에도 없다).
---   시간표(첫차·막차 4열)만 바뀌면 판본을 새로 안 끊고 같은 행을 UPDATE 하므로 id 도 안 움직인다.
+-- 응답의 route.referenceVersionId 는 이 표의 id 를 그대로 내보낸다.
+-- 판본이 새로 생기면 id 가 바뀌고, 그것이 클라이언트에게 "화면을 다시 받아라" 신호다.
 CREATE TABLE route_version (
     id                         bigint      GENERATED ALWAYS AS IDENTITY,
     route_id                   bigint      NOT NULL,
@@ -48,12 +35,9 @@ CREATE TABLE route_version (
     up_first_departure_time    varchar(5),           -- KST HH:MM
     up_last_departure_time     varchar(5),
     down_first_departure_time  varchar(5),
-    down_last_departure_time   varchar(5),           -- 1650 은 상행 22:35 · 하행 23:55
-    -- 상류가 개편을 알려주지 않아 정류소 목록을 해시해 바뀐 것을 알아낸다.
-    -- UNIQUE 를 걸지 않는다. 공사로 A 에서 B 로 갔다가 다시 A 로 돌아오면 해시가 되풀이되는데,
-    -- 그때도 새 판본을 끊어야 한다. 기간이 다르고, 관측이 판본에 매달리고,
-    -- 무엇보다 id 가 그대로면 클라이언트가 개편을 못 알아챈다.
-    -- "직전과 같으면 새로 안 만든다"는 가장 최근 판본과만 비교하는 규칙이라 적재 로직에서 본다.
+    down_last_departure_time   varchar(5),
+    -- 상류가 개편을 안 알려줘서 정류소 목록을 해시해 감지한다.
+    -- UNIQUE 를 안 건다. 공사로 A 에서 B 로 갔다가 A 로 돌아오면 해시가 되풀이되는데 그때도 새 판본이다.
     content_digest             char(64)    NOT NULL,
     valid_from                 timestamptz NOT NULL,
     valid_to                   timestamptz,          -- NULL = 지금 쓰는 판본
@@ -69,10 +53,10 @@ CREATE TABLE route_version (
 CREATE TABLE route_stop (
     route_version_id  bigint      NOT NULL,
     stop_order        integer     NOT NULL, -- stationSeq. 회차로 같은 정류소가 두 번 나와 이것이 정체성이다
-    stop_id           varchar(20) NOT NULL, -- stationId. UNIQUE 를 안 건다. 같은 정류소를 두 번 지나면 적재가 막힌다
+    stop_id           varchar(20) NOT NULL, -- stationId. 같은 정류소를 두 번 지나므로 UNIQUE 를 안 건다
     name              varchar(60) NOT NULL,
     direction         varchar(4)  NOT NULL, -- UP · DOWN
-    boarding_allowed  boolean     NOT NULL, -- NOT stop_id LIKE '277%'. 1650 24곳 · 3330 7곳이 불가
+    boarding_allowed  boolean     NOT NULL, -- NOT stop_id LIKE '277%'
     CONSTRAINT pk_route_stop PRIMARY KEY (route_version_id, stop_order),
     CONSTRAINT fk_route_stop_version FOREIGN KEY (route_version_id)
         REFERENCES route_version (id),
@@ -86,14 +70,14 @@ CREATE TABLE observation_batch (
     attempt_number         integer      NOT NULL,
     attempt_key            varchar(160) NOT NULL, -- 재시도해도 값이 같아 묶음이 두 개 안 생긴다
     requested_at           timestamptz  NOT NULL,
-    response_received_at   timestamptz,           -- 응답 observedAt 의 권위. queryTime 이 아니다
+    response_received_at   timestamptz,           -- 관측 시각의 권위. queryTime 이 아니다
     forecast_completed_at  timestamptz,           -- 차가 0대라 예보 행이 없어도 찍는다
     completed_at           timestamptz,
     http_status            integer,
     result_code            integer,               -- Open API resultCode 원문
     outcome                varchar(32)  NOT NULL,
     failure_code           varchar(32),
-    provider_rows          integer,               -- 실측 17
+    provider_rows          integer,
     stored_rows            integer,               -- 응답 vehiclesInService
     excluded_rows          integer,
     CONSTRAINT pk_observation_batch PRIMARY KEY (id),
@@ -103,14 +87,7 @@ CREATE TABLE observation_batch (
     CONSTRAINT ux_batch_context UNIQUE (id, route_version_id)
 );
 
--- 확정된 /board 조회가 요청마다 도는 질의다.
--- "그 판본의, 예보까지 끝난, 가장 최근 묶음" 하나를 고른다.
--- 이 표는 수집 한 번에 한 행씩 늘어 하루 8,556 행, 한 해 310만 행이 된다.
--- 부분 조건은 조회의 WHERE 와 글자 그대로 같아야 계획기가 이 인덱스를 고른다.
---
--- 다른 조회 경로에는 인덱스를 붙이지 않았다. 읽는 코드가 아직 없어 어떤 질의가 될지 모른다.
--- 직전 도착 차량(SAL-95), 여정 잇기(SAL-94), 채점 회수(SAL-97) 를 구현할 때
--- 그쪽에서 자기 질의를 보고 붙이거나 고치면 된다. 그 시점에 한 번 모여 같이 보면 좋겠다.
+-- /board 가 요청마다 도는 질의. 부분 조건이 조회의 WHERE 와 글자 그대로 같아야 계획기가 이걸 고른다.
 CREATE INDEX ix_batch_forecast_ready
     ON observation_batch (route_version_id, response_received_at DESC)
     WHERE outcome IN ('SUCCESS_ROWS', 'SUCCESS_EMPTY') AND forecast_completed_at IS NOT NULL;
@@ -120,28 +97,22 @@ CREATE TABLE vehicle_observation (
     observation_batch_id  bigint       NOT NULL,
     route_version_id      bigint       NOT NULL, -- 순번의 뜻을 정하는 판본
     source_row_number     integer      NOT NULL,
-    observed_at           timestamptz  NOT NULL, -- queryTime. 같은 묶음은 밀리초까지 같다
-    vehicle_id            varchar(40),           -- vehId. 해시하지 않는다. 차량별 정원 조회에 원문이 필요하다
+    observed_at           timestamptz  NOT NULL, -- observation_batch.response_received_at 과 같은 값
+    vehicle_id            varchar(40),           -- vehId. 차량별 정원 조회에 원문이 필요해 해시하지 않는다
     vehicle_trip_key      varchar(120),          -- 회차해 돌아온 차와 아직 안 온 차를 가른다
     plate_number          varchar(20),           -- plateNo
-    stop_order            integer      NOT NULL, -- 통과 순번. stationSeq 원문이 아니다
-    stop_id               varchar(20)  NOT NULL, -- stationId
+    stop_order            integer      NOT NULL, -- stationSeq 원문. 통과 순번은 running_state 로 계산한다
+    stop_id               varchar(20)  NOT NULL, -- stationId. stop_order 와 같은 정류소여야 한다
     running_state         integer,               -- stateCd. 실측 0 · 1 · 2
-    remaining_seats       integer,               -- remainSeatCnt. 실측에 -1(미제공) 섞임
-    crowd_level           integer,               -- crowded. 실측 0 · 1. 0 이 나온다
+    remaining_seats       integer,               -- remainSeatCnt
+    crowd_level           integer,               -- crowded. 0 은 미제공이라 저장 전에 접는다
     vehicle_type          integer,               -- lowPlate. 정원이 여기서 유도된다(2층 68 · 저상 40 · 그 밖 45)
-    route_type            integer,               -- routeTypeCd. 실측 전건 11
-    tagless               integer,               -- taglessCd. 실측 0 · 1
+    route_type            integer,               -- routeTypeCd
+    tagless               integer,               -- taglessCd
     CONSTRAINT pk_vehicle_observation PRIMARY KEY (id),
     CONSTRAINT fk_observation_batch FOREIGN KEY (observation_batch_id, route_version_id)
         REFERENCES observation_batch (id, route_version_id),
-    -- 이 FK 가 관측을 버린다. 드문 일이 아니다. 개발 요청서 B19 :
-    --   통과 순번은 stateCd=1(도착)이면 stationSeq-1 이라, stationSeq=1 이고 stateCd=1 이면 0 이 나온다.
-    --   route_stop.stop_order 는 1 부터라 그 행은 적재가 실패한다. 첫 정류소에 도착하는 버스마다 걸린다.
-    --   노선 개편으로 순번이 밀린 동안에도 같은 일이 난다.
-    -- FK 를 빼는 것으로는 안 풀린다. seat_forecast 의 FK 는 (판본, 순번)만 보고 stop_id 는 안 봐서,
-    --   빼면 어긋난 관측이 저장되고 틀린 정류소에 예보가 붙는다.
-    -- SAL-82(정규화) · SAL-84(관측 저장)가 같이 정한다. SAL-83 범위 밖이다.
+    -- 노선 개편으로 상류 순번과 우리 정류소 목록이 어긋나는 동안 관측이 버려진다. SAL-84 · SAL-88 몫.
     CONSTRAINT fk_observation_route_stop FOREIGN KEY (route_version_id, stop_order, stop_id)
         REFERENCES route_stop (route_version_id, stop_order, stop_id),
     CONSTRAINT ux_observation_source_row UNIQUE (observation_batch_id, source_row_number),

--- a/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
@@ -17,8 +17,8 @@ class VehicleObservationTest {
     private static final String PLATE_NUMBER = "경기70아0001";
     private static final String ROUTE_3330 = "204000057";
     private static final String STOP_205000217 = "205000217";
-    private static final int STOP_ORDER_6 = 6;
-    private static final int FIRST_STOP_ORDER = 1;
+    private static final int STOP_SEQUENCE_6 = 6;
+    private static final int FIRST_STOP_SEQUENCE = 1;
     private static final int ROUTE_TYPE_11 = 11;
     private static final int TAGLESS_1 = 1;
 
@@ -34,10 +34,10 @@ class VehicleObservationTest {
     @Test
     void 잔여석이_있는_차량은_그_수를_그대로_쓴다() {
         // given
-        final BusLocation bus = busWithSeats(SEATS_43);
+        BusLocation bus = busWithSeats(SEATS_43);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
         assertThat(actual.remainingSeats()).isEqualTo(new Known(SEATS_43));
@@ -46,10 +46,10 @@ class VehicleObservationTest {
     @Test
     void 잔여석이_0인_차량은_잔여석을_아는_차량이다() {
         // given
-        final BusLocation bus = busWithSeats(0);
+        BusLocation bus = busWithSeats(0);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
         assertThat(actual.remainingSeats()).isEqualTo(new Known(0));
@@ -61,10 +61,10 @@ class VehicleObservationTest {
         final int remainingSeatCount
     ) {
         // given
-        final BusLocation bus = busWithSeats(remainingSeatCount);
+        BusLocation bus = busWithSeats(remainingSeatCount);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
         assertThat(actual.remainingSeats())
@@ -74,10 +74,10 @@ class VehicleObservationTest {
     @Test
     void 잔여석_항목이_없는_차량은_알려주지_않은_것으로_판단한다() {
         // given
-        final BusLocation bus = busWithSeats(null);
+        BusLocation bus = busWithSeats(null);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
         assertThat(actual.remainingSeats())
@@ -104,7 +104,7 @@ class VehicleObservationTest {
         assertThatThrownBy(() -> new VehicleObservation(
             VEHICLE_204000206,
             PLATE_NUMBER,
-            STOP_ORDER_6,
+            STOP_SEQUENCE_6,
             STOP_205000217,
             RUNNING_STATE_DEPARTED,
             null,
@@ -121,10 +121,10 @@ class VehicleObservationTest {
         final int crowdLevel
     ) {
         // given
-        final BusLocation bus = busWithCrowdLevel(crowdLevel);
+        BusLocation bus = busWithCrowdLevel(crowdLevel);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
         assertThat(actual.crowdLevel()).isEqualTo(crowdLevel);
@@ -134,13 +134,13 @@ class VehicleObservationTest {
     @NullSource
     @ValueSource(ints = {0, 5, -1})
     void 혼잡도가_1에서_4가_아니면_모르는_것으로_판단한다(
-        final Integer crowdLevel
+        Integer crowdLevel
     ) {
         // given
-        final BusLocation bus = busWithCrowdLevel(crowdLevel);
+        BusLocation bus = busWithCrowdLevel(crowdLevel);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
         assertThat(actual.crowdLevel()).isNull();
@@ -149,10 +149,10 @@ class VehicleObservationTest {
     @Test
     void 잔여석을_몰라도_혼잡도_3은_그대로_쓴다() {
         // given
-        final BusLocation bus = bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, -1, CROWD_LEVEL_3, NORMAL_BUS);
+        BusLocation bus = bus(STOP_SEQUENCE_6, RUNNING_STATE_DEPARTED, -1, CROWD_LEVEL_3, NORMAL_BUS);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
         assertThat(actual.remainingSeats()).isInstanceOf(Unknown.class);
@@ -162,10 +162,10 @@ class VehicleObservationTest {
     @Test
     void 혼잡도를_몰라도_잔여석_43석은_그대로_쓴다() {
         // given
-        final BusLocation bus = bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, SEATS_43, 0, NORMAL_BUS);
+        BusLocation bus = bus(STOP_SEQUENCE_6, RUNNING_STATE_DEPARTED, SEATS_43, 0, NORMAL_BUS);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
         assertThat(actual.crowdLevel()).isNull();
@@ -175,10 +175,10 @@ class VehicleObservationTest {
     @Test
     void 이층버스의_차량_유형은_2이고_잔여석은_43석_그대로다() {
         // given
-        final BusLocation bus = bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, SEATS_43, CROWD_LEVEL_3, DOUBLE_DECKER_BUS);
+        BusLocation bus = bus(STOP_SEQUENCE_6, RUNNING_STATE_DEPARTED, SEATS_43, CROWD_LEVEL_3, DOUBLE_DECKER_BUS);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
         assertThat(actual.vehicleType()).isEqualTo(DOUBLE_DECKER_BUS);
@@ -188,34 +188,94 @@ class VehicleObservationTest {
     @Test
     void 정류소_순번은_Open_API가_준_순번을_그대로_쓴다() {
         // given
-        final BusLocation bus = busAt(STOP_ORDER_6, RUNNING_STATE_DEPARTED);
+        BusLocation bus = busAt(STOP_SEQUENCE_6, RUNNING_STATE_DEPARTED);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
-        assertThat(actual.stopOrder()).isEqualTo(STOP_ORDER_6);
+        assertThat(actual.stopSequence()).isEqualTo(STOP_SEQUENCE_6);
+    }
+
+    @Test
+    void 정류소에_도착한_버스도_그_정류소_순번을_그대로_쓴다() {
+        // given
+        BusLocation bus = busAt(STOP_SEQUENCE_6, RUNNING_STATE_ARRIVED);
+
+        // when
+        VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.stopSequence()).isEqualTo(STOP_SEQUENCE_6);
     }
 
     @Test
     void 첫_정류소에_도착한_버스의_순번은_1이다() {
         // given
-        final BusLocation bus = busAt(FIRST_STOP_ORDER, RUNNING_STATE_ARRIVED);
+        BusLocation bus = busAt(FIRST_STOP_SEQUENCE, RUNNING_STATE_ARRIVED);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
-        assertThat(actual.stopOrder()).isEqualTo(FIRST_STOP_ORDER);
+        assertThat(actual.stopSequence()).isEqualTo(FIRST_STOP_SEQUENCE);
+    }
+
+    @Test
+    void 정류소를_출발한_버스는_그_정류소까지_지나왔다() {
+        // given
+        BusLocation bus = busAt(STOP_SEQUENCE_6, RUNNING_STATE_DEPARTED);
+
+        // when
+        VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.passedStopOrder()).isEqualTo(STOP_SEQUENCE_6);
+    }
+
+    @Test
+    void 정류소에_도착한_버스는_직전_정류소까지_지나왔다() {
+        // given
+        BusLocation bus = busAt(STOP_SEQUENCE_6, RUNNING_STATE_ARRIVED);
+
+        // when
+        VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.passedStopOrder()).isEqualTo(STOP_SEQUENCE_6 - 1);
+    }
+
+    @Test
+    void 첫_정류소에_도착한_버스는_지나온_정류소가_없다() {
+        // given
+        BusLocation bus = busAt(FIRST_STOP_SEQUENCE, RUNNING_STATE_ARRIVED);
+
+        // when
+        VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.passedStopOrder()).isZero();
+    }
+
+    @Test
+    void 운행_상태를_모르면_지나온_정류소도_모른다() {
+        // given
+        BusLocation bus = bus(STOP_SEQUENCE_6, null, SEATS_43, CROWD_LEVEL_3, NORMAL_BUS);
+
+        // when
+        VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.passedStopOrder()).isNull();
     }
 
     @Test
     void 차량_아이디는_Open_API가_준_값을_문자열_그대로_쓴다() {
         // given
-        final BusLocation bus = busAt(STOP_ORDER_6, RUNNING_STATE_DEPARTED);
+        BusLocation bus = busAt(STOP_SEQUENCE_6, RUNNING_STATE_DEPARTED);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
         assertThat(actual.vehicleId()).isEqualTo(VEHICLE_204000206);
@@ -224,10 +284,10 @@ class VehicleObservationTest {
     @Test
     void 번호판도_관측에_담는다() {
         // given
-        final BusLocation bus = busAt(STOP_ORDER_6, RUNNING_STATE_DEPARTED);
+        BusLocation bus = busAt(STOP_SEQUENCE_6, RUNNING_STATE_DEPARTED);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
         assertThat(actual.plateNumber()).isEqualTo(PLATE_NUMBER);
@@ -236,16 +296,16 @@ class VehicleObservationTest {
     @Test
     void Open_API가_준_차량_한_대를_관측_한_건으로_만든다() {
         // given
-        final BusLocation bus = bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, SEATS_43, CROWD_LEVEL_3, DOUBLE_DECKER_BUS);
+        BusLocation bus = bus(STOP_SEQUENCE_6, RUNNING_STATE_DEPARTED, SEATS_43, CROWD_LEVEL_3, DOUBLE_DECKER_BUS);
 
         // when
-        final VehicleObservation actual = VehicleObservation.from(bus);
+        VehicleObservation actual = VehicleObservation.from(bus);
 
         // then
         assertThat(actual).isEqualTo(new VehicleObservation(
             VEHICLE_204000206,
             PLATE_NUMBER,
-            STOP_ORDER_6,
+            STOP_SEQUENCE_6,
             STOP_205000217,
             RUNNING_STATE_DEPARTED,
             new Known(SEATS_43),
@@ -256,30 +316,30 @@ class VehicleObservationTest {
     }
 
     private static BusLocation busAt(
-        final int stopOrder,
+        final int stopSequence,
         final int runningState
     ) {
-        return bus(stopOrder, runningState, SEATS_43, CROWD_LEVEL_3, NORMAL_BUS);
+        return bus(stopSequence, runningState, SEATS_43, CROWD_LEVEL_3, NORMAL_BUS);
     }
 
     private static BusLocation busWithSeats(
-        final Integer remainingSeatCount
+        Integer remainingSeatCount
     ) {
-        return bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, remainingSeatCount, CROWD_LEVEL_3, NORMAL_BUS);
+        return bus(STOP_SEQUENCE_6, RUNNING_STATE_DEPARTED, remainingSeatCount, CROWD_LEVEL_3, NORMAL_BUS);
     }
 
     private static BusLocation busWithCrowdLevel(
-        final Integer crowdLevel
+        Integer crowdLevel
     ) {
-        return bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, SEATS_43, crowdLevel, NORMAL_BUS);
+        return bus(STOP_SEQUENCE_6, RUNNING_STATE_DEPARTED, SEATS_43, crowdLevel, NORMAL_BUS);
     }
 
     private static BusLocation bus(
-        final Integer stopOrder,
-        final Integer runningState,
-        final Integer remainingSeatCount,
-        final Integer crowdLevel,
-        final Integer vehicleType
+        Integer stopSequence,
+        Integer runningState,
+        Integer remainingSeatCount,
+        Integer crowdLevel,
+        Integer vehicleType
     ) {
         return new BusLocation(
             PLATE_NUMBER,
@@ -288,7 +348,7 @@ class VehicleObservationTest {
             ROUTE_3330,
             ROUTE_TYPE_11,
             STOP_205000217,
-            stopOrder,
+            stopSequence,
             runningState,
             remainingSeatCount,
             crowdLevel,

--- a/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
@@ -18,12 +18,14 @@ class VehicleObservationTest {
     private static final String ROUTE_3330 = "204000057";
     private static final String STOP_205000217 = "205000217";
     private static final int STOP_ORDER_6 = 6;
+    private static final int FIRST_STOP_ORDER = 1;
     private static final int ROUTE_TYPE_11 = 11;
     private static final int TAGLESS_1 = 1;
 
     private static final int NORMAL_BUS = 0;
     private static final int DOUBLE_DECKER_BUS = 2;
 
+    private static final int RUNNING_STATE_ARRIVED = 1;
     private static final int RUNNING_STATE_DEPARTED = 2;
 
     private static final int SEATS_43 = 43;
@@ -181,6 +183,37 @@ class VehicleObservationTest {
         // then
         assertThat(actual.vehicleType()).isEqualTo(DOUBLE_DECKER_BUS);
         assertThat(actual.remainingSeats()).isEqualTo(new Known(SEATS_43));
+    }
+
+    @Test
+    void 정류소_순번은_Open_API가_준_순번을_그대로_쓴다() {
+        // given
+        final BusLocation bus = busAt(STOP_ORDER_6, RUNNING_STATE_DEPARTED);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.stopOrder()).isEqualTo(STOP_ORDER_6);
+    }
+
+    @Test
+    void 첫_정류소에_도착한_버스의_순번은_1이다() {
+        // given
+        final BusLocation bus = busAt(FIRST_STOP_ORDER, RUNNING_STATE_ARRIVED);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.stopOrder()).isEqualTo(FIRST_STOP_ORDER);
+    }
+
+    private static BusLocation busAt(
+        final int stopOrder,
+        final int runningState
+    ) {
+        return bus(stopOrder, runningState, SEATS_43, CROWD_LEVEL_3, NORMAL_BUS);
     }
 
     private static BusLocation busWithSeats(

--- a/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
@@ -1,0 +1,140 @@
+package com.gustler.backend.collector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gustler.backend.collector.RemainingSeats.Known;
+import com.gustler.backend.collector.RemainingSeats.Unknown;
+import com.gustler.backend.collector.dto.BusLocationResponse.BusLocation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class VehicleObservationTest {
+
+    private static final String VEHICLE_204000206 = "204000206";
+    private static final String PLATE_NUMBER = "경기70아0001";
+    private static final String ROUTE_3330 = "204000057";
+    private static final String STOP_205000217 = "205000217";
+    private static final int STOP_ORDER_6 = 6;
+    private static final int ROUTE_TYPE_11 = 11;
+    private static final int TAGLESS_1 = 1;
+
+    private static final int NORMAL_BUS = 0;
+
+    private static final int RUNNING_STATE_DEPARTED = 2;
+
+    private static final int SEATS_43 = 43;
+    private static final int CROWD_LEVEL_3 = 3;
+
+    @Test
+    void 잔여석이_있는_차량은_그_수를_그대로_쓴다() {
+        // given
+        final BusLocation bus = busWithSeats(SEATS_43);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.remainingSeats()).isEqualTo(new Known(SEATS_43));
+    }
+
+    @Test
+    void 잔여석이_0인_차량은_잔여석을_아는_차량이다() {
+        // given
+        final BusLocation bus = busWithSeats(0);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.remainingSeats()).isEqualTo(new Known(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, -2, -99})
+    void 잔여석이_음수인_차량은_모른다고_알려준_것으로_판단한다(
+        final int remainingSeatCount
+    ) {
+        // given
+        final BusLocation bus = busWithSeats(remainingSeatCount);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.remainingSeats())
+            .isEqualTo(new Unknown(SeatUnknownReason.REPORTED_UNKNOWN));
+    }
+
+    @Test
+    void 잔여석_항목이_없는_차량은_알려주지_않은_것으로_판단한다() {
+        // given
+        final BusLocation bus = busWithSeats(null);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.remainingSeats())
+            .isEqualTo(new Unknown(SeatUnknownReason.NOT_REPORTED));
+    }
+
+    @Test
+    void 아는_잔여석은_음수일_수_없다() {
+        // when & then
+        assertThatThrownBy(() -> new Known(-1))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 잔여석을_모르는_경우에도_사유는_반드시_있다() {
+        // when & then
+        assertThatThrownBy(() -> new Unknown(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void 관측에는_잔여석이_아는_것이든_모르는_것이든_들어간다() {
+        // when & then
+        assertThatThrownBy(() -> new VehicleObservation(
+            VEHICLE_204000206,
+            PLATE_NUMBER,
+            STOP_ORDER_6,
+            STOP_205000217,
+            RUNNING_STATE_DEPARTED,
+            null,
+            CROWD_LEVEL_3,
+            NORMAL_BUS,
+            ROUTE_TYPE_11,
+            TAGLESS_1))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    private static BusLocation busWithSeats(
+        final Integer remainingSeatCount
+    ) {
+        return bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, remainingSeatCount, CROWD_LEVEL_3, NORMAL_BUS);
+    }
+
+    private static BusLocation bus(
+        final Integer stopOrder,
+        final Integer runningState,
+        final Integer remainingSeatCount,
+        final Integer crowdLevel,
+        final Integer vehicleType
+    ) {
+        return new BusLocation(
+            PLATE_NUMBER,
+            VEHICLE_204000206,
+            vehicleType,
+            ROUTE_3330,
+            ROUTE_TYPE_11,
+            STOP_205000217,
+            stopOrder,
+            runningState,
+            remainingSeatCount,
+            crowdLevel,
+            TAGLESS_1);
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
@@ -209,6 +209,52 @@ class VehicleObservationTest {
         assertThat(actual.stopOrder()).isEqualTo(FIRST_STOP_ORDER);
     }
 
+    @Test
+    void 차량_아이디는_Open_API가_준_값을_문자열_그대로_쓴다() {
+        // given
+        final BusLocation bus = busAt(STOP_ORDER_6, RUNNING_STATE_DEPARTED);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.vehicleId()).isEqualTo(VEHICLE_204000206);
+    }
+
+    @Test
+    void 번호판도_관측에_담는다() {
+        // given
+        final BusLocation bus = busAt(STOP_ORDER_6, RUNNING_STATE_DEPARTED);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.plateNumber()).isEqualTo(PLATE_NUMBER);
+    }
+
+    @Test
+    void Open_API가_준_차량_한_대를_관측_한_건으로_만든다() {
+        // given
+        final BusLocation bus = bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, SEATS_43, CROWD_LEVEL_3, DOUBLE_DECKER_BUS);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual).isEqualTo(new VehicleObservation(
+            VEHICLE_204000206,
+            PLATE_NUMBER,
+            STOP_ORDER_6,
+            STOP_205000217,
+            RUNNING_STATE_DEPARTED,
+            new Known(SEATS_43),
+            CROWD_LEVEL_3,
+            DOUBLE_DECKER_BUS,
+            ROUTE_TYPE_11,
+            TAGLESS_1));
+    }
+
     private static BusLocation busAt(
         final int stopOrder,
         final int runningState

--- a/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
@@ -8,6 +8,7 @@ import com.gustler.backend.collector.RemainingSeats.Unknown;
 import com.gustler.backend.collector.dto.BusLocationResponse.BusLocation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class VehicleObservationTest {
@@ -21,6 +22,7 @@ class VehicleObservationTest {
     private static final int TAGLESS_1 = 1;
 
     private static final int NORMAL_BUS = 0;
+    private static final int DOUBLE_DECKER_BUS = 2;
 
     private static final int RUNNING_STATE_DEPARTED = 2;
 
@@ -111,10 +113,86 @@ class VehicleObservationTest {
             .isInstanceOf(NullPointerException.class);
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4})
+    void 혼잡도가_1에서_4까지면_그대로_쓴다(
+        final int crowdLevel
+    ) {
+        // given
+        final BusLocation bus = busWithCrowdLevel(crowdLevel);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.crowdLevel()).isEqualTo(crowdLevel);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(ints = {0, 5, -1})
+    void 혼잡도가_1에서_4가_아니면_모르는_것으로_판단한다(
+        final Integer crowdLevel
+    ) {
+        // given
+        final BusLocation bus = busWithCrowdLevel(crowdLevel);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.crowdLevel()).isNull();
+    }
+
+    @Test
+    void 잔여석을_몰라도_혼잡도_3은_그대로_쓴다() {
+        // given
+        final BusLocation bus = bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, -1, CROWD_LEVEL_3, NORMAL_BUS);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.remainingSeats()).isInstanceOf(Unknown.class);
+        assertThat(actual.crowdLevel()).isEqualTo(CROWD_LEVEL_3);
+    }
+
+    @Test
+    void 혼잡도를_몰라도_잔여석_43석은_그대로_쓴다() {
+        // given
+        final BusLocation bus = bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, SEATS_43, 0, NORMAL_BUS);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.crowdLevel()).isNull();
+        assertThat(actual.remainingSeats()).isEqualTo(new Known(SEATS_43));
+    }
+
+    @Test
+    void 이층버스의_차량_유형은_2이고_잔여석은_43석_그대로다() {
+        // given
+        final BusLocation bus = bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, SEATS_43, CROWD_LEVEL_3, DOUBLE_DECKER_BUS);
+
+        // when
+        final VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.vehicleType()).isEqualTo(DOUBLE_DECKER_BUS);
+        assertThat(actual.remainingSeats()).isEqualTo(new Known(SEATS_43));
+    }
+
     private static BusLocation busWithSeats(
         final Integer remainingSeatCount
     ) {
         return bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, remainingSeatCount, CROWD_LEVEL_3, NORMAL_BUS);
+    }
+
+    private static BusLocation busWithCrowdLevel(
+        final Integer crowdLevel
+    ) {
+        return bus(STOP_ORDER_6, RUNNING_STATE_DEPARTED, SEATS_43, crowdLevel, NORMAL_BUS);
     }
 
     private static BusLocation bus(


### PR DESCRIPTION
## 요약

- Open API 응답의 차량 한 대를 관측 값 하나로 정규화합니다. 
- 잔여석은 아는 경우와 모르는 경우를 타입으로 갈랐습니다. 
- DB는 안 건드립니다. 지금은 순수 도메인 객체고 매핑은 SAL-84 에서 할 예정입니다

<br/>

## 변경사항


| 객체                   | 무엇                                           |
| -------------------- | -------------------------------------------- |
| `VehicleObservation` | Open API 차량 한 대의 관측 한 건                      |
| `RemainingSeats`     | 잔여석. 아는 경우(`Known`)와 모르는 경우(`Unknown`)로 갈립니다 |
| `SeatUnknownReason`  | 잔여석을 모르는 이유 두 가지                             |


`SeatUnknownReason` 의 두 값은 티켓과 스키마 주석의 `MINUS_ONE` · `FIELD_ABSENT` 에서 이름을 바꿨습니다.
`-1` 이라는 **모양**만 말하고 뜻을 안 말하기도 하고, `-2` 가 오면 그 이름이 거짓말이 돼서요.

```
REPORTED_UNKNOWN   항목은 왔는데 값이 -1 이다. 이 차는 잔여석을 못 센다는 표시
NOT_REPORTED       remainSeatCnt 항목 자체가 응답에 없다
```

SAL-84 가 만들 컬럼도 `seat_unavailable_reason` 이 아니라 `seat_unknown_reason` 이어야 맞습니다.

<br/>

## 설계 결정

### 잔여석을 모르면 모르는 이유를 남겨야 하고,,잔여석을 알면 사유가 null 이어야 하고,,불편한 상황

```java
public VehicleObservation {
    if ((remainingSeats == null) == (seatUnavailableReason == null)) {   // <<<<<< 이거 읽히나요..?
        throw new IllegalArgumentException(...);
    }
}
```

클래스 수가 늘어나는 리펙토링은 웬만하면 안 하고 싶었는데,   
나중에 규칙을 파악하기가 어려울 것 같아서 이것만 고치고 갑니다..ㅎ

```java
public sealed interface RemainingSeats {
    record Known(int seats) implements RemainingSeats { }
    record Unknown(SeatUnknownReason reason) implements RemainingSeats { }
}
```

위에처럼 if 문에서 검증하지 않고도 잔여석과 사유를 XOR로 관리가 가능합니다.

근데 문제는 `JPA`가 `sealed`를 바로 못 다뤄서 이 부분은 DB 연결하면서 원복/유지 트레이드오프 다뤄보겠습니다

<br/>

### 정류소 순번에서 1을 빼지 않습니다

GBIS 는 버스마다 **정류소 순번**(몇 번째 정류소인가)이랑 **운행 상태**(도착인가 출발인가)를 같이 줍니다.

기존 프로토타입 이관 시 결정했던 사항(요청서 B19)에서는 여기서 **통과 순번**이라는 다른 값을 만들라고 해요.
이미 지나친 정류소가 몇 번째냐는 값이고, 도착이면 1을 뺍니다.

**그런데 빼면 안 됩니다.** `stop_id` 는 원문 그대로 들어가거든요.

```sql
stop_order  integer      NOT NULL, -- 통과 순번. stationSeq 원문이 아니다
stop_id     varchar(20)  NOT NULL, -- stationId          <<<<<< 이건 원문
```

6번 정류소에 도착한 버스를 빼서 넣으면 **두 열이 서로 다른 정류소를 가리킵니다.**

```
stop_order = 5           지나온 정류소
stop_id    = 6번 정류소   원문 그대로
```

FK 가 이 둘을 짝으로 검사하는데 `route_stop` 에 `(5, 6번 아이디)` 라는 짝은 없습니다.
첫 정류소만이 아니라 **도착 관측이 전부 막힙니다.**

실제로 PostgreSQL 18 에 넣어봤습니다.

| 넣은 값 | 결과 |
| --- | --- |
| `(6, 6번 정류소)` | 들어감 |
| `(5, 6번 정류소)` | **막힘** |
| `(0, 6번 정류소)` | 막힘 |

그래서 원문 순번을 그대로 씁니다. 두 열이 같은 정류소를 가리켜서 FK 가 항상 맞아요.
통과 순번은 `running_state` 를 같이 저장하니 읽을 때 계산됩니다.

```
통과 순번 = 운행 상태가 '도착' 이면 (정류소 순번 - 1), 아니면 그대로
```

빼서 저장하려면 `stop_id` 도 이전 정류소로 바꿔야 하는데, 위치정보 API 가 이전 정류소 아이디를 안 줍니다.
`route_stop` 을 조회해야 알 수 있고, 순번 검증은 SAL-88 이후 일이라 이번 티켓에서는 못 합니다.

통과 순번은 `VehicleObservation.passedStopOrder()` 가 계산합니다. 계산이 한 곳에만 있어서 쓰는 쪽이 빠뜨릴 일이 없어요.
`passed_stop_order` 컬럼을 두는 건 SAL-84 에서 하기로 동키랑 얘기했습니다. 거기엔 FK 가 없으니 첫 정류소 도착도 `0` 으로 그냥 들어갑니다.

**한계**: 저장되는 값은 원문이라, 컬럼만 보고 예보 거리를 계산하면 도착 관측에서 한 정류소 어긋납니다.
V1 주석의 `통과 순번. stationSeq 원문이 아니다` 도 원문 기준으로 고쳤습니다.

<br/>

### Open API 문서에 없는 값은 모르는 값으로 파싱

혼잡도가 `5`로 오거나? 잔여석이 `-2`로 오면요?

예외를 던지면 그 시점의 수집이 통째로 날아가기 때문에 1-4로 정규화 하고, 그 외의 값은 '모르는 값'으로 관리하고 있습니다.

<br/>

### 정규화 규칙은 잔여석 타입의 책임으로 설계했습니다

처음엔 `VehicleObservation`이 if문으로 아는 값인지, 모르는 값인지 결정했는데   
`아는 잔여석은 음수일 수 없다`는 이미 `RemainingSeats`에 있기도 하고, 잔여석 자체가 자신의 상태를 결정하면 좋을 것 같아서 아래처럼 설계했습니다.

```java
public sealed interface RemainingSeats {
    static RemainingSeats from(Integer count) { ... }   // <<<<<< 근데 인터페이스에 static이 너무 불편한데,,,?
}
```

"인터페이스가 구현을 알면 안 된다"는 레벨1,2 때 제가 세운 규칙이었는데요. 그래서 처음엔 interface 안에 static으로 구현함수가 있는게 불편했어요.

인터페이스의 큰 장점은 확장성이라고 생각합니다.

인터페이스 틀을 만들어두면 구현체를 만들어서 끼워넣기가 편하잖아요.   
근데 이때 어떤 구현체가 들어올지 모르니까 구현체에 영향이 가는 `default` 메서드 같은 걸 넣는 건 좋은 설계가 아니라고 생각해요.



근데 sealed의 경우는 인터페이스가 구현체를 모르기 때문에 발생하는 문제점들을 잡아주기 위해 생겼어요.  
그리고 실제로 sealed interface 안에 구현체들이 코드로 적히는 구조이기도 하고요.

```java
if (seats instanceof Known k) { ... }
// if 분기가 Unknown 에 대한 처리를 안 해도 에러가 나지 않음
```

`sealed`를 붙이면 구현이 `Known`과 `Unknown` 2개 뿐이라는 걸 컴파일러가 알게 되고, 개발 시점에 알 수 있어요.



결론은 sealed interface는 이미 구현체를 알고 있고, `from()`을 구현한다고 해서 구현체에 영향이 가거나 추가 정보를 알게되는 느낌이 아니라 판단해서 이렇게 설계했습니다.

