### PR TITLE
feat(SAL-88): 노선 판본과 경유 정류소 적재

### DIFF
--- a/backend/src/main/java/com/gustler/backend/collector/BoardingPolicy.java
+++ b/backend/src/main/java/com/gustler/backend/collector/BoardingPolicy.java
@@ -1,0 +1,15 @@
+package com.gustler.backend.collector;
+
+public final class BoardingPolicy {
+
+    private static final String TRANSIT_ONLY_STOP_ID_PREFIX = "277";
+
+    private BoardingPolicy() {
+    }
+
+    public static boolean allowsBoardingAt(
+        String stopId
+    ) {
+        return !stopId.startsWith(TRANSIT_ONLY_STOP_ID_PREFIX);
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/RouteContentDigest.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RouteContentDigest.java
@@ -1,0 +1,59 @@
+package com.gustler.backend.collector;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public record RouteContentDigest(
+    String value
+) {
+
+    private static final String ALGORITHM = "SHA-256";
+    private static final String NO_TURN_SEQUENCE = "단방향";
+
+    public static RouteContentDigest of(
+        RouteStops routeStops
+    ) {
+        MessageDigest digest = newDigest();
+        updateWithLengthPrefixed(digest, turnSequenceOf(routeStops));
+        routeStops.stops().forEach(stop -> updateWithIdentityOf(digest, stop));
+        return new RouteContentDigest(HexFormat.of().formatHex(digest.digest()));
+    }
+
+    private static String turnSequenceOf(
+        RouteStops routeStops
+    ) {
+        if (routeStops.turnSequence() == null) {
+            return NO_TURN_SEQUENCE;
+        }
+        return String.valueOf(routeStops.turnSequence());
+    }
+
+    private static void updateWithIdentityOf(
+        MessageDigest digest,
+        RouteStop stop
+    ) {
+        updateWithLengthPrefixed(digest, String.valueOf(stop.stopOrder()));
+        updateWithLengthPrefixed(digest, stop.stopId());
+        updateWithLengthPrefixed(digest, stop.name());
+    }
+
+    private static void updateWithLengthPrefixed(
+        MessageDigest digest,
+        String value
+    ) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+        digest.update(bytes);
+    }
+
+    private static MessageDigest newDigest() {
+        try {
+            return MessageDigest.getInstance(ALGORITHM);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(ALGORITHM + " 을 쓸 수 없다", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/RouteStop.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RouteStop.java
@@ -1,0 +1,10 @@
+package com.gustler.backend.collector;
+
+public record RouteStop(
+    int stopOrder,
+    String stopId,
+    String name,
+    StopDirection direction,
+    boolean boardingAllowed
+) {
+}

--- a/backend/src/main/java/com/gustler/backend/collector/RouteStops.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RouteStops.java
@@ -9,7 +9,20 @@ public record RouteStops(
 
     public RouteStops {
         stops = List.copyOf(stops);
+        validateStopOrdersDoNotRepeat(stops);
         validateTurnSequenceIsOneOfStops(turnSequence, stops);
+    }
+
+    private static void validateStopOrdersDoNotRepeat(
+        List<RouteStop> stops
+    ) {
+        final long distinctStopOrders = stops.stream()
+            .mapToInt(RouteStop::stopOrder)
+            .distinct()
+            .count();
+        if (distinctStopOrders != stops.size()) {
+            throw new IllegalArgumentException("한 판본에 같은 정류소 순번이 두 번 나온다");
+        }
     }
 
     private static void validateTurnSequenceIsOneOfStops(

--- a/backend/src/main/java/com/gustler/backend/collector/RouteStops.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RouteStops.java
@@ -1,0 +1,48 @@
+package com.gustler.backend.collector;
+
+import java.util.List;
+
+public record RouteStops(
+    Integer turnSequence,
+    List<RouteStop> stops
+) {
+
+    public RouteStops {
+        stops = List.copyOf(stops);
+    }
+
+    public static RouteStops from(
+        Integer turnSequence,
+        List<UpstreamRouteStop> upstreamStops
+    ) {
+        return new RouteStops(
+            turnSequence,
+            upstreamStops.stream()
+                .map(upstreamStop -> toRouteStop(upstreamStop, turnSequence))
+                .toList()
+        );
+    }
+
+    private static RouteStop toRouteStop(
+        UpstreamRouteStop upstreamStop,
+        Integer turnSequence
+    ) {
+        return new RouteStop(
+            upstreamStop.stopOrder(),
+            upstreamStop.stopId(),
+            upstreamStop.name(),
+            directionOf(upstreamStop.stopOrder(), turnSequence),
+            BoardingPolicy.allowsBoardingAt(upstreamStop.stopId())
+        );
+    }
+
+    private static StopDirection directionOf(
+        final int stopOrder,
+        Integer turnSequence
+    ) {
+        if (turnSequence == null || stopOrder <= turnSequence) {
+            return StopDirection.UP;
+        }
+        return StopDirection.DOWN;
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/RouteStops.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RouteStops.java
@@ -9,6 +9,22 @@ public record RouteStops(
 
     public RouteStops {
         stops = List.copyOf(stops);
+        validateTurnSequenceIsOneOfStops(turnSequence, stops);
+    }
+
+    private static void validateTurnSequenceIsOneOfStops(
+        Integer turnSequence,
+        List<RouteStop> stops
+    ) {
+        if (turnSequence == null) {
+            return;
+        }
+        final boolean passesTurnSequence = stops.stream()
+            .anyMatch(stop -> stop.stopOrder() == turnSequence);
+        if (!passesTurnSequence) {
+            throw new IllegalArgumentException(
+                "회차 순번 %d 인 정류소를 경유하지 않는다".formatted(turnSequence));
+        }
     }
 
     public static RouteStops from(

--- a/backend/src/main/java/com/gustler/backend/collector/RouteTimetable.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RouteTimetable.java
@@ -1,0 +1,9 @@
+package com.gustler.backend.collector;
+
+public record RouteTimetable(
+    String upFirstDepartureTime,
+    String upLastDepartureTime,
+    String downFirstDepartureTime,
+    String downLastDepartureTime
+) {
+}

--- a/backend/src/main/java/com/gustler/backend/collector/RouteVersionContent.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RouteVersionContent.java
@@ -1,0 +1,38 @@
+package com.gustler.backend.collector;
+
+public record RouteVersionContent(
+    RouteContentDigest contentDigest,
+    RouteTimetable timetable
+) {
+
+    public static RouteVersionContent of(
+        RouteStops routeStops,
+        RouteTimetable timetable
+    ) {
+        return new RouteVersionContent(RouteContentDigest.of(routeStops), timetable);
+    }
+
+    public RouteVersionDecision decideFor(
+        RouteVersionContent incoming
+    ) {
+        if (!hasSameStopsAs(incoming)) {
+            return RouteVersionDecision.OPEN_NEW_VERSION;
+        }
+        if (!hasSameTimetableAs(incoming)) {
+            return RouteVersionDecision.REVISE_TIMETABLE;
+        }
+        return RouteVersionDecision.KEEP_CURRENT_VERSION;
+    }
+
+    private boolean hasSameStopsAs(
+        RouteVersionContent other
+    ) {
+        return contentDigest.equals(other.contentDigest);
+    }
+
+    private boolean hasSameTimetableAs(
+        RouteVersionContent other
+    ) {
+        return timetable.equals(other.timetable);
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/RouteVersionDecision.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RouteVersionDecision.java
@@ -1,0 +1,9 @@
+package com.gustler.backend.collector;
+
+public enum RouteVersionDecision {
+
+    OPEN_NEW_VERSION,
+    REVISE_TIMETABLE,
+    KEEP_CURRENT_VERSION,
+    ;
+}

--- a/backend/src/main/java/com/gustler/backend/collector/RouteVersionLoader.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RouteVersionLoader.java
@@ -22,23 +22,37 @@ public class RouteVersionLoader {
         RouteTimetable timetable,
         OffsetDateTime readAt
     ) {
+        RouteVersionContent incomingContent = RouteVersionContent.of(routeStops, timetable);
+
         return routeVersionRepository.findLatestOf(routeId)
-            .map(latestVersion -> continueFrom(latestVersion, routeId, routeStops, timetable, readAt))
-            .orElseGet(() -> routeVersionRepository.openNewVersion(routeId, routeStops, timetable, readAt));
+            .map(latestVersion -> continueFrom(latestVersion, routeId, routeStops, incomingContent, readAt))
+            .orElseGet(() -> routeVersionRepository.openNewVersion(routeId, routeStops, incomingContent, readAt));
     }
 
     private long continueFrom(
         StoredRouteVersion latestVersion,
         final long routeId,
         RouteStops routeStops,
-        RouteTimetable timetable,
+        RouteVersionContent incomingContent,
         OffsetDateTime readAt
     ) {
-        return switch (latestVersion.content().decideFor(RouteVersionContent.of(routeStops, timetable))) {
-            case OPEN_NEW_VERSION -> routeVersionRepository.openNewVersion(routeId, routeStops, timetable, readAt);
-            case REVISE_TIMETABLE -> reviseTimetableOf(latestVersion, timetable);
+        return switch (latestVersion.content().decideFor(incomingContent)) {
+            case OPEN_NEW_VERSION -> openNewVersionAfter(latestVersion, routeId, routeStops, incomingContent, readAt);
+            case REVISE_TIMETABLE -> reviseTimetableOf(latestVersion, incomingContent.timetable());
             case KEEP_CURRENT_VERSION -> latestVersion.id();
         };
+    }
+
+    private long openNewVersionAfter(
+        StoredRouteVersion latestVersion,
+        final long routeId,
+        RouteStops routeStops,
+        RouteVersionContent incomingContent,
+        OffsetDateTime readAt
+    ) {
+        latestVersion.requireOpenableAt(readAt);
+        routeVersionRepository.closeAt(latestVersion.id(), readAt);
+        return routeVersionRepository.openNewVersion(routeId, routeStops, incomingContent, readAt);
     }
 
     private long reviseTimetableOf(

--- a/backend/src/main/java/com/gustler/backend/collector/RouteVersionLoader.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RouteVersionLoader.java
@@ -1,0 +1,51 @@
+package com.gustler.backend.collector;
+
+import java.time.OffsetDateTime;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class RouteVersionLoader {
+
+    private final RouteVersionRepository routeVersionRepository;
+
+    public RouteVersionLoader(
+        RouteVersionRepository routeVersionRepository
+    ) {
+        this.routeVersionRepository = routeVersionRepository;
+    }
+
+    @Transactional
+    public long load(
+        final long routeId,
+        RouteStops routeStops,
+        RouteTimetable timetable,
+        OffsetDateTime readAt
+    ) {
+        return routeVersionRepository.findLatestOf(routeId)
+            .map(latestVersion -> continueFrom(latestVersion, routeId, routeStops, timetable, readAt))
+            .orElseGet(() -> routeVersionRepository.openNewVersion(routeId, routeStops, timetable, readAt));
+    }
+
+    private long continueFrom(
+        StoredRouteVersion latestVersion,
+        final long routeId,
+        RouteStops routeStops,
+        RouteTimetable timetable,
+        OffsetDateTime readAt
+    ) {
+        return switch (latestVersion.content().decideFor(RouteVersionContent.of(routeStops, timetable))) {
+            case OPEN_NEW_VERSION -> routeVersionRepository.openNewVersion(routeId, routeStops, timetable, readAt);
+            case REVISE_TIMETABLE -> reviseTimetableOf(latestVersion, timetable);
+            case KEEP_CURRENT_VERSION -> latestVersion.id();
+        };
+    }
+
+    private long reviseTimetableOf(
+        StoredRouteVersion latestVersion,
+        RouteTimetable timetable
+    ) {
+        routeVersionRepository.reviseTimetableOf(latestVersion.id(), timetable);
+        return latestVersion.id();
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/RouteVersionRepository.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RouteVersionRepository.java
@@ -1,0 +1,23 @@
+package com.gustler.backend.collector;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+public interface RouteVersionRepository {
+
+    Optional<StoredRouteVersion> findLatestOf(
+        long routeId
+    );
+
+    long openNewVersion(
+        long routeId,
+        RouteStops routeStops,
+        RouteTimetable timetable,
+        OffsetDateTime openedAt
+    );
+
+    void reviseTimetableOf(
+        long routeVersionId,
+        RouteTimetable timetable
+    );
+}

--- a/backend/src/main/java/com/gustler/backend/collector/RouteVersionRepository.java
+++ b/backend/src/main/java/com/gustler/backend/collector/RouteVersionRepository.java
@@ -9,10 +9,15 @@ public interface RouteVersionRepository {
         long routeId
     );
 
+    void closeAt(
+        long routeVersionId,
+        OffsetDateTime closedAt
+    );
+
     long openNewVersion(
         long routeId,
         RouteStops routeStops,
-        RouteTimetable timetable,
+        RouteVersionContent content,
         OffsetDateTime openedAt
     );
 

--- a/backend/src/main/java/com/gustler/backend/collector/StopDirection.java
+++ b/backend/src/main/java/com/gustler/backend/collector/StopDirection.java
@@ -1,0 +1,8 @@
+package com.gustler.backend.collector;
+
+public enum StopDirection {
+
+    UP,
+    DOWN,
+    ;
+}

--- a/backend/src/main/java/com/gustler/backend/collector/StoredRouteVersion.java
+++ b/backend/src/main/java/com/gustler/backend/collector/StoredRouteVersion.java
@@ -1,0 +1,7 @@
+package com.gustler.backend.collector;
+
+public record StoredRouteVersion(
+    long id,
+    RouteVersionContent content
+) {
+}

--- a/backend/src/main/java/com/gustler/backend/collector/StoredRouteVersion.java
+++ b/backend/src/main/java/com/gustler/backend/collector/StoredRouteVersion.java
@@ -5,12 +5,17 @@ import java.time.OffsetDateTime;
 public record StoredRouteVersion(
     long id,
     OffsetDateTime validFrom,
+    OffsetDateTime validTo,
     RouteVersionContent content
 ) {
 
     public void requireOpenableAt(
         OffsetDateTime readAt
     ) {
+        if (validTo != null) {
+            throw new IllegalStateException(
+                "직전 판본이 %s 에 이미 닫혀 새 판본을 열 수 없다".formatted(validTo));
+        }
         if (!readAt.isAfter(validFrom)) {
             throw new IllegalArgumentException(
                 "직전 판본이 %s 부터라 %s 에 새 판본을 열 수 없다".formatted(validFrom, readAt));

--- a/backend/src/main/java/com/gustler/backend/collector/StoredRouteVersion.java
+++ b/backend/src/main/java/com/gustler/backend/collector/StoredRouteVersion.java
@@ -1,7 +1,19 @@
 package com.gustler.backend.collector;
 
+import java.time.OffsetDateTime;
+
 public record StoredRouteVersion(
     long id,
+    OffsetDateTime validFrom,
     RouteVersionContent content
 ) {
+
+    public void requireOpenableAt(
+        OffsetDateTime readAt
+    ) {
+        if (!readAt.isAfter(validFrom)) {
+            throw new IllegalArgumentException(
+                "직전 판본이 %s 부터라 %s 에 새 판본을 열 수 없다".formatted(validFrom, readAt));
+        }
+    }
 }

--- a/backend/src/main/java/com/gustler/backend/collector/UpstreamRouteStop.java
+++ b/backend/src/main/java/com/gustler/backend/collector/UpstreamRouteStop.java
@@ -1,0 +1,8 @@
+package com.gustler.backend.collector;
+
+public record UpstreamRouteStop(
+    int stopOrder,
+    String stopId,
+    String name
+) {
+}

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/JpaRouteVersionRepository.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/JpaRouteVersionRepository.java
@@ -28,7 +28,8 @@ public class JpaRouteVersionRepository implements RouteVersionRepository {
         final long routeId
     ) {
         return routeVersionEntityRepository.findFirstByRouteIdOrderByValidFromDescIdDesc(routeId)
-            .map(version -> new StoredRouteVersion(version.getId(), version.getValidFrom(), version.content()));
+            .map(version -> new StoredRouteVersion(
+                version.getId(), version.getValidFrom(), version.getValidTo(), version.content()));
     }
 
     @Override

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/JpaRouteVersionRepository.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/JpaRouteVersionRepository.java
@@ -1,0 +1,74 @@
+package com.gustler.backend.collector.persistence.jpa;
+
+import com.gustler.backend.collector.RouteStops;
+import com.gustler.backend.collector.RouteTimetable;
+import com.gustler.backend.collector.RouteVersionContent;
+import com.gustler.backend.collector.RouteVersionRepository;
+import com.gustler.backend.collector.StoredRouteVersion;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JpaRouteVersionRepository implements RouteVersionRepository {
+
+    private final RouteVersionEntityRepository routeVersionEntityRepository;
+    private final RouteStopEntityRepository routeStopEntityRepository;
+
+    public JpaRouteVersionRepository(
+        RouteVersionEntityRepository routeVersionEntityRepository,
+        RouteStopEntityRepository routeStopEntityRepository
+    ) {
+        this.routeVersionEntityRepository = routeVersionEntityRepository;
+        this.routeStopEntityRepository = routeStopEntityRepository;
+    }
+
+    @Override
+    public Optional<StoredRouteVersion> findLatestOf(
+        final long routeId
+    ) {
+        return routeVersionEntityRepository.findFirstByRouteIdOrderByValidFromDescIdDesc(routeId)
+            .map(version -> new StoredRouteVersion(version.getId(), version.content()));
+    }
+
+    @Override
+    public long openNewVersion(
+        final long routeId,
+        RouteStops routeStops,
+        RouteTimetable timetable,
+        OffsetDateTime openedAt
+    ) {
+        closePreviousBeforeOpeningNew(routeId, openedAt);
+
+        RouteVersionJpaEntity newVersion = routeVersionEntityRepository.save(new RouteVersionJpaEntity(
+            routeId,
+            routeStops.turnSequence(),
+            RouteVersionContent.of(routeStops, timetable),
+            openedAt));
+        routeStopEntityRepository.saveAll(routeStops.stops().stream()
+            .map(stop -> new RouteStopJpaEntity(newVersion.getId(), stop))
+            .toList());
+        return newVersion.getId();
+    }
+
+    @Override
+    public void reviseTimetableOf(
+        final long routeVersionId,
+        RouteTimetable timetable
+    ) {
+        routeVersionEntityRepository.findById(routeVersionId)
+            .orElseThrow()
+            .revise(timetable);
+    }
+
+    private void closePreviousBeforeOpeningNew(
+        final long routeId,
+        OffsetDateTime openedAt
+    ) {
+        routeVersionEntityRepository.findFirstByRouteIdOrderByValidFromDescIdDesc(routeId)
+            .ifPresent(previousVersion -> {
+                previousVersion.closeAt(openedAt);
+                routeVersionEntityRepository.flush();
+            });
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/JpaRouteVersionRepository.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/JpaRouteVersionRepository.java
@@ -28,23 +28,27 @@ public class JpaRouteVersionRepository implements RouteVersionRepository {
         final long routeId
     ) {
         return routeVersionEntityRepository.findFirstByRouteIdOrderByValidFromDescIdDesc(routeId)
-            .map(version -> new StoredRouteVersion(version.getId(), version.content()));
+            .map(version -> new StoredRouteVersion(version.getId(), version.getValidFrom(), version.content()));
+    }
+
+    @Override
+    public void closeAt(
+        final long routeVersionId,
+        OffsetDateTime closedAt
+    ) {
+        findVersionOrThrow(routeVersionId).closeAt(closedAt);
+        routeVersionEntityRepository.flush();
     }
 
     @Override
     public long openNewVersion(
         final long routeId,
         RouteStops routeStops,
-        RouteTimetable timetable,
+        RouteVersionContent content,
         OffsetDateTime openedAt
     ) {
-        closePreviousBeforeOpeningNew(routeId, openedAt);
-
-        RouteVersionJpaEntity newVersion = routeVersionEntityRepository.save(new RouteVersionJpaEntity(
-            routeId,
-            routeStops.turnSequence(),
-            RouteVersionContent.of(routeStops, timetable),
-            openedAt));
+        RouteVersionJpaEntity newVersion = routeVersionEntityRepository.save(
+            new RouteVersionJpaEntity(routeId, routeStops.turnSequence(), content, openedAt));
         routeStopEntityRepository.saveAll(routeStops.stops().stream()
             .map(stop -> new RouteStopJpaEntity(newVersion.getId(), stop))
             .toList());
@@ -56,19 +60,13 @@ public class JpaRouteVersionRepository implements RouteVersionRepository {
         final long routeVersionId,
         RouteTimetable timetable
     ) {
-        routeVersionEntityRepository.findById(routeVersionId)
-            .orElseThrow()
-            .revise(timetable);
+        findVersionOrThrow(routeVersionId).revise(timetable);
     }
 
-    private void closePreviousBeforeOpeningNew(
-        final long routeId,
-        OffsetDateTime openedAt
+    private RouteVersionJpaEntity findVersionOrThrow(
+        final long routeVersionId
     ) {
-        routeVersionEntityRepository.findFirstByRouteIdOrderByValidFromDescIdDesc(routeId)
-            .ifPresent(previousVersion -> {
-                previousVersion.closeAt(openedAt);
-                routeVersionEntityRepository.flush();
-            });
+        return routeVersionEntityRepository.findById(routeVersionId)
+            .orElseThrow(() -> new IllegalStateException("판본 %d 가 없다".formatted(routeVersionId)));
     }
 }

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteStopEntityRepository.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteStopEntityRepository.java
@@ -1,0 +1,6 @@
+package com.gustler.backend.collector.persistence.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RouteStopEntityRepository extends JpaRepository<RouteStopJpaEntity, RouteStopJpaId> {
+}

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteStopJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteStopJpaEntity.java
@@ -1,0 +1,40 @@
+package com.gustler.backend.collector.persistence.jpa;
+
+import com.gustler.backend.collector.RouteStop;
+import com.gustler.backend.collector.StopDirection;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "CollectorRouteStop")
+@Table(name = "route_stop")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RouteStopJpaEntity {
+
+    @EmbeddedId
+    private RouteStopJpaId id;
+
+    private String stopId;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private StopDirection direction;
+
+    private boolean boardingAllowed;
+
+    public RouteStopJpaEntity(
+        final long routeVersionId,
+        RouteStop stop
+    ) {
+        this.id = new RouteStopJpaId(routeVersionId, stop.stopOrder());
+        this.stopId = stop.stopId();
+        this.name = stop.name();
+        this.direction = stop.direction();
+        this.boardingAllowed = stop.boardingAllowed();
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteStopJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteStopJpaEntity.java
@@ -9,11 +9,12 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Persistable;
 
 @Entity(name = "CollectorRouteStop")
 @Table(name = "route_stop")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RouteStopJpaEntity {
+public class RouteStopJpaEntity implements Persistable<RouteStopJpaId> {
 
     @EmbeddedId
     private RouteStopJpaId id;
@@ -36,5 +37,15 @@ public class RouteStopJpaEntity {
         this.name = stop.name();
         this.direction = stop.direction();
         this.boardingAllowed = stop.boardingAllowed();
+    }
+
+    @Override
+    public RouteStopJpaId getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isNew() {
+        return true;
     }
 }

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteStopJpaId.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteStopJpaId.java
@@ -1,0 +1,11 @@
+package com.gustler.backend.collector.persistence.jpa;
+
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+
+@Embeddable
+public record RouteStopJpaId(
+    Long routeVersionId,
+    Integer stopOrder
+) implements Serializable {
+}

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteVersionEntityRepository.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteVersionEntityRepository.java
@@ -1,0 +1,11 @@
+package com.gustler.backend.collector.persistence.jpa;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RouteVersionEntityRepository extends JpaRepository<RouteVersionJpaEntity, Long> {
+
+    Optional<RouteVersionJpaEntity> findFirstByRouteIdOrderByValidFromDescIdDesc(
+        long routeId
+    );
+}

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteVersionJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteVersionJpaEntity.java
@@ -60,6 +60,9 @@ public class RouteVersionJpaEntity {
     public void closeAt(
         OffsetDateTime closedAt
     ) {
+        if (validTo != null) {
+            throw new IllegalStateException("판본 %d 는 %s 에 이미 닫혔다".formatted(id, validTo));
+        }
         this.validTo = closedAt;
     }
 

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteVersionJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteVersionJpaEntity.java
@@ -1,0 +1,93 @@
+package com.gustler.backend.collector.persistence.jpa;
+
+import com.gustler.backend.collector.RouteContentDigest;
+import com.gustler.backend.collector.RouteTimetable;
+import com.gustler.backend.collector.RouteVersionContent;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity(name = "CollectorRouteVersion")
+@Table(name = "route_version")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RouteVersionJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long routeId;
+
+    private Integer turnSequence;
+
+    private String upFirstDepartureTime;
+
+    private String upLastDepartureTime;
+
+    private String downFirstDepartureTime;
+
+    private String downLastDepartureTime;
+
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private String contentDigest;
+
+    private OffsetDateTime validFrom;
+
+    private OffsetDateTime validTo;
+
+    public RouteVersionJpaEntity(
+        final long routeId,
+        Integer turnSequence,
+        RouteVersionContent content,
+        OffsetDateTime validFrom
+    ) {
+        this.routeId = routeId;
+        this.turnSequence = turnSequence;
+        this.contentDigest = content.contentDigest().value();
+        this.validFrom = validFrom;
+        applyTimetable(content.timetable());
+    }
+
+    public void closeAt(
+        OffsetDateTime closedAt
+    ) {
+        this.validTo = closedAt;
+    }
+
+    public void revise(
+        RouteTimetable timetable
+    ) {
+        applyTimetable(timetable);
+    }
+
+    public RouteVersionContent content() {
+        return new RouteVersionContent(new RouteContentDigest(contentDigest), timetable());
+    }
+
+    private RouteTimetable timetable() {
+        return new RouteTimetable(
+            upFirstDepartureTime,
+            upLastDepartureTime,
+            downFirstDepartureTime,
+            downLastDepartureTime
+        );
+    }
+
+    private void applyTimetable(
+        RouteTimetable timetable
+    ) {
+        this.upFirstDepartureTime = timetable.upFirstDepartureTime();
+        this.upLastDepartureTime = timetable.upLastDepartureTime();
+        this.downFirstDepartureTime = timetable.downFirstDepartureTime();
+        this.downLastDepartureTime = timetable.downLastDepartureTime();
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/collector/BoardingPolicyTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/BoardingPolicyTest.java
@@ -1,0 +1,29 @@
+package com.gustler.backend.collector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class BoardingPolicyTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        // 277 두 곳은 3330 실측 위치정보 응답(location-live-snapshot.json)에서 뜬 경유 지점이다.
+        "277103149, false",
+        "277103157, false",
+        "205000217, true",  // 범계역
+        "206000055, true",
+        "208000069, true",  // 안양역. 1650 과 3330 의 회차 정류소다
+    })
+    void 정류소_ID가_277로_시작하지_않는_곳에서만_승차할_수_있다(
+        String stopId,
+        final boolean expected
+    ) {
+        // when
+        final boolean actual = BoardingPolicy.allowsBoardingAt(stopId);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/collector/RouteContentDigestTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/RouteContentDigestTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class RouteContentDigestTest {
 
-    private static final int TURN_SEQUENCE_3330 = 43;
+    private static final int TURN_SEQUENCE = 2;
     private static final String STOP_205000217 = "205000217";
     private static final String STOP_208000069 = "208000069";
     private static final String STOP_NAME_범계역 = "범계역";
@@ -26,7 +26,7 @@ class RouteContentDigestTest {
     @Test
     void 정류소_하나의_순번이_바뀌면_다른_해시가_나온다() {
         // given
-        RouteStops moved = RouteStops.from(TURN_SEQUENCE_3330, List.of(
+        RouteStops moved = RouteStops.from(TURN_SEQUENCE, List.of(
             new UpstreamRouteStop(1, STOP_205000217, STOP_NAME_범계역),
             new UpstreamRouteStop(2, STOP_208000069, STOP_NAME_안양역),
             new UpstreamRouteStop(4, STOP_205000217, STOP_NAME_범계역)
@@ -42,7 +42,7 @@ class RouteContentDigestTest {
     @Test
     void 정류소_이름이_바뀌면_다른_해시가_나온다() {
         // given
-        RouteStops renamed = RouteStops.from(TURN_SEQUENCE_3330, List.of(
+        RouteStops renamed = RouteStops.from(TURN_SEQUENCE, List.of(
             new UpstreamRouteStop(1, STOP_205000217, STOP_NAME_범계역),
             new UpstreamRouteStop(2, STOP_208000069, "안양역(경유)"),
             new UpstreamRouteStop(3, STOP_205000217, STOP_NAME_범계역)
@@ -83,9 +83,9 @@ class RouteContentDigestTest {
     @Test
     void 정류소_이름에_구분자가_섞여도_정류소가_하나인_노선과_둘인_노선은_해시가_다르다() {
         // given
-        RouteStops oneStopWithSeparatorInName = RouteStops.from(TURN_SEQUENCE_3330, List.of(
+        RouteStops oneStopWithSeparatorInName = RouteStops.from(1, List.of(
             new UpstreamRouteStop(1, STOP_205000217, "범계역\n2|208000069|안양역")));
-        RouteStops twoStops = RouteStops.from(TURN_SEQUENCE_3330, List.of(
+        RouteStops twoStops = RouteStops.from(1, List.of(
             new UpstreamRouteStop(1, STOP_205000217, STOP_NAME_범계역),
             new UpstreamRouteStop(2, STOP_208000069, STOP_NAME_안양역)));
 
@@ -97,7 +97,7 @@ class RouteContentDigestTest {
     }
 
     private RouteStops threeStops() {
-        return RouteStops.from(TURN_SEQUENCE_3330, List.of(
+        return RouteStops.from(TURN_SEQUENCE, List.of(
             new UpstreamRouteStop(1, STOP_205000217, STOP_NAME_범계역),
             new UpstreamRouteStop(2, STOP_208000069, STOP_NAME_안양역),
             new UpstreamRouteStop(3, STOP_205000217, STOP_NAME_범계역)

--- a/backend/src/test/java/com/gustler/backend/collector/RouteContentDigestTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/RouteContentDigestTest.java
@@ -1,0 +1,106 @@
+package com.gustler.backend.collector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RouteContentDigestTest {
+
+    private static final int TURN_SEQUENCE_3330 = 43;
+    private static final String STOP_205000217 = "205000217";
+    private static final String STOP_208000069 = "208000069";
+    private static final String STOP_NAME_범계역 = "범계역";
+    private static final String STOP_NAME_안양역 = "안양역";
+    private static final String HEXADECIMAL_64 = "^[0-9a-f]{64}$";
+
+    @Test
+    void 정류소_목록이_같으면_같은_해시가_나온다() {
+        // when
+        RouteContentDigest actual = RouteContentDigest.of(threeStops());
+
+        // then
+        assertThat(actual).isEqualTo(RouteContentDigest.of(threeStops()));
+    }
+
+    @Test
+    void 정류소_하나의_순번이_바뀌면_다른_해시가_나온다() {
+        // given
+        RouteStops moved = RouteStops.from(TURN_SEQUENCE_3330, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, STOP_NAME_범계역),
+            new UpstreamRouteStop(2, STOP_208000069, STOP_NAME_안양역),
+            new UpstreamRouteStop(4, STOP_205000217, STOP_NAME_범계역)
+        ));
+
+        // when
+        RouteContentDigest actual = RouteContentDigest.of(moved);
+
+        // then
+        assertThat(actual).isNotEqualTo(RouteContentDigest.of(threeStops()));
+    }
+
+    @Test
+    void 정류소_이름이_바뀌면_다른_해시가_나온다() {
+        // given
+        RouteStops renamed = RouteStops.from(TURN_SEQUENCE_3330, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, STOP_NAME_범계역),
+            new UpstreamRouteStop(2, STOP_208000069, "안양역(경유)"),
+            new UpstreamRouteStop(3, STOP_205000217, STOP_NAME_범계역)
+        ));
+
+        // when
+        RouteContentDigest actual = RouteContentDigest.of(renamed);
+
+        // then
+        assertThat(actual).isNotEqualTo(RouteContentDigest.of(threeStops()));
+    }
+
+    @Test
+    void 회차_순번이_바뀌면_다른_해시가_나온다() {
+        // given
+        RouteStops turnedElsewhere = RouteStops.from(1, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, STOP_NAME_범계역),
+            new UpstreamRouteStop(2, STOP_208000069, STOP_NAME_안양역),
+            new UpstreamRouteStop(3, STOP_205000217, STOP_NAME_범계역)
+        ));
+
+        // when
+        RouteContentDigest actual = RouteContentDigest.of(turnedElsewhere);
+
+        // then
+        assertThat(actual).isNotEqualTo(RouteContentDigest.of(threeStops()));
+    }
+
+    @Test
+    void 판본_해시는_16진수_64글자다() {
+        // when
+        RouteContentDigest actual = RouteContentDigest.of(threeStops());
+
+        // then
+        assertThat(actual.value()).matches(HEXADECIMAL_64);
+    }
+
+    @Test
+    void 정류소_이름에_구분자가_섞여도_정류소가_하나인_노선과_둘인_노선은_해시가_다르다() {
+        // given
+        RouteStops oneStopWithSeparatorInName = RouteStops.from(TURN_SEQUENCE_3330, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, "범계역\n2|208000069|안양역")));
+        RouteStops twoStops = RouteStops.from(TURN_SEQUENCE_3330, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, STOP_NAME_범계역),
+            new UpstreamRouteStop(2, STOP_208000069, STOP_NAME_안양역)));
+
+        // when
+        RouteContentDigest actual = RouteContentDigest.of(oneStopWithSeparatorInName);
+
+        // then
+        assertThat(actual).isNotEqualTo(RouteContentDigest.of(twoStops));
+    }
+
+    private RouteStops threeStops() {
+        return RouteStops.from(TURN_SEQUENCE_3330, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, STOP_NAME_범계역),
+            new UpstreamRouteStop(2, STOP_208000069, STOP_NAME_안양역),
+            new UpstreamRouteStop(3, STOP_205000217, STOP_NAME_범계역)
+        ));
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/collector/RouteStopsTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/RouteStopsTest.java
@@ -96,6 +96,17 @@ class RouteStopsTest {
         assertThat(actual).containsExactly(true, false, true);
     }
 
+    @Test
+    void 한_판본에_같은_정류소_순번은_한_번만_나온다() {
+        // when
+        Throwable actual = catchThrowable(() -> RouteStops.from(1, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, ANY_STOP_NAME),
+            new UpstreamRouteStop(1, STOP_208000069, ANY_STOP_NAME))));
+
+        // then
+        assertThat(actual).isInstanceOf(IllegalArgumentException.class);
+    }
+
     @ParameterizedTest
     @ValueSource(ints = {0, 999})
     void 회차_순번은_경유하는_정류소_중_하나의_순번이다(

--- a/backend/src/test/java/com/gustler/backend/collector/RouteStopsTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/RouteStopsTest.java
@@ -1,0 +1,112 @@
+package com.gustler.backend.collector;
+
+import static com.gustler.backend.collector.StopDirection.DOWN;
+import static com.gustler.backend.collector.StopDirection.UP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class RouteStopsTest {
+
+    private static final int TURN_SEQUENCE_3330 = 43;
+    private static final int STOP_COUNT_3330 = 85;
+    private static final String STOP_208000069 = "208000069"; // 안양역. 3330 회차 정류소
+    private static final String STOP_277103149 = "277103149"; // 경유 지점
+    private static final String STOP_205000217 = "205000217"; // 범계역
+    private static final String ANY_STOP_NAME = "안양역";
+
+    @Test
+    void 회차_순번이_43이면_43번_정류소가_상행이고_44번_정류소가_하행이다() {
+        // given
+        RouteStops routeStops = fold3330();
+
+        // when
+        List<StopDirection> actual = List.of(
+            directionAt(routeStops, TURN_SEQUENCE_3330),
+            directionAt(routeStops, TURN_SEQUENCE_3330 + 1)
+        );
+
+        // then
+        assertThat(actual).containsExactly(UP, DOWN);
+    }
+
+    @Test
+    void 회차_순번이_없으면_모든_정류소가_상행이다() {
+        // given
+        RouteStops routeStops = RouteStops.from(null, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, ANY_STOP_NAME),
+            new UpstreamRouteStop(2, STOP_208000069, ANY_STOP_NAME),
+            new UpstreamRouteStop(3, STOP_205000217, ANY_STOP_NAME)
+        ));
+
+        // when
+        List<StopDirection> actual = routeStops.stops().stream().map(RouteStop::direction).toList();
+
+        // then
+        assertThat(actual).containsOnly(UP);
+    }
+
+    @Test
+    void 정류소_순번에_GBIS_stationSeq를_그대로_넣는다() {
+        // given
+        RouteStops routeStops = RouteStops.from(1, List.of(
+            new UpstreamRouteStop(6, STOP_205000217, ANY_STOP_NAME)
+        ));
+
+        // when
+        final int actual = routeStops.stops().getFirst().stopOrder();
+
+        // then
+        assertThat(actual).isEqualTo(6);
+    }
+
+    @Test
+    void 같은_정류소를_두_번_지나도_순번으로_구분된다() {
+        // given
+        RouteStops routeStops = RouteStops.from(2, List.of(
+            new UpstreamRouteStop(2, STOP_208000069, ANY_STOP_NAME),
+            new UpstreamRouteStop(3, STOP_208000069, ANY_STOP_NAME)
+        ));
+
+        // when
+        List<Integer> actual = routeStops.stops().stream().map(RouteStop::stopOrder).toList();
+
+        // then
+        assertThat(actual).containsExactly(2, 3);
+    }
+
+    @Test
+    void 정류소_목록을_접으면_정류소마다_승차_가능_여부가_정해진다() {
+        // given
+        RouteStops routeStops = RouteStops.from(3, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, ANY_STOP_NAME),
+            new UpstreamRouteStop(2, STOP_277103149, ANY_STOP_NAME),
+            new UpstreamRouteStop(3, STOP_208000069, ANY_STOP_NAME)
+        ));
+
+        // when
+        List<Boolean> actual = routeStops.stops().stream().map(RouteStop::boardingAllowed).toList();
+
+        // then
+        assertThat(actual).containsExactly(true, false, true);
+    }
+
+    private RouteStops fold3330() {
+        return RouteStops.from(TURN_SEQUENCE_3330, IntStream.rangeClosed(1, STOP_COUNT_3330)
+            .mapToObj(stopOrder -> new UpstreamRouteStop(stopOrder, STOP_205000217, ANY_STOP_NAME))
+            .toList());
+    }
+
+    private StopDirection directionAt(
+        RouteStops routeStops,
+        final int stopOrder
+    ) {
+        return routeStops.stops().stream()
+            .filter(stop -> stop.stopOrder() == stopOrder)
+            .findFirst()
+            .orElseThrow()
+            .direction();
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/collector/RouteStopsTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/RouteStopsTest.java
@@ -3,10 +3,13 @@ package com.gustler.backend.collector;
 import static com.gustler.backend.collector.StopDirection.DOWN;
 import static com.gustler.backend.collector.StopDirection.UP;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class RouteStopsTest {
 
@@ -51,7 +54,7 @@ class RouteStopsTest {
     @Test
     void 정류소_순번에_GBIS_stationSeq를_그대로_넣는다() {
         // given
-        RouteStops routeStops = RouteStops.from(1, List.of(
+        RouteStops routeStops = RouteStops.from(6, List.of(
             new UpstreamRouteStop(6, STOP_205000217, ANY_STOP_NAME)
         ));
 
@@ -93,10 +96,26 @@ class RouteStopsTest {
         assertThat(actual).containsExactly(true, false, true);
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {0, 999})
+    void 회차_순번은_경유하는_정류소_중_하나의_순번이다(
+        final int turnSequence
+    ) {
+        // when
+        Throwable actual = catchThrowable(() -> RouteStops.from(turnSequence, eightyFiveUpstreamStops()));
+
+        // then
+        assertThat(actual).isInstanceOf(IllegalArgumentException.class);
+    }
+
     private RouteStops fold3330() {
-        return RouteStops.from(TURN_SEQUENCE_3330, IntStream.rangeClosed(1, STOP_COUNT_3330)
+        return RouteStops.from(TURN_SEQUENCE_3330, eightyFiveUpstreamStops());
+    }
+
+    private List<UpstreamRouteStop> eightyFiveUpstreamStops() {
+        return IntStream.rangeClosed(1, STOP_COUNT_3330)
             .mapToObj(stopOrder -> new UpstreamRouteStop(stopOrder, STOP_205000217, ANY_STOP_NAME))
-            .toList());
+            .toList();
     }
 
     private StopDirection directionAt(

--- a/backend/src/test/java/com/gustler/backend/collector/RouteVersionContentTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/RouteVersionContentTest.java
@@ -1,0 +1,71 @@
+package com.gustler.backend.collector;
+
+import static com.gustler.backend.collector.RouteVersionDecision.KEEP_CURRENT_VERSION;
+import static com.gustler.backend.collector.RouteVersionDecision.OPEN_NEW_VERSION;
+import static com.gustler.backend.collector.RouteVersionDecision.REVISE_TIMETABLE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RouteVersionContentTest {
+
+    private static final String STOP_205000217 = "205000217";
+    private static final String STOP_208000069 = "208000069";
+    private static final RouteTimetable TIMETABLE_1650 =
+        new RouteTimetable("05:00", "22:35", "05:00", "23:55");
+    private static final RouteTimetable TIMETABLE_1650_LAST_BUS_MOVED =
+        new RouteTimetable("05:00", "22:50", "05:00", "23:55");
+
+    @Test
+    void 직전_판본과_정류소가_다르면_새로_끊는다() {
+        // given
+        RouteVersionContent stored = RouteVersionContent.of(twoStops(), TIMETABLE_1650);
+
+        // when
+        RouteVersionDecision actual = stored.decideFor(RouteVersionContent.of(threeStops(), TIMETABLE_1650));
+
+        // then
+        assertThat(actual).isEqualTo(OPEN_NEW_VERSION);
+    }
+
+    @Test
+    void 시간표만_바뀌면_같은_판본의_첫차와_막차를_고친다() {
+        // given
+        RouteVersionContent stored = RouteVersionContent.of(twoStops(), TIMETABLE_1650);
+
+        // when
+        RouteVersionDecision actual =
+            stored.decideFor(RouteVersionContent.of(twoStops(), TIMETABLE_1650_LAST_BUS_MOVED));
+
+        // then
+        assertThat(actual).isEqualTo(REVISE_TIMETABLE);
+    }
+
+    @Test
+    void 직전_판본과_정류소도_시간표도_같으면_그_판본을_그대로_쓴다() {
+        // given
+        RouteVersionContent stored = RouteVersionContent.of(twoStops(), TIMETABLE_1650);
+
+        // when
+        RouteVersionDecision actual = stored.decideFor(RouteVersionContent.of(twoStops(), TIMETABLE_1650));
+
+        // then
+        assertThat(actual).isEqualTo(KEEP_CURRENT_VERSION);
+    }
+
+    private RouteStops twoStops() {
+        return RouteStops.from(1, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, "범계역"),
+            new UpstreamRouteStop(2, STOP_208000069, "안양역")
+        ));
+    }
+
+    private RouteStops threeStops() {
+        return RouteStops.from(1, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, "범계역"),
+            new UpstreamRouteStop(2, STOP_208000069, "안양역"),
+            new UpstreamRouteStop(3, STOP_205000217, "범계역")
+        ));
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/collector/RouteVersionLoaderTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/RouteVersionLoaderTest.java
@@ -1,6 +1,7 @@
 package com.gustler.backend.collector;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.gustler.backend.support.IntegrationTest;
 import jakarta.persistence.EntityManager;
@@ -8,6 +9,8 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.transaction.annotation.Transactional;
@@ -159,6 +162,22 @@ class RouteVersionLoaderTest {
 
         // then
         assertThat(stopOrdersOf(versionId)).containsExactly(1, 2);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"2026-08-19T11:14:04.911+09:00", "2026-08-12T11:14:04.911+09:00"})
+    void 새_판본은_직전_판본이_시작한_뒤의_시각에만_연다(
+        String readAt
+    ) {
+        // given
+        loader.load(routeId, threeStops(), TIMETABLE_1650, FIRST_READ_AT);
+
+        // when
+        Throwable actual = catchThrowable(
+            () -> loader.load(routeId, fourStops(), TIMETABLE_1650, OffsetDateTime.parse(readAt)));
+
+        // then
+        assertThat(actual).isInstanceOf(IllegalArgumentException.class);
     }
 
     private RouteStops threeStops() {

--- a/backend/src/test/java/com/gustler/backend/collector/RouteVersionLoaderTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/RouteVersionLoaderTest.java
@@ -25,7 +25,7 @@ class RouteVersionLoaderTest {
     private static final String STOP_205000217 = "205000217";
     private static final String STOP_208000069 = "208000069";
     private static final String STOP_277103149 = "277103149";
-    private static final int TURN_SEQUENCE_3330 = 43;
+    private static final int TURN_SEQUENCE = 2;
     private static final String LAST_BUS_MOVED_TO = "22:50";
 
     private static final RouteTimetable TIMETABLE_1650 =
@@ -162,7 +162,7 @@ class RouteVersionLoaderTest {
     }
 
     private RouteStops threeStops() {
-        return RouteStops.from(TURN_SEQUENCE_3330, List.of(
+        return RouteStops.from(TURN_SEQUENCE, List.of(
             new UpstreamRouteStop(1, STOP_205000217, "범계역"),
             new UpstreamRouteStop(2, STOP_277103149, "안양대교(경유)"),
             new UpstreamRouteStop(3, STOP_208000069, "안양역")
@@ -170,7 +170,7 @@ class RouteVersionLoaderTest {
     }
 
     private RouteStops fourStops() {
-        return RouteStops.from(TURN_SEQUENCE_3330, List.of(
+        return RouteStops.from(TURN_SEQUENCE, List.of(
             new UpstreamRouteStop(1, STOP_205000217, "범계역"),
             new UpstreamRouteStop(2, STOP_277103149, "안양대교(경유)"),
             new UpstreamRouteStop(3, STOP_208000069, "안양역"),

--- a/backend/src/test/java/com/gustler/backend/collector/RouteVersionLoaderTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/RouteVersionLoaderTest.java
@@ -180,6 +180,28 @@ class RouteVersionLoaderTest {
         assertThat(actual).isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    void 새_판본은_아직_열려_있는_직전_판본_뒤에만_연다() {
+        // given
+        insertClosedVersion();
+
+        // when
+        Throwable actual = catchThrowable(
+            () -> loader.load(routeId, threeStops(), TIMETABLE_1650, SECOND_READ_AT));
+
+        // then
+        assertThat(actual).isInstanceOf(IllegalStateException.class);
+    }
+
+    private void insertClosedVersion() {
+        jdbcClient.sql("""
+                INSERT INTO route_version (route_id, content_digest, valid_from, valid_to)
+                VALUES (?, ?, ?, ?)
+                """)
+            .params(routeId, "0".repeat(64), FIRST_READ_AT, SECOND_READ_AT)
+            .update();
+    }
+
     private RouteStops threeStops() {
         return RouteStops.from(TURN_SEQUENCE, List.of(
             new UpstreamRouteStop(1, STOP_205000217, "범계역"),

--- a/backend/src/test/java/com/gustler/backend/collector/RouteVersionLoaderTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/RouteVersionLoaderTest.java
@@ -1,0 +1,231 @@
+package com.gustler.backend.collector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gustler.backend.support.IntegrationTest;
+import jakarta.persistence.EntityManager;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.transaction.annotation.Transactional;
+
+@IntegrationTest
+@Transactional
+class RouteVersionLoaderTest {
+
+    private static final OffsetDateTime FIRST_READ_AT = OffsetDateTime.parse("2026-08-19T11:14:04.911+09:00");
+    private static final OffsetDateTime SECOND_READ_AT = OffsetDateTime.parse("2026-08-26T11:14:04.911+09:00");
+    private static final OffsetDateTime THIRD_READ_AT = OffsetDateTime.parse("2026-09-02T11:14:04.911+09:00");
+
+    private static final String SOURCE_ID = "GBIS";
+    private static final String ROUTE_204000057 = "204000057";
+    private static final String STOP_205000217 = "205000217";
+    private static final String STOP_208000069 = "208000069";
+    private static final String STOP_277103149 = "277103149";
+    private static final int TURN_SEQUENCE_3330 = 43;
+    private static final String LAST_BUS_MOVED_TO = "22:50";
+
+    private static final RouteTimetable TIMETABLE_1650 =
+        new RouteTimetable("05:00", "22:35", "05:00", "23:55");
+    private static final RouteTimetable TIMETABLE_1650_LAST_BUS_MOVED =
+        new RouteTimetable("05:00", LAST_BUS_MOVED_TO, "05:00", "23:55");
+
+    @Autowired
+    private RouteVersionLoader loader;
+
+    @Autowired
+    private JdbcClient jdbcClient;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private long routeId;
+
+    @BeforeEach
+    void 노선_행을_먼저_넣는다() {
+        routeId = insertRoute();
+    }
+
+    @Test
+    void 판본이_하나도_없으면_새_판본을_넣는다() {
+        // when
+        loader.load(routeId, threeStops(), TIMETABLE_1650, FIRST_READ_AT);
+
+        // then
+        assertThat(versionCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 판본을_새로_끊으면_정류소_목록도_같이_들어간다() {
+        // given
+        final long versionId = loader.load(routeId, threeStops(), TIMETABLE_1650, FIRST_READ_AT);
+
+        // when
+        List<Integer> actual = stopOrdersOf(versionId);
+
+        // then
+        assertThat(actual).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void 직전_판본과_정류소가_다르면_판본이_둘이_된다() {
+        // given
+        loader.load(routeId, threeStops(), TIMETABLE_1650, FIRST_READ_AT);
+
+        // when
+        loader.load(routeId, fourStops(), TIMETABLE_1650, SECOND_READ_AT);
+
+        // then
+        assertThat(versionCount()).isEqualTo(2);
+    }
+
+    @Test
+    void 새_판본이_열리는_시각에_직전_판본의_유효기간이_닫힌다() {
+        // given
+        final long firstVersionId = loader.load(routeId, threeStops(), TIMETABLE_1650, FIRST_READ_AT);
+        loader.load(routeId, fourStops(), TIMETABLE_1650, SECOND_READ_AT);
+
+        // when
+        OffsetDateTime actual = validToOf(firstVersionId);
+
+        // then
+        assertThat(actual).isEqualTo(SECOND_READ_AT);
+    }
+
+    @Test
+    void 해시가_예전_판본과_같아도_직전과_다르면_새_판본을_넣는다() {
+        // given
+        loader.load(routeId, threeStops(), TIMETABLE_1650, FIRST_READ_AT);
+        loader.load(routeId, fourStops(), TIMETABLE_1650, SECOND_READ_AT);
+
+        // when
+        loader.load(routeId, threeStops(), TIMETABLE_1650, THIRD_READ_AT);
+
+        // then
+        assertThat(versionCount()).isEqualTo(3);
+    }
+
+    @Test
+    void 시간표만_바뀌면_판본_id가_그대로다() {
+        // given
+        final long firstVersionId = loader.load(routeId, threeStops(), TIMETABLE_1650, FIRST_READ_AT);
+
+        // when
+        final long actual =
+            loader.load(routeId, threeStops(), TIMETABLE_1650_LAST_BUS_MOVED, SECOND_READ_AT);
+
+        // then
+        assertThat(actual).isEqualTo(firstVersionId);
+    }
+
+    @Test
+    void 시간표만_바뀌면_같은_판본의_막차가_고쳐진다() {
+        // given
+        final long versionId = loader.load(routeId, threeStops(), TIMETABLE_1650, FIRST_READ_AT);
+        loader.load(routeId, threeStops(), TIMETABLE_1650_LAST_BUS_MOVED, SECOND_READ_AT);
+
+        // when
+        String actual = upLastDepartureTimeOf(versionId);
+
+        // then
+        assertThat(actual).isEqualTo(LAST_BUS_MOVED_TO);
+    }
+
+    @Test
+    void 직전_판본과_정류소도_시간표도_같으면_판본을_더_만들지_않는다() {
+        // given
+        loader.load(routeId, threeStops(), TIMETABLE_1650, FIRST_READ_AT);
+
+        // when
+        loader.load(routeId, threeStops(), TIMETABLE_1650, SECOND_READ_AT);
+
+        // then
+        assertThat(versionCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 같은_정류소를_두_번_지나는_노선도_적재된다() {
+        // given
+        RouteStops passesTwice = RouteStops.from(1, List.of(
+            new UpstreamRouteStop(1, STOP_208000069, "안양역"),
+            new UpstreamRouteStop(2, STOP_208000069, "안양역")
+        ));
+
+        // when
+        final long versionId = loader.load(routeId, passesTwice, TIMETABLE_1650, FIRST_READ_AT);
+
+        // then
+        assertThat(stopOrdersOf(versionId)).containsExactly(1, 2);
+    }
+
+    private RouteStops threeStops() {
+        return RouteStops.from(TURN_SEQUENCE_3330, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, "범계역"),
+            new UpstreamRouteStop(2, STOP_277103149, "안양대교(경유)"),
+            new UpstreamRouteStop(3, STOP_208000069, "안양역")
+        ));
+    }
+
+    private RouteStops fourStops() {
+        return RouteStops.from(TURN_SEQUENCE_3330, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, "범계역"),
+            new UpstreamRouteStop(2, STOP_277103149, "안양대교(경유)"),
+            new UpstreamRouteStop(3, STOP_208000069, "안양역"),
+            new UpstreamRouteStop(4, STOP_205000217, "범계역")
+        ));
+    }
+
+    private long insertRoute() {
+        return jdbcClient.sql("""
+                INSERT INTO route (
+                    public_route_id, source_id, source_route_id,
+                    display_name, start_stop_name, end_stop_name
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                RETURNING id
+                """)
+            .params(ROUTE_204000057, SOURCE_ID, ROUTE_204000057, "3330", "범계역", "강남역")
+            .query(Long.class)
+            .single();
+    }
+
+    private int versionCount() {
+        entityManager.flush();
+        return jdbcClient.sql("SELECT count(*) FROM route_version WHERE route_id = ?")
+            .param(routeId)
+            .query(Integer.class)
+            .single();
+    }
+
+    private List<Integer> stopOrdersOf(
+        final long versionId
+    ) {
+        entityManager.flush();
+        return jdbcClient.sql("SELECT stop_order FROM route_stop WHERE route_version_id = ? ORDER BY stop_order")
+            .param(versionId)
+            .query(Integer.class)
+            .list();
+    }
+
+    private OffsetDateTime validToOf(
+        final long versionId
+    ) {
+        entityManager.flush();
+        return jdbcClient.sql("SELECT valid_to FROM route_version WHERE id = ?")
+            .param(versionId)
+            .query(OffsetDateTime.class)
+            .single();
+    }
+
+    private String upLastDepartureTimeOf(
+        final long versionId
+    ) {
+        entityManager.flush();
+        return jdbcClient.sql("SELECT up_last_departure_time FROM route_version WHERE id = ?")
+            .param(versionId)
+            .query(String.class)
+            .single();
+    }
+}


### PR DESCRIPTION
## 요약

노선 판본(`route_version`)과 그 판본의 경유 정류소(`route_stop`)를 적재합니다.
상류가 노선 개편을 안 알려줘서 정류소 목록을 해시해두고 **바뀐 것을 우리가 알아냅니다.**
바뀌었으면 새 판본을 끊고, 시간표만 바뀌었으면 같은 행을 고칩니다.

<br/>

## 변경사항

- 정류소 ID 가 `277` 로 시작하면 버스가 안 서는 곳이라 판별해 `boarding_allowed` 에 박습니다
- 방향 구분 없이 오는 단일 배열을 `turnSeq` 로 접어 상행과 하행을 가릅니다
- 정류소 목록을 SHA-256 으로 요약해 가장 최근 판본과 견주고, 판본을 끊을지 여기서 정합니다
- `collector` 에 첫 영속화 계층을 놓습니다. 포트 `RouteVersionRepository` 와 JPA 어댑터입니다

**상류 호출은 안 들어갑니다.** `GBIS_SERVICE_KEY` 가 없어 노선정보 응답 픽스처를 못 만들었습니다.
스펙만 보고 픽스처를 지어내지 않았습니다. 두 상류(`getBusRouteStationListv2` · `getBusRouteInfoItemv2`)
파싱과 실측 건수 검증(1650 89개 · 3330 85개)은 키가 나오면 다음 티켓입니다.

<br/>

## 설계 결정

### 엔티티 이름을 `CollectorRouteVersion` 으로 갈랐습니다

`api` 패키지가 이미 같은 표를 보는 `RouteVersionJpaEntity` 를 갖고 있습니다(#29 · #33).
`PackageBoundaryTest` 가 `collector` → `api` 를 막아서 **가져다 쓸 수가 없습니다.**

그냥 같은 이름으로 하나 더 만들면 어떻게 되나 궁금해서 띄워봤는데 이렇게 죽습니다.

```
org.hibernate.DuplicateMappingException:
  Entity classes [...alpha.RouteVersionJpaEntity] and [...beta.RouteVersionJpaEntity]
  share the entity name 'RouteVersionJpaEntity' (entity names must be distinct)
```

한쪽에 `@Entity(name = ...)` 을 주니까 바로 통과합니다. #33 에 `@Entity(name = "Board...")` 선례가 있어서 따라갔습니다.

⚠️ 여기 함정이 하나 붙습니다. **`@Table` 기본값이 클래스 이름이 아니라 엔티티 이름에서 나옵니다.**
`@Table` 을 빼고 돌려보니 `missing table [collector_route_stop]` 으로 죽더라고요. 그래서 `@Table` 이 필수입니다.

**한계**: 같은 표를 두 곳에서 매핑합니다. 열이 바뀌면 양쪽을 다 고쳐야 하는데 컴파일러가 안 잡아줍니다.
`JdbcClient` 로 쓰는 안도 봤는데(읽기는 JPA, 쓰기는 JDBC), 팀이 JPA 로 가기로 해서 접었습니다.

<br/>

### 해시를 구분자로 잇지 않고 값마다 길이를 앞에 붙입니다

처음엔 `순번|정류소ID|이름` 을 줄바꿈으로 이어서 해시했습니다. 근데 **이름이 마지막 필드라
이름에 줄바꿈이 있으면 가짜 정류소를 밀어 넣을 수 있더라고요.** 실제로 충돌합니다.

```java
정류소 하나: (1, "205000217", "범계역\n2|208000069|안양역")
정류소 둘  : (1, "205000217", "범계역"), (2, "208000069", "안양역")
→ 해시가 같음                                 // <<<<<< 개편이 났는데 못 알아챕니다
```

GBIS 이름에 줄바꿈이 오는 걸 본 적은 없습니다. 그래도 **판본을 가르는 근거가 이 해시 하나뿐이라**
`MessageDigest.update` 로 값마다 길이를 먼저 넣는 쪽으로 바꿨습니다. 회귀 테스트를 걸어뒀습니다.

<br/>

### 새 판본을 넣기 전에 직전 판본을 닫고 **flush 합니다**

`ex_route_version_no_overlap` 이 `EXCLUDE USING gist` 로 같은 노선의 기간 겹침을 막습니다.
그래서 직전 판본의 `valid_to` 를 먼저 닫아야 하는데, **닫는 코드를 써놔도 안 됩니다.**
Hibernate 가 한 트랜잭션에서 INSERT 를 UPDATE 보다 먼저 내보내거든요. 하..

```java
previousVersion.closeAt(openedAt);
routeVersionEntityRepository.flush();   // <<<<<< 이게 없으면 아래 INSERT 가 제약에 걸립니다
```

정말 필요한지 확인하려고 `flush()` 를 빼고 돌려봤습니다. 통합 테스트 3개가 이렇게 죽습니다.

```
DataIntegrityViolationException: conflicting key value violates
exclusion constraint "ex_route_version_no_overlap"
```

이 순서는 제약을 아는 어댑터가 갖고 있고, 로더는 모릅니다.

<br/>

### 적재 시각을 `Clock` 이 아니라 파라미터로 받습니다

`load(routeId, routeStops, timetable, readAt)` 입니다.

처음엔 로더가 `Clock` 을 주입받아 `OffsetDateTime.now(clock)` 을 썼습니다. 두 가지가 걸렸습니다.

하나는 의미입니다. **`valid_from` 은 상류를 읽은 시각이어야지 DB 에 쓴 시각이 아닙니다.**
호출과 저장 사이에 재시도가 끼면 어긋납니다.

다른 하나는 테스트입니다. 시각을 고정하려고 `@MockitoBean Clock` 을 썼더니 스프링 컨텍스트 캐시 키가 갈려서
**postgres 컨테이너가 2개** 뜨더라고요. 실측입니다. 파라미터로 내리니 1개가 됐습니다.

`Clock` 규칙(SAL-77)은 그대로입니다. 부르는 쪽(다음 티켓 스케줄러)이 주입받은 `Clock` 에서 얻어 넘깁니다.

<br/>

### `collector` 에 포트를 뒀습니다. 여기는 같이 봐주세요

`api` 는 `RouteQueryRepository`(인터페이스) ↔ `JpaRouteQueryRepository`(구현) 로 가는데,
`collector` 는 `GbisLocationSource` 가 `RestClient` 를 직접 쓰는 등 포트가 하나도 없습니다.

**`api` 쪽에 맞췄습니다.** `RouteVersionLoader` 가 JPA 를 아예 안 보고 48줄입니다.
`flush` 순서 같은 제약 사정은 어댑터가 가져갔습니다.

**한계**: 구현이 하나뿐인데 인터페이스를 뒀습니다. 지금은 순수하게 방향 맞추기용입니다.
`collector` 전체를 이쪽으로 옮길 게 아니면 여기만 튀어 보일 수 있는데, 어떻게 보시나요?

<br/>

### 판별 규칙을 적재 시점에 박습니다

`boarding_allowed` 는 열에 `DEFAULT` 가 없어서 적재 코드가 반드시 정하게 되어 있습니다.
추론 · 통계 · 응답 조립 · 채점이 전부 이 열을 조인해 읽고, **하류에서 규칙을 다시 구현하지 않습니다.**

**한계**: `BoardingPolicy` 가 상수 하나짜리 정적 유틸입니다.
나중에 판별을 룰셋 테이블로 옮기고 싶어지면 이 방식은 못 씁니다.

<br/>

## 확인 사항

### ⚠️ 회차 순번의 방향 경계가 아직 가정입니다

`stopOrder <= turnSequence` 를 상행으로 잡았습니다. **회차 정류소가 상행의 마지막**이 됩니다.
3330 이면 상행 1~43(43곳), 하행 44~85(42곳)입니다.

`turnSeq` 가 회차 정류소의 순번인지 하행 첫 정류소의 순번인지 **응답을 못 봐서 확인을 못 했습니다.**
반대면 부등호 하나와 테스트 이름 하나가 바뀝니다. 픽스처가 나오면 제일 먼저 볼 겁니다.

### 이 티켓에서 안 한 것 둘

- **`route` 표 적재.** `route_version.route_id` 가 NOT NULL FK 라 `route` 행이 먼저 있어야 하는데,
  노선 자체의 식별 정보라 성격이 달라 별도로 뺐습니다. 테스트는 픽스처로 `route` 행을 먼저 넣습니다
- **`hibernate.jdbc.batch_size`.** 지금은 `saveAll` 이 정류소 89행에 INSERT 를 89번 냅니다.
  `application.yml` 이라 앱 전체 엔티티에 걸려서 여기서 정하지 않았습니다. 판본 갱신이 드물어 급하진 않습니다

### 요일패턴은 평일 것만 저장합니다

`route_version` 에 첫차 · 막차 4열뿐이라 **요일 축이 없습니다.** 네 벌(`we*` · `sat*` · `sun*` · 평일)을
다 받아 대조하는 것은 상류 파싱이 들어오는 다음 티켓입니다. 대조해서 평일과 다른 벌이 나오면 그때 멈추고 알리겠습니다.

<br/>

## 검증

```
./gradlew cleanTest test   →   120개 통과 (dev 기준 92 + 신규 28)
```

커밋 5개를 각각 임시 워크트리에 띄워 전부 돌려봤습니다. **어느 지점에서 잘라도 초록입니다.**

| 커밋 | |
| --- | --- |
| 승차 가능 여부 판별 | 97개 |
| 상행과 하행 분리 | 102개 |
| 판본 내용 요약 | 108개 |
| 판본 판단 | 111개 |
| 적재 | 120개 |
