### PR TITLE
fix: 같은 표를 매핑한 엔티티의 논리 컬럼명을 맞춘다

### DIFF
--- a/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteVersionJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/api/route/persistence/jpa/RouteVersionJpaEntity.java
@@ -28,22 +28,28 @@ public class RouteVersionJpaEntity {
     @JoinColumn(name = "route_id", nullable = false)
     private RouteJpaEntity route;
 
+    @Column(name = "turn_sequence")
     private Integer turnSequence;
 
+    @Column(name = "up_first_departure_time")
     private String upFirstDepartureTime;
 
+    @Column(name = "up_last_departure_time")
     private String upLastDepartureTime;
 
+    @Column(name = "down_first_departure_time")
     private String downFirstDepartureTime;
 
+    @Column(name = "down_last_departure_time")
     private String downLastDepartureTime;
 
     @JdbcTypeCode(SqlTypes.CHAR)
-    @Column(nullable = false)
+    @Column(name = "content_digest", nullable = false)
     private String contentDigest;
 
-    @Column(nullable = false)
+    @Column(name = "valid_from", nullable = false)
     private OffsetDateTime validFrom;
 
+    @Column(name = "valid_to")
     private OffsetDateTime validTo;
 }

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteStopJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteStopJpaEntity.java
@@ -3,6 +3,7 @@ package com.gustler.backend.collector.persistence.jpa;
 import com.gustler.backend.collector.RouteStop;
 import com.gustler.backend.collector.StopDirection;
 import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -19,6 +20,7 @@ public class RouteStopJpaEntity implements Persistable<RouteStopJpaId> {
     @EmbeddedId
     private RouteStopJpaId id;
 
+    @Column(name = "stop_id")
     private String stopId;
 
     private String name;
@@ -26,6 +28,7 @@ public class RouteStopJpaEntity implements Persistable<RouteStopJpaId> {
     @Enumerated(EnumType.STRING)
     private StopDirection direction;
 
+    @Column(name = "boarding_allowed")
     private boolean boardingAllowed;
 
     public RouteStopJpaEntity(

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteStopJpaId.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteStopJpaId.java
@@ -1,11 +1,15 @@
 package com.gustler.backend.collector.persistence.jpa;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
 
 @Embeddable
 public record RouteStopJpaId(
+    @Column(name = "route_version_id")
     Long routeVersionId,
+
+    @Column(name = "stop_order")
     Integer stopOrder
 ) implements Serializable {
 }

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteVersionJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/RouteVersionJpaEntity.java
@@ -3,6 +3,7 @@ package com.gustler.backend.collector.persistence.jpa;
 import com.gustler.backend.collector.RouteContentDigest;
 import com.gustler.backend.collector.RouteTimetable;
 import com.gustler.backend.collector.RouteVersionContent;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -25,23 +26,32 @@ public class RouteVersionJpaEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "route_id")
     private Long routeId;
 
+    @Column(name = "turn_sequence")
     private Integer turnSequence;
 
+    @Column(name = "up_first_departure_time")
     private String upFirstDepartureTime;
 
+    @Column(name = "up_last_departure_time")
     private String upLastDepartureTime;
 
+    @Column(name = "down_first_departure_time")
     private String downFirstDepartureTime;
 
+    @Column(name = "down_last_departure_time")
     private String downLastDepartureTime;
 
     @JdbcTypeCode(SqlTypes.CHAR)
+    @Column(name = "content_digest")
     private String contentDigest;
 
+    @Column(name = "valid_from")
     private OffsetDateTime validFrom;
 
+    @Column(name = "valid_to")
     private OffsetDateTime validTo;
 
     public RouteVersionJpaEntity(


### PR DESCRIPTION
## 무엇이 깨졌나

`dev`(`a7541e1`)가 빨간 상태입니다. `./gradlew test` 기준 **200개 중 24개 실패**입니다.

```
org.hibernate.DuplicateMappingException: Table [route_version] contains physical column name
[route_id] referred to by multiple logical column names: [route_id], [routeId]
```

`entityManagerFactory` 생성에서 죽어 `ApplicationContext`를 띄우는 테스트가 전부 걸립니다.

## 왜 각 PR 에서는 안 걸렸나

`route_version`과 `route_stop`을 **collector와 api 양쪽이 각각 매핑**하는데, 한쪽만 `@Column(name = ...)`을 명시했습니다.

| 표 | collector (SAL-88) | api (SAL-103 · SAL-104) |
|---|---|---|
| `route_version.route_id` | `private Long routeId;` → 논리명 `routeId` | `@JoinColumn(name = "route_id")` → 논리명 `route_id` |
| `route_version.content_digest` | `@Column(name = "content_digest")` | `@Column(nullable = false)` → 논리명 `contentDigest` |
| `route_stop.route_version_id` | `record RouteStopJpaId(Long routeVersionId, ...)` | `@Column(name = "route_version_id")` |

물리 컬럼명은 양쪽 다 snake_case로 같지만 **논리 컬럼명이 갈립니다.** Hibernate는 같은 물리 컬럼에 논리명이 둘이면 거부합니다.

각 PR 단독으로는 그 표를 매핑하는 엔티티가 하나뿐이라 드러나지 않고, **둘이 같이 들어온 뒤에야** 터집니다. SAL-88(`4cd3dbd`)이 들어갈 때는 초록이었고 SAL-103(`a7541e1`)이 뒤이어 들어가면서 처음 부딪혔습니다.

## 무엇을 고쳤나

양쪽 모두 `@Column(name = ...)`을 명시해 규약을 하나로 맞췄습니다.

- `collector/persistence/jpa/RouteVersionJpaEntity` — 9필드
- `collector/persistence/jpa/RouteStopJpaEntity` — `stopId` · `boardingAllowed`
- `collector/persistence/jpa/RouteStopJpaId` — `routeVersionId` · `stopOrder`
- `api/route/persistence/jpa/RouteVersionJpaEntity` — 8필드

동작은 바뀌지 않습니다. 물리 컬럼명이 원래 그 값이었고 논리명만 맞춘 것입니다.

## 검증

```
a7541e1 (현재 dev)   200 tests, 24 failed
+ 이 PR              200 tests,  0 failed
```

## 남은 이야기

`@Column(name)`을 빼면 Spring Boot가 snake_case로 바꿔준다는 것은 맞습니다. 다만 **한 표를 두 패키지가 매핑하는 동안에는** 양쪽이 같은 방식을 써야 합니다. 관계 필드는 `@JoinColumn(name = ...)`이 필요해서 그쪽을 암묵으로 돌릴 수는 없으니, 명시하는 쪽으로 맞췄습니다.

`collector`와 `api`가 같은 표를 각자 매핑하는 구조 자체를 어떻게 볼지는 별도 논의가 필요해 보입니다.