### PR TITLE
feat(SAL-63): API 클라이언트 기반 모듈과 fetch 래퍼 추가

### DIFF
--- a/frontend/src/shared/api/cacheControl.ts
+++ b/frontend/src/shared/api/cacheControl.ts
@@ -1,0 +1,39 @@
+const MAX_AGE_DIRECTIVE = /^max-age="?(\d+)"?$/i;
+const WHOLE_SECONDS = /^\d+$/;
+
+export interface CacheLifetime {
+  noStore: boolean;
+  maxAgeSeconds: number | null;
+  ageSeconds: number;
+}
+
+export function cacheLifetimeFrom(headers: Headers): CacheLifetime {
+  const directives = (headers.get("cache-control") ?? "").split(",").map((directive) => directive.trim());
+  const age = headers.get("age");
+
+  return {
+    noStore: directives.some((directive) => directive.toLowerCase() === "no-store"),
+    maxAgeSeconds: maxAgeSecondsIn(directives),
+    ageSeconds: age !== null && WHOLE_SECONDS.test(age) ? Number(age) : 0,
+  };
+}
+
+function maxAgeSecondsIn(directives: string[]): number | null {
+  for (const directive of directives) {
+    const seconds = MAX_AGE_DIRECTIVE.exec(directive)?.[1];
+    if (seconds !== undefined) {
+      return Number(seconds);
+    }
+  }
+
+  return null;
+}
+
+export function remainingFreshSecondsFrom(headers: Headers): number | null {
+  const { noStore, maxAgeSeconds, ageSeconds } = cacheLifetimeFrom(headers);
+  if (noStore || maxAgeSeconds === null) {
+    return null;
+  }
+
+  return Math.max(0, maxAgeSeconds - ageSeconds);
+}

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,0 +1,143 @@
+import { cacheLifetimeFrom, type CacheLifetime } from "./cacheControl";
+import { referenceClockFrom, type ReferenceClock } from "./referenceClock";
+import { retryAfterMillisFrom } from "./retryAfter";
+import type { ErrorCode, ErrorResponse } from "./routeForecast.types";
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const TIMEOUT_REASON = "timeout";
+
+const ERROR_CODES: ReadonlySet<string> = new Set<ErrorCode>([
+  "INVALID_ROUTE_ID",
+  "ROUTE_NOT_FOUND",
+  "MODEL_OUT_OF_SCOPE",
+  "NO_RECENT_OBSERVATION",
+  "SERVICE_UNAVAILABLE",
+]);
+
+export interface ApiSuccess<T> {
+  ok: true;
+  body: T;
+  status: number;
+  requestId: string | null;
+  clock: ReferenceClock | null;
+  lifetime: CacheLifetime;
+}
+
+export type ApiFailure =
+  | { kind: "contract"; error: ErrorResponse; status: number; retryAfterMs: number | null }
+  | { kind: "rateLimited"; retryAfterMs: number | null; requestId: string | null }
+  | { kind: "methodNotAllowed"; requestId: string | null }
+  | { kind: "malformed"; status: number; requestId: string | null }
+  | { kind: "timeout" }
+  | { kind: "aborted" }
+  | { kind: "network"; cause: unknown };
+
+export interface ApiError {
+  ok: false;
+  failure: ApiFailure;
+}
+
+export type ApiResult<T> = ApiSuccess<T> | ApiError;
+
+export interface RequestOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+export async function requestJson<T>(url: string, options: RequestOptions = {}): Promise<ApiResult<T>> {
+  if (options.signal?.aborted) {
+    return failed({ kind: "aborted" });
+  }
+
+  const controller = new AbortController();
+  const forwardAbort = () => controller.abort(options.signal?.reason);
+  options.signal?.addEventListener("abort", forwardAbort, { once: true });
+  const timeout = setTimeout(() => controller.abort(TIMEOUT_REASON), options.timeoutMs ?? REQUEST_TIMEOUT_MS);
+
+  let response: Response | null = null;
+  try {
+    response = await fetch(url, { headers: { Accept: "application/json" }, signal: controller.signal });
+    const clock = referenceClockFrom(response.headers);
+    const infrastructureFailure = infrastructureFailureOf(response, clock);
+    if (infrastructureFailure !== null) {
+      return failed(infrastructureFailure);
+    }
+
+    const body: unknown = await response.json();
+    return interpret<T>(response, body, clock);
+  } catch (cause) {
+    if (controller.signal.aborted) {
+      return failed(controller.signal.reason === TIMEOUT_REASON ? { kind: "timeout" } : { kind: "aborted" });
+    }
+    if (response !== null) {
+      return failed({ kind: "malformed", status: response.status, requestId: requestIdOf(response) });
+    }
+    return failed({ kind: "network", cause });
+  } finally {
+    clearTimeout(timeout);
+    options.signal?.removeEventListener("abort", forwardAbort);
+  }
+}
+
+function infrastructureFailureOf(response: Response, clock: ReferenceClock | null): ApiFailure | null {
+  if (response.status === 429) {
+    return { kind: "rateLimited", retryAfterMs: retryAfterMsOf(response, clock), requestId: requestIdOf(response) };
+  }
+  if (response.status === 405) {
+    return { kind: "methodNotAllowed", requestId: requestIdOf(response) };
+  }
+  return null;
+}
+
+function interpret<T>(response: Response, body: unknown, clock: ReferenceClock | null): ApiResult<T> {
+  const requestId = requestIdOf(response);
+
+  if (response.ok) {
+    return {
+      ok: true,
+      body: body as T,
+      status: response.status,
+      requestId,
+      clock,
+      lifetime: cacheLifetimeFrom(response.headers),
+    };
+  }
+
+  if (isErrorResponse(body)) {
+    return failed({
+      kind: "contract",
+      error: body,
+      status: response.status,
+      retryAfterMs: retryAfterMsOf(response, clock),
+    });
+  }
+
+  return failed({ kind: "malformed", status: response.status, requestId });
+}
+
+function isErrorResponse(value: unknown): value is ErrorResponse {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.code === "string" &&
+    ERROR_CODES.has(candidate.code) &&
+    typeof candidate.message === "string" &&
+    typeof candidate.requestId === "string" &&
+    typeof candidate.retryable === "boolean"
+  );
+}
+
+function retryAfterMsOf(response: Response, clock: ReferenceClock | null): number | null {
+  return clock === null ? null : retryAfterMillisFrom(response.headers, clock.now());
+}
+
+function requestIdOf(response: Response): string | null {
+  return response.headers.get("x-request-id");
+}
+
+function failed(failure: ApiFailure): ApiError {
+  return { ok: false, failure };
+}

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -131,7 +131,7 @@ function isErrorResponse(value: unknown): value is ErrorResponse {
 }
 
 function retryAfterMsOf(response: Response, clock: ReferenceClock | null): number | null {
-  return clock === null ? null : retryAfterMillisFrom(response.headers, clock.now());
+  return retryAfterMillisFrom(response.headers, clock === null ? null : clock.now());
 }
 
 function requestIdOf(response: Response): string | null {

--- a/frontend/src/shared/api/latestRequestGate.ts
+++ b/frontend/src/shared/api/latestRequestGate.ts
@@ -1,0 +1,32 @@
+export interface RequestTicket {
+  readonly signal: AbortSignal;
+  isLatest(): boolean;
+  abort(): void;
+}
+
+export interface LatestRequestGate {
+  issue(): RequestTicket;
+  close(): void;
+}
+
+export function createLatestRequestGate(): LatestRequestGate {
+  let latest: AbortController | null = null;
+
+  return {
+    issue() {
+      latest?.abort();
+      const controller = new AbortController();
+      latest = controller;
+
+      return {
+        signal: controller.signal,
+        isLatest: () => latest === controller,
+        abort: () => controller.abort(),
+      };
+    },
+    close() {
+      latest?.abort();
+      latest = null;
+    },
+  };
+}

--- a/frontend/src/shared/api/referenceClock.ts
+++ b/frontend/src/shared/api/referenceClock.ts
@@ -1,0 +1,22 @@
+import { cacheLifetimeFrom } from "./cacheControl";
+
+export interface ReferenceClock {
+  readonly servedAt: number;
+  now(): number;
+}
+
+export function referenceClockFrom(
+  headers: Headers,
+  elapsedNow: () => number = () => performance.now(),
+): ReferenceClock | null {
+  const date = headers.get("date");
+  if (date === null) return null;
+
+  const originAt = Date.parse(date);
+  if (Number.isNaN(originAt)) return null;
+
+  const servedAt = originAt + cacheLifetimeFrom(headers).ageSeconds * 1000;
+  const receivedAt = elapsedNow();
+
+  return { servedAt, now: () => servedAt + (elapsedNow() - receivedAt) };
+}

--- a/frontend/src/shared/api/retryAfter.ts
+++ b/frontend/src/shared/api/retryAfter.ts
@@ -1,0 +1,19 @@
+const WHOLE_SECONDS = /^\d+$/;
+
+export function retryAfterMillisFrom(headers: Headers, now: number): number | null {
+  const retryAfter = headers.get("retry-after");
+  if (retryAfter === null) {
+    return null;
+  }
+
+  if (WHOLE_SECONDS.test(retryAfter)) {
+    return Number(retryAfter) * 1000;
+  }
+
+  const retryAt = Date.parse(retryAfter);
+  if (Number.isNaN(retryAt)) {
+    return null;
+  }
+
+  return Math.max(0, retryAt - now);
+}

--- a/frontend/src/shared/api/retryAfter.ts
+++ b/frontend/src/shared/api/retryAfter.ts
@@ -1,6 +1,6 @@
 const WHOLE_SECONDS = /^\d+$/;
 
-export function retryAfterMillisFrom(headers: Headers, now: number): number | null {
+export function retryAfterMillisFrom(headers: Headers, now: number | null): number | null {
   const retryAfter = headers.get("retry-after");
   if (retryAfter === null) {
     return null;
@@ -8,6 +8,10 @@ export function retryAfterMillisFrom(headers: Headers, now: number): number | nu
 
   if (WHOLE_SECONDS.test(retryAfter)) {
     return Number(retryAfter) * 1000;
+  }
+
+  if (now === null) {
+    return null;
   }
 
   const retryAt = Date.parse(retryAfter);

--- a/frontend/src/shared/api/routeForecast.api.ts
+++ b/frontend/src/shared/api/routeForecast.api.ts
@@ -1,0 +1,16 @@
+import { requestJson, type ApiResult, type RequestOptions } from "./client";
+import type { Board, LiveVehicles, RouteListResponse } from "./routeForecast.types";
+
+const API_BASE = "/api/v1";
+
+export function fetchRoutes(options?: RequestOptions): Promise<ApiResult<RouteListResponse>> {
+  return requestJson<RouteListResponse>(`${API_BASE}/routes`, options);
+}
+
+export function fetchBoard(routeId: string, options?: RequestOptions): Promise<ApiResult<Board>> {
+  return requestJson<Board>(`${API_BASE}/routes/${encodeURIComponent(routeId)}/board`, options);
+}
+
+export function fetchLiveVehicles(routeId: string, options?: RequestOptions): Promise<ApiResult<LiveVehicles>> {
+  return requestJson<LiveVehicles>(`${API_BASE}/routes/${encodeURIComponent(routeId)}/vehicles`, options);
+}

--- a/frontend/webpack/webpack.dev.cjs
+++ b/frontend/webpack/webpack.dev.cjs
@@ -9,6 +9,9 @@ module.exports = merge(common, {
     dir: path.resolve(__dirname, "../env"),
   },
   devtool: "eval-source-map",
+  output: {
+    publicPath: "/",
+  },
   module: {
     rules: [
       {
@@ -35,7 +38,7 @@ module.exports = merge(common, {
     proxy: [
       {
         context: ["/api"],
-        target: "http://localhost:8080",
+        target: process.env.API_PROXY_TARGET ?? "http://localhost:8080",
         changeOrigin: true,
       },
     ],


### PR DESCRIPTION
## 작업 내용

SAL-63(API 클라이언트와 응답 매퍼 계층)의 첫 조각입니다. 화면이 실데이터를 부르는 데 필요한 최소 경로(fetch 래퍼 + 세 API 호출 함수)와, 그 래퍼가 기대는 기반 모듈 4개를 담았습니다. 커밋은 4개이고 앞의 3개는 v4 타입을 전혀 import하지 않는 순수 모듈입니다.

| 커밋 | 파일 | 역할 |
|---|---|---|
| Cache-Control과 Retry-After 헤더 해석 모듈 추가 | `shared/api/cacheControl.ts`, `shared/api/retryAfter.ts` | 응답 헤더를 캐시 수명과 재시도 대기 시간으로 해석 |
| Date 헤더 기반 기준 시각 유틸 추가 | `shared/api/referenceClock.ts` | 서버 시계 기준의 "지금" |
| 최신 요청만 반영하는 경쟁 상태 게이트 추가 | `shared/api/latestRequestGate.ts` | 늦게 온 옛 응답이 새 화면을 덮지 못하게 하는 티켓 |
| fetch 래퍼와 세 API 호출 함수 추가 | `shared/api/client.ts`, `shared/api/routeForecast.api.ts`, `webpack/webpack.dev.cjs` | HTTP 호출, 결과 정규화, 로컬 프록시 스위치 |

### 1. fetch 래퍼 `requestJson`과 결과 객체 `ApiResult`

`requestJson<T>(url, { signal?, timeoutMs? })`는 예외를 던지지 않고 결과 객체를 돌려줍니다. SAL-63이 정한 이 계층의 출력 셋(DTO, 정규화된 에러, 기준 시각)이 한 객체에 담기고, 호출 측이 `catch (e: unknown)`에서 타입을 추측할 일이 없어집니다.

성공(`ok: true`)은 다섯 필드를 가집니다.

* `body`: SAL-49 타입 그대로의 DTO (`T`)
* `status`: HTTP 상태
* `requestId`: `X-Request-ID` 헤더 (BE와 문제를 맞춰볼 때 씁니다)
* `clock`: Date 헤더로 만든 기준 시각 (`ReferenceClock | null`)
* `lifetime`: Cache-Control 해석 결과 (`CacheLifetime`)

실패(`ok: false`)의 `failure`는 일곱 갈래입니다.

| kind | 언제 |
|---|---|
| `contract` | 4xx/5xx이고 본문이 계약의 에러 envelope(code 5종, message, requestId, retryable)일 때. `retryAfterMs` 포함 |
| `rateLimited` | 429. 본문을 읽기 전에 status로 가릅니다. `Retry-After`를 밀리초로 |
| `methodNotAllowed` | 405. 역시 본문 전에 |
| `malformed` | 본문이 JSON이 아니거나(CloudFront 폴백 HTML 등), 4xx/5xx인데 envelope 모양이 아닐 때 |
| `timeout` | 기본 10초 안에 응답이 없을 때 |
| `aborted` | 호출 측 signal로 취소됐을 때 (에러가 아니라 무시 대상) |
| `network` | fetch 자체가 실패했을 때 (DNS, 연결 끊김). `cause` 보존 |

429와 405를 본문 읽기 전에 가르는 이유는 두 응답이 빈 본문이나 비JSON으로 올 수 있어서입니다. 본문을 먼저 읽으면 `malformed`로 잘못 분류됩니다.

### 2. Cache-Control 해석 `cacheLifetimeFrom`

헤더를 한 번 쪼개 `CacheLifetime { noStore, maxAgeSeconds, ageSeconds }` 객체로 돌려주고, `remainingFreshSecondsFrom`이 남은 신선도(초)를 파생합니다. 세 값은 "이 응답의 캐시 수명"이라는 한 사실의 세 면이라 한 객체로 묶었습니다.

`no-store`가 있으면 `max-age`가 같이 있어도 `null`("폴링 근거 없음")을 돌려줍니다. 데모 서버가 `/board`에 `no-store, max-age=0`을 내는데, `no-store`를 무시하면 남은 신선도가 0초가 되어 즉시 재요청을 반복하게 됩니다. `Age` 헤더(CloudFront 경유 시 붙는 캐시 체류 초)는 `max-age`에서 뺍니다. 폴링 주기 상수는 이 계층 어디에도 없고, `null`일 때의 동작은 호출 측 정책(티켓 미결 항목)입니다.

### 3. 기준 시각 `referenceClockFrom`

`Date` 헤더 + `Age`로 응답이 손에 들어온 순간의 서버 시각(`servedAt`)을 잡고, 그 뒤 경과는 `performance.now()`(페이지 로드 후 경과 밀리초, 단조 시계)로 더합니다. 팀 원칙이 금지하는 것은 틀릴 수 있는 기기 벽시계(`Date.now()`)이고, 경과 시간 측정은 그 원칙에 걸리지 않습니다. `Date` 헤더가 없으면 기기 시계로 대체하지 않고 `null`을 돌려줍니다(틀린 시각을 보여주는 것보다 신선도 표시를 못 하는 편이 낫습니다). `Retry-After`가 날짜형일 때의 "지금"도 이 시계에서 옵니다.

### 4. 경쟁 상태 게이트 `createLatestRequestGate`

티켓 하나가 요청 하나입니다. `issue()`가 직전 요청을 `abort()`로 끊고 새 `AbortController`를 최신으로 등록하며, 응답 뒤에 `isLatest()`로 한 번 더 확인합니다. abort는 네트워크를 끊지만 본문 파싱 뒤에 다른 `await`가 끼면 그 틈을 못 막아서, 두 장치를 같이 둡니다. 타임아웃은 같은 컨트롤러를 `abort()`하는 방식이라 `AbortSignal.any`가 필요 없습니다. browserslist `defaults`에 Chrome 109가 있고(한국 기준 질의로 바꿔도 Chrome 111이 3.24%) `AbortSignal.any`는 Chrome 116부터라 쓸 수 없기도 합니다.

### 5. 상대 경로와 프록시

`routeForecast.api.ts`의 세 함수(`fetchRoutes`, `fetchBoard`, `fetchLiveVehicles`)는 `/api/v1/...` 상대 경로만 부릅니다. 로컬은 webpack dev 프록시가, 배포본은 CloudFront의 `/api/*` 동작이 API 서버로 넘겨주므로 브라우저 코드에 베이스 URL도 CORS 처리도 없습니다. 팀 BE로 바꿀 때는 CloudFront 원본만 바꾸면 되고 코드 변경은 없습니다.

`webpack.dev.cjs`의 프록시 target은 `API_PROXY_TARGET` 환경변수로 뺐습니다(기본값은 계약의 로컬 서버 `http://localhost:8080`, 데모 서버로 돌릴 때 `API_PROXY_TARGET=https://15-164-85-201.sslip.io pnpm dev`). 같은 파일에 `output.publicPath: "/"`를 추가했는데, 이것은 2026-08-09 리뷰에서 재현된 "중첩 경로 새로고침 시 상대 경로로 번들을 찾다 흰 화면" 결함의 해결입니다(프로덕션은 이미 `/`였습니다).

### 6. 계약 기준과 데모 서버

기준은 Client API 2.0.0(pages.dev의 `/v4-fe/client.openapi.yaml`)입니다. 데모 서버가 내는 응답은 그 상위집합(`vehiclePlate`, `plateNo`, `plateState`, `dataMode`, `freshness`, `servedAt`, `snapshotId`, model digest)이며 초과 필드는 무시하기로 했습니다. 계약의 `additionalProperties: false`를 런타임 검증에 그대로 옮기지 않습니다(옮기면 데모 서버 응답이 전부 거부됩니다).

실측으로 확인한 데모 서버의 2.0.0 이탈 3건: (1) `/board`와 `/vehicles`가 `Cache-Control: no-store, max-age=0`(계약은 적응형 max-age 15~600) (2) CORS 허용 출처가 문서 CloudFront 하나뿐(계약 본문의 localhost 3000/5173 목록과 다름) (3) `/routes/abc/board`가 400 INVALID_ROUTE_ID가 아니라 404 ROUTE_NOT_FOUND. 이 PR의 코드는 세 경우 모두 그대로 동작합니다(각각 null 근거, 프록시, contract 실패로 분류).

## 확인 사항

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

`pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm build` 전부 통과했습니다.

리포에 테스트 러너가 아직 없어서 Node 24의 TS 실행으로 스모크를 돌렸습니다.

* 모듈 26케이스: `max-age=15` → 15, `public, max-age="300"` → 300, `max-age=` → null, `no-store, max-age=0` → null, `Age 5`에 `max-age 15` → 10, Age 초과 → 0, `Retry-After: 60` → 60000, HTTP 날짜 +10초 → 10000, 과거 날짜 → 0, Date 헤더 → servedAt, Age 3 → +3000, 가짜 스톱워치 10초 → now() +10000, Date 없음 → null, 두 번째 issue가 첫 티켓을 abort, isLatest 전환, abort()와 isLatest 독립, close 뒤 비최신 등
* 래퍼 실호출 12케이스(데모 서버): `/routes` 200(max-age 300, clock 있음), `/board` 200(no-store), `/vehicles` 200, 999999999 → contract ROUTE_NOT_FOUND, abc → contract ROUTE_NOT_FOUND, 비-envelope 404 → malformed, 1ms 타임아웃 → timeout, 사전 취소 → aborted, 도중 취소 → aborted, 없는 호스트 → network, HTML 본문 → malformed

이 케이스들은 테스트 러너 결정(SAL-75, vitest 검토 중) 뒤에 그대로 테스트로 옮길 예정입니다.

## 참고 사항

**후속 PR로 남긴 SAL-63 항목**: Cache-Control 준수 폴링 스케줄러(visibility 포함), referenceVersionId 불일치 감지와 재요청, 런타임 필수 필드 검증(초과 필드 무시는 확정, 필수 필드 결손 시 전체 에러 vs 부분 표시는 미결), 테스트. 미결 결정(재시도 정책, 상태 관리 방식, 폴링 근거 없을 때의 동작)은 티켓 본문에 있습니다.

**리뷰에서 봐 주셨으면 하는 지점 셋**

1. `requestJson`이 throw 대신 결과 객체(`ApiResult`)를 돌려주는 선택. 호출 측 코드가 `if (!result.ok)` 분기로 단순해지는 대신, 실패를 무시하고 지나가기도 쉬워집니다.
2. `requestJson`의 `catch` 분기 순서: 컨트롤러가 abort됐으면 reason으로 timeout/aborted를 가르고, 응답 객체가 이미 있으면 malformed, 아니면 network. 이 순서가 맞는지.
3. 429/405를 본문을 읽기 전에 status로 가르는 순서와, 그 외 4xx/5xx에서 envelope 판별(`isErrorResponse`)이 code 5종 집합으로 충분한지.

**`client.ts`가 `routeForecast.types.ts`의 `ErrorCode`/`ErrorResponse`에 의존**하므로 이 PR은 SAL-49 머지 이후 기준입니다. 호출처(`fetchBoard`를 쓰는 판정 보드, `fetchRoutes`를 쓰는 노선 선택)는 SAL-53(라우팅)과 함께 다음 PR에 있습니다.
