### PR TITLE
feat(SAL-53): 진입 동선과 노선 딥링크 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@amplitude/unified": "^1.1.29",
     "react": "^19.2.8",
-    "react-dom": "^19.2.8"
+    "react-dom": "^19.2.8",
+    "react-router": "^8.3.0"
   },
   "devDependencies": {
     "@babel/core": "^8.0.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
+      react-router:
+        specifier: ^8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@babel/core':
         specifier: ^8.0.1
@@ -1744,6 +1747,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
@@ -3026,6 +3032,16 @@ packages:
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
+
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
+    peerDependencies:
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
@@ -5450,6 +5466,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-es@3.1.1: {}
+
   cookie-signature@1.0.7: {}
 
   cookie@0.7.2: {}
@@ -6696,6 +6714,13 @@ snapshots:
       scheduler: 0.27.0
 
   react-refresh@0.18.0: {}
+
+  react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      cookie-es: 3.1.1
+      react: 19.2.8
+    optionalDependencies:
+      react-dom: 19.2.8(react@19.2.8)
 
   react@19.2.8: {}
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,5 +1,10 @@
-import { RouteSelectPage } from "@/pages/route-select";
+import { BrowserRouter } from "react-router";
+import { AppRoutes } from "./routes";
 
 export function App() {
-  return <RouteSelectPage />;
+  return (
+    <BrowserRouter>
+      <AppRoutes />
+    </BrowserRouter>
+  );
 }

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -1,0 +1,13 @@
+import { Route, Routes } from "react-router";
+import { RouteSelectPage } from "@/pages/route-select";
+import { VerdictBoardPage } from "@/pages/verdict-board";
+import { paths } from "@/shared/routing/paths";
+
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route path={paths.routeSelect} element={<RouteSelectPage />} />
+      <Route path={paths.board} element={<VerdictBoardPage />} />
+    </Routes>
+  );
+}

--- a/frontend/src/pages/route-select/components/RouteList.tsx
+++ b/frontend/src/pages/route-select/components/RouteList.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from "react-router";
+import { boardPathFor } from "@/shared/routing/paths";
 import type { RouteCore } from "../api/routeSelect.type";
 import { RouteListItem } from "./RouteListItem";
 
@@ -6,9 +8,9 @@ interface RouteListProps {
 }
 
 export function RouteList({ routes }: RouteListProps) {
+  const navigate = useNavigate();
   const handleSelect = (routeId: RouteCore["id"]) => {
-    void routeId;
-    //TODO: SAL-53에서 판정 보드 이동 로직 구현 예정
+    void navigate(boardPathFor(routeId));
   };
 
   return (

--- a/frontend/src/shared/routing/paths.ts
+++ b/frontend/src/shared/routing/paths.ts
@@ -1,0 +1,8 @@
+export const paths = {
+  routeSelect: "/",
+  board: "/routes/:routeId",
+} as const;
+
+export function boardPathFor(routeId: string): string {
+  return `/routes/${encodeURIComponent(routeId)}`;
+}

--- a/frontend/webpack/webpack.dev.cjs
+++ b/frontend/webpack/webpack.dev.cjs
@@ -5,6 +5,9 @@ const common = require("./webpack.common.cjs");
 
 module.exports = merge(common, {
   mode: "development",
+  output: {
+    publicPath: "/",
+  },
   dotenv: {
     dir: path.resolve(__dirname, "../env"),
   },

--- a/frontend/webpack/webpack.dev.cjs
+++ b/frontend/webpack/webpack.dev.cjs
@@ -5,9 +5,6 @@ const common = require("./webpack.common.cjs");
 
 module.exports = merge(common, {
   mode: "development",
-  output: {
-    publicPath: "/",
-  },
   dotenv: {
     dir: path.resolve(__dirname, "../env"),
   },


### PR DESCRIPTION
## 작업 내용

- `react-router 8` 의존성을 추가하고 `BrowserRouter`와 `AppRoutes`를 연결했습니다.
- `/`에서는 노선 선택 화면을, `/routes/:routeId`에서는 판정 보드를 렌더링하도록 경로를 정의했습니다.
- `shared/routing/paths.ts`에 경로 패턴과 `boardPathFor(routeId)`를 두어 라우트 정의와 실제 이동 URL이 같은 규칙을 사용하도록 했습니다.
- 노선을 선택하면 `RouteList`의 `handleSelect`가 해당 노선 ID로 판정 보드 경로를 만들고 `navigate()`로 이동하도록 연결했습니다.

### 전체 흐름

```text
/ , root page url로 진입
→ RouteSelectPage
→ 노선 선택
→ boardPathFor(routeId)
→ navigate(/routes/{routeId})
→ AppRoutes가 /routes/:routeId와 매칭
→ VerdictBoardPage 렌더링
```

새 탭이나 새로고침으로 딥링크에 바로 들어오는 경우에는 개발 서버의 `historyApiFallback`이 `index.html`을 반환하고, SAL-63의 `publicPath: "/"` 설정으로 번들을 루트에서 불러옵니다. 이후 `BrowserRouter`가 현재 URL을 읽고 판정 보드를 렌더링합니다.

### 고민했던 내용

라우팅 방식부터 이동 책임을 어디에 둘지까지 생각보다 고민할 부분이 많았습니다.

라우팅은 해시 방식, 직접 `pushState/popstate` 구현, `react-router`를 비교했습니다. 현재 dev 서버와 CloudFront 모두 SPA fallback이 준비되어 있어 해시 방식의 장점이 크지 않았고, 파라미터·뒤로가기·딥링크를 직접 관리하는 비용도 피하고 싶어 History API 기반 `react-router`를 선택했습니다.

이동 책임은 `App`이나 `Page`까지 올리면 `RouteList`의 재사용성이 높아진다는 장점이 있었습니다. 다만 현재 도메인에서는 이 목록을 다른 맥락에서 재사용할 가능성보다 북마크나 노선 상태처럼 노선 목록 안쪽 기능이 확장될 가능성이 더 높다고 판단했습니다. 그래서 기존 결정대로 `RouteList`가 노선 ID와 이동을 알고 `RouteListItem`에 핸들러를 내려주는 구조를 유지했습니다.

SAL-53에서는 전달받은 구현 패치와 SAL-71의 기존 인터페이스를 유지해 `button + useNavigate`로 연결했습니다. 목적 URL이 생긴 만큼 장기적으로는 `Link`가 더 시맨틱하다는 의견도 타당하다고 생각해서, 이번 PR의 범위를 다시 넓히기보다는 [SAL-109](https://higgs95.atlassian.net/browse/SAL-109) 후속 티켓으로 분리해두었습니다.

## 확인 사항

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] `/`에서 3330 선택 시 `/routes/204000057`로 이동하는 것을 확인했습니다.
- [x] 브라우저 뒤로가기로 노선 선택 화면에 돌아오는 것을 확인했습니다.

## 참고 사항

- `routeId`를 읽어 실제 판정 보드 데이터를 조회하는 부분은 SAL-50에서 담당합니다. 현재 이 PR은 URL과 화면까지의 동선을 연결하는 범위입니다.
- 허용되지 않은 노선 ID의 오류 화면은 SAL-64 티켓의 구현 범위이므로 이번 티켓에서 구현하지 않았습니다.
- 개발 환경의 `publicPath: "/"`는 SAL-63 PR에 이미 포함되어 있어 이 PR에서는 제거했습니다. 두 PR이 합쳐질 때 같은 `output` 객체에 키가 중복되어 `no-dupe-keys`가 발생하는 문제를 피하기 위한 결정입니다.
- `/routes/:routeId` 직접 진입과 새로고침 동작은 SAL-63의 `publicPath` 설정과 함께 합쳐진 환경에서 완성됩니다.
- RouteList 책임 배치에 관한 고민은 [[SAL-71] RouteList의 노선 도메인 및 선택 책임 배치 결정](https://higgs95.atlassian.net/wiki/spaces/HEM52VQZUW/pages/16121860/SAL-71+RouteList)에 정리해두었습니다.
- 관련 Jira 티켓: [SAL-53](https://higgs95.atlassian.net/browse/SAL-53), [SAL-109](https://higgs95.atlassian.net/browse/SAL-109)


[SAL-109]: https://higgs95.atlassian.net/browse/SAL-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ