### PR TITLE
feat(SAL-84): 수집 묶음과 차량 관측 적재

### DIFF
--- a/backend/src/main/java/com/gustler/backend/api/vehicle/application/LiveVehicleQueryService.java
+++ b/backend/src/main/java/com/gustler/backend/api/vehicle/application/LiveVehicleQueryService.java
@@ -56,11 +56,27 @@ public class LiveVehicleQueryService {
         );
         return overviewOf(
             snapshot,
-            VehicleObservationState.VEHICLES_PRESENT,
+            stateOf(vehicles),
             observedAt,
             staleAt,
             vehicles
         );
+    }
+
+    /**
+     * 상류가 차를 줬어도 내보낼 것이 하나도 없으면 "본 차가 없다" 다.
+     * VEHICLES_PRESENT 에 빈 배열을 실어 보내면 계약이 어긋난다.
+     *
+     * <p>비는 길이 둘이다. 저장할 때 뺀 행(SAL-84)과 읽을 때 거른 행(운행 상태를 해석 못 한 경우)이다.
+     * stored_rows 를 읽는 대신 실제로 내보낼 목록을 보면 둘 다 덮인다.
+     */
+    private VehicleObservationState stateOf(
+        List<ObservedVehicle> vehicles
+    ) {
+        if (vehicles.isEmpty()) {
+            return VehicleObservationState.NO_VEHICLES_OBSERVED;
+        }
+        return VehicleObservationState.VEHICLES_PRESENT;
     }
 
     private boolean isUsableLatestSnapshot(

--- a/backend/src/main/java/com/gustler/backend/api/vehicle/application/LiveVehicleQueryService.java
+++ b/backend/src/main/java/com/gustler/backend/api/vehicle/application/LiveVehicleQueryService.java
@@ -9,6 +9,8 @@ import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true, isolation = Isolation.REPEATABLE_READ)
 public class LiveVehicleQueryService {
+
+    private static final Logger log = LoggerFactory.getLogger(LiveVehicleQueryService.class);
 
     private final VehicleQueryRepository vehicleQueryRepository;
     private final VehicleFreshnessPolicy freshnessPolicy;
@@ -54,9 +58,12 @@ public class LiveVehicleQueryService {
         List<ObservedVehicle> vehicles = vehicleQueryRepository.findVehicles(
             snapshot.latestBatchId()
         );
+        if (vehicles.isEmpty()) {
+            return unreadableObservation(snapshot, observedAt, staleAt);
+        }
         return overviewOf(
             snapshot,
-            stateOf(vehicles),
+            VehicleObservationState.VEHICLES_PRESENT,
             observedAt,
             staleAt,
             vehicles
@@ -64,19 +71,30 @@ public class LiveVehicleQueryService {
     }
 
     /**
-     * 상류가 차를 줬어도 내보낼 것이 하나도 없으면 "본 차가 없다" 다.
-     * VEHICLES_PRESENT 에 빈 배열을 실어 보내면 계약이 어긋난다.
+     * 상류가 차량 행을 줬는데 우리가 하나도 못 읽은 상태.
      *
-     * <p>비는 길이 둘이다. 저장할 때 뺀 행(SAL-84)과 읽을 때 거른 행(운행 상태를 해석 못 한 경우)이다.
-     * stored_rows 를 읽는 대신 실제로 내보낼 목록을 보면 둘 다 덮인다.
+     * <p>"차가 없다"(NO_VEHICLES_OBSERVED)로 내면 안 된다. 상류가 없다고 한 적이 없다.
+     * 상류가 필드 형식을 바꾸면 그때부터 모든 행이 걸러지는데, 0대로 보이면 이상을 알아챌 수가 없다.
+     * 지금 무엇이 다니는지 말해줄 수 없다는 뜻이라 UNKNOWN 이 맞는 자리다.
+     *
+     * <p>계속 나면 상류 계약이 바뀐 것이다. 운영이 알아채라고 WARN 을 남긴다.
      */
-    private VehicleObservationState stateOf(
-        List<ObservedVehicle> vehicles
+    private LiveVehicleOverview unreadableObservation(
+        VehicleSnapshot snapshot,
+        OffsetDateTime observedAt,
+        OffsetDateTime staleAt
     ) {
-        if (vehicles.isEmpty()) {
-            return VehicleObservationState.NO_VEHICLES_OBSERVED;
-        }
-        return VehicleObservationState.VEHICLES_PRESENT;
+        log.warn(
+            "상류가 차량 행을 줬는데 읽어낸 관측이 없다. 노선={} 묶음={}",
+            snapshot.routeId(),
+            snapshot.latestBatchId());
+        return overviewOf(
+            snapshot,
+            VehicleObservationState.UNKNOWN,
+            observedAt,
+            staleAt,
+            List.of()
+        );
     }
 
     private boolean isUsableLatestSnapshot(

--- a/backend/src/main/java/com/gustler/backend/collector/CollectedObservations.java
+++ b/backend/src/main/java/com/gustler/backend/collector/CollectedObservations.java
@@ -1,0 +1,47 @@
+package com.gustler.backend.collector;
+
+import com.gustler.backend.collector.dto.BusLocationResponse.BusLocation;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * 한 판에서 상류가 준 차량을 쌓을 것과 뺀 것으로 가른 결과.
+ *
+ * <p>운행 상태의 뜻을 모르는 차량은 그 행만 뺀다. 한 대 때문에 그 판을 통째로 버리지 않는다.
+ * 상류가 모르는 값을 줄 때 수집을 세우지 않는 것이 이 표의 규칙이고,
+ * station_id 에 FK 를 걸지 않은 것도 같은 이유다.
+ */
+public record CollectedObservations(
+    List<UpstreamObservationRow> storableRows,
+    List<UpstreamObservationRow> excludedRows
+) {
+
+    public CollectedObservations {
+        storableRows = List.copyOf(storableRows);
+        excludedRows = List.copyOf(excludedRows);
+    }
+
+    public static CollectedObservations from(
+        List<BusLocation> buses
+    ) {
+        Map<Boolean, List<UpstreamObservationRow>> rowsByStorable = IntStream.range(0, buses.size())
+            .mapToObj(rowNumber -> toRow(rowNumber, buses.get(rowNumber)))
+            .collect(Collectors.partitioningBy(row -> row.observation().hasKnownRunningState()));
+
+        return new CollectedObservations(rowsByStorable.get(true), rowsByStorable.get(false));
+    }
+
+    /** 상류가 준 행 수. 뺀 행까지 센다. */
+    public int providerRows() {
+        return storableRows.size() + excludedRows.size();
+    }
+
+    private static UpstreamObservationRow toRow(
+        final int rowNumber,
+        BusLocation bus
+    ) {
+        return new UpstreamObservationRow(rowNumber, VehicleObservation.from(bus));
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/CollectedObservations.java
+++ b/backend/src/main/java/com/gustler/backend/collector/CollectedObservations.java
@@ -28,7 +28,7 @@ public record CollectedObservations(
     ) {
         Map<Boolean, List<UpstreamObservationRow>> rowsByStorable = IntStream.range(0, buses.size())
             .mapToObj(rowNumber -> toRow(rowNumber, buses.get(rowNumber)))
-            .collect(Collectors.partitioningBy(row -> row.observation().hasKnownRunningState()));
+            .collect(Collectors.partitioningBy(CollectedObservations::isStorable));
 
         return new CollectedObservations(rowsByStorable.get(true), rowsByStorable.get(false));
     }
@@ -36,6 +36,20 @@ public record CollectedObservations(
     /** 상류가 준 행 수. 뺀 행까지 센다. */
     public int providerRows() {
         return storableRows.size() + excludedRows.size();
+    }
+
+    /**
+     * 쌓을 수 있는 관측인가. 저장할 때 비울 수 없는 값이 다 있어야 한다.
+     *
+     * <p>하나라도 비면 그 행의 INSERT 가 거절되는데, 묶음과 관측이 한 트랜잭션이라
+     * 그 판이 통째로 되감긴다. 차 하나 때문에 나머지 열여섯의 관측과
+     * "수집했다" 는 기록까지 같이 사라진다.
+     */
+    private static boolean isStorable(
+        UpstreamObservationRow row
+    ) {
+        return row.observation().hasKnownStop()
+            && row.observation().hasKnownRunningState();
     }
 
     private static UpstreamObservationRow toRow(

--- a/backend/src/main/java/com/gustler/backend/collector/ObservationAttempt.java
+++ b/backend/src/main/java/com/gustler/backend/collector/ObservationAttempt.java
@@ -1,0 +1,19 @@
+package com.gustler.backend.collector;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 한 판의 호출을 언제 계획해서 언제 보내고 언제 받았나. 몇 번째 시도인지도 같이 든다.
+ *
+ * <p>attemptKey 는 재시도해도 값이 같다. 한 번의 계획에 묶음이 두 개 생기는 것을 DB 가 막는 근거다.
+ * responseReceivedAt 이 관측 시각의 권위다. 상류가 주는 queryTime 이 아니다.
+ */
+public record ObservationAttempt(
+    long routeVersionId,
+    OffsetDateTime scheduledAt,
+    int attemptNumber,
+    String attemptKey,
+    OffsetDateTime requestedAt,
+    OffsetDateTime responseReceivedAt
+) {
+}

--- a/backend/src/main/java/com/gustler/backend/collector/ObservationBatch.java
+++ b/backend/src/main/java/com/gustler/backend/collector/ObservationBatch.java
@@ -1,0 +1,32 @@
+package com.gustler.backend.collector;
+
+/** 저장할 한 판의 기록. 그 판에서 상류가 준 행과 우리가 쌓은 행과 뺀 행을 같이 센다. */
+public record ObservationBatch(
+    ObservationAttempt attempt,
+    ObservationBatchOutcome outcome,
+    int providerRows,
+    int storedRows,
+    int excludedRows,
+    String normalizationVersion
+) {
+
+    /**
+     * 지금 도는 정규화 규칙의 판. 규칙이 바뀌면 올린다.
+     * 응답 원문을 따로 안 남겨서 관측이 사실상 원본이고, 이 값이 있어야
+     * 나중에 어느 규칙으로 접힌 값인지 되짚는다.
+     */
+    public static final String CURRENT_NORMALIZATION_VERSION = "normalization-v1.0.0";
+
+    public static ObservationBatch of(
+        ObservationAttempt attempt,
+        CollectedObservations collected
+    ) {
+        return new ObservationBatch(
+            attempt,
+            ObservationBatchOutcome.forProviderRows(collected.providerRows()),
+            collected.providerRows(),
+            collected.storableRows().size(),
+            collected.excludedRows().size(),
+            CURRENT_NORMALIZATION_VERSION);
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/ObservationBatchOutcome.java
+++ b/backend/src/main/java/com/gustler/backend/collector/ObservationBatchOutcome.java
@@ -1,0 +1,28 @@
+package com.gustler.backend.collector;
+
+/**
+ * 한 판의 결말.
+ *
+ * <p>지금은 성공 두 갈래뿐이다. 실패 갈래와 예약 사다리(예약만 하고 안 보냄 · 보냈는데 결과 모름)는
+ * 호출 장부를 만드는 SAL-85 가 붙인다.
+ */
+public enum ObservationBatchOutcome {
+
+    SUCCESS_ROWS,
+    SUCCESS_EMPTY,
+    ;
+
+    /**
+     * 상류가 준 행 수로 정한다. 우리가 쌓은 행 수가 아니다.
+     * "상류가 차가 없다고 했다"와 "차는 있었는데 우리가 다 뺐다"는 다른 사실이고,
+     * 관측 간격 90초 판정에서 뜻이 갈린다.
+     */
+    public static ObservationBatchOutcome forProviderRows(
+        final int providerRows
+    ) {
+        if (providerRows > 0) {
+            return SUCCESS_ROWS;
+        }
+        return SUCCESS_EMPTY;
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/ObservationLoader.java
+++ b/backend/src/main/java/com/gustler/backend/collector/ObservationLoader.java
@@ -49,11 +49,12 @@ public class ObservationLoader {
     ) {
         for (UpstreamObservationRow row : collected.excludedRows()) {
             log.warn(
-                "뜻을 모르는 운행 상태라 관측을 뺐다. 판본={} 시도키={} 상류행={} 운행상태={}",
+                "쌓을 수 없는 관측을 뺐다. 판본={} 시도키={} 상류행={} 운행상태={} 정류소순번={}",
                 attempt.routeVersionId(),
                 attempt.attemptKey(),
                 row.sourceRowNumber(),
-                row.observation().runningState());
+                row.observation().runningState(),
+                row.observation().stopSequence());
         }
     }
 }

--- a/backend/src/main/java/com/gustler/backend/collector/ObservationLoader.java
+++ b/backend/src/main/java/com/gustler/backend/collector/ObservationLoader.java
@@ -1,0 +1,59 @@
+package com.gustler.backend.collector;
+
+import com.gustler.backend.collector.dto.BusLocationResponse.BusLocation;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 한 판의 호출과 그 판에서 본 차량을 한 트랜잭션에 쌓는다.
+ *
+ * <p>차가 한 대도 없는 판도 묶음을 남긴다. 지운 적이 없어야 관측 간격 90초 판정에서
+ * 연결이 끊긴 자리를 알아본다.
+ */
+@Component
+public class ObservationLoader {
+
+    private static final Logger log = LoggerFactory.getLogger(ObservationLoader.class);
+
+    private final ObservationRepository observationRepository;
+
+    public ObservationLoader(
+        ObservationRepository observationRepository
+    ) {
+        this.observationRepository = observationRepository;
+    }
+
+    @Transactional
+    public long load(
+        ObservationAttempt attempt,
+        List<BusLocation> buses
+    ) {
+        CollectedObservations collected = CollectedObservations.from(buses);
+        logExcludedRows(attempt, collected);
+
+        return observationRepository.save(
+            ObservationBatch.of(attempt, collected),
+            collected.storableRows());
+    }
+
+    /**
+     * 뺀 행은 값 하나하나를 남긴다. 응답 원문을 통째로 찍으면 번호판이 로그로 샌다.
+     * 차량 아이디와 번호판은 찍지 않는다.
+     */
+    private void logExcludedRows(
+        ObservationAttempt attempt,
+        CollectedObservations collected
+    ) {
+        for (UpstreamObservationRow row : collected.excludedRows()) {
+            log.warn(
+                "뜻을 모르는 운행 상태라 관측을 뺐다. 판본={} 시도키={} 상류행={} 운행상태={}",
+                attempt.routeVersionId(),
+                attempt.attemptKey(),
+                row.sourceRowNumber(),
+                row.observation().runningState());
+        }
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/ObservationRepository.java
+++ b/backend/src/main/java/com/gustler/backend/collector/ObservationRepository.java
@@ -1,0 +1,11 @@
+package com.gustler.backend.collector;
+
+import java.util.List;
+
+public interface ObservationRepository {
+
+    long save(
+        ObservationBatch batch,
+        List<UpstreamObservationRow> storableRows
+    );
+}

--- a/backend/src/main/java/com/gustler/backend/collector/UpstreamObservationRow.java
+++ b/backend/src/main/java/com/gustler/backend/collector/UpstreamObservationRow.java
@@ -1,0 +1,11 @@
+package com.gustler.backend.collector;
+
+/**
+ * 상류 응답의 차량 한 줄. 응답에서 몇 번째 줄이었는지와 그 줄을 정규화한 관측을 같이 들고 있다.
+ * 뜻을 모르는 운행 상태의 차량을 빼고 나면 줄 번호가 비므로, 번호를 관측에 붙여 둬야 한다.
+ */
+public record UpstreamObservationRow(
+    int sourceRowNumber,
+    VehicleObservation observation
+) {
+}

--- a/backend/src/main/java/com/gustler/backend/collector/VehicleObservation.java
+++ b/backend/src/main/java/com/gustler/backend/collector/VehicleObservation.java
@@ -43,6 +43,14 @@ public record VehicleObservation(
     }
 
     /**
+     * 이 관측이 어느 정류소의 것인지 아는가.
+     * 순번과 정류소 ID 가 둘 다 있어야 쌓을 수 있다. 둘 다 저장할 때 비울 수 없는 값이다.
+     */
+    public boolean hasKnownStop() {
+        return stopSequence != null && stopId != null;
+    }
+
+    /**
      * 상류가 준 운행 상태가 우리가 뜻을 아는 값인가.
      * 0 이동 중 · 1 도착 중 · 2 지나감 셋뿐이고, 그 밖의 값은 무슨 상황인지 모른다.
      */

--- a/backend/src/main/java/com/gustler/backend/collector/VehicleObservation.java
+++ b/backend/src/main/java/com/gustler/backend/collector/VehicleObservation.java
@@ -18,7 +18,9 @@ public record VehicleObservation(
 
     private static final int LOWEST_CROWD_LEVEL = 1;
     private static final int HIGHEST_CROWD_LEVEL = 4;
+    private static final int MOVING_BETWEEN_STOPS = 0;
     private static final int ARRIVED_AT_STOP = 1;
+    private static final int DEPARTED_FROM_STOP = 2;
 
     public VehicleObservation {
         Objects.requireNonNull(remainingSeats, "잔여석은 아는 것이든 모르는 것이든 있어야 한다");
@@ -38,6 +40,19 @@ public record VehicleObservation(
             bus.vehicleType(),
             bus.routeType(),
             bus.taglessCode());
+    }
+
+    /**
+     * 상류가 준 운행 상태가 우리가 뜻을 아는 값인가.
+     * 0 이동 중 · 1 도착 중 · 2 지나감 셋뿐이고, 그 밖의 값은 무슨 상황인지 모른다.
+     */
+    public boolean hasKnownRunningState() {
+        if (runningState == null) {
+            return false;
+        }
+        return runningState == MOVING_BETWEEN_STOPS
+            || runningState == ARRIVED_AT_STOP
+            || runningState == DEPARTED_FROM_STOP;
     }
 
     /** 이 버스가 지나온 정류소의 순번. 도착 중이면 그 정류소는 아직 안 지났다. */

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/CollectorObservationBatchRepository.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/CollectorObservationBatchRepository.java
@@ -1,0 +1,11 @@
+package com.gustler.backend.collector.persistence.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 이름 앞의 Collector 는 조회 쪽에 같은 표를 보는 리포지터리가 따로 있어서 붙였다.
+ * Spring Data 인터페이스는 빈이고 빈 이름이 단순 클래스 이름에서 나온다.
+ * 이름이 겹치면 BeanDefinitionOverrideException 으로 앱이 안 뜬다.
+ */
+public interface CollectorObservationBatchRepository extends JpaRepository<ObservationBatchJpaEntity, Long> {
+}

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/CollectorVehicleObservationRepository.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/CollectorVehicleObservationRepository.java
@@ -1,0 +1,6 @@
+package com.gustler.backend.collector.persistence.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CollectorVehicleObservationRepository extends JpaRepository<VehicleObservationJpaEntity, Long> {
+}

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/JpaObservationRepository.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/JpaObservationRepository.java
@@ -1,0 +1,40 @@
+package com.gustler.backend.collector.persistence.jpa;
+
+import com.gustler.backend.collector.ObservationBatch;
+import com.gustler.backend.collector.ObservationRepository;
+import com.gustler.backend.collector.UpstreamObservationRow;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JpaObservationRepository implements ObservationRepository {
+
+    private final CollectorObservationBatchRepository observationBatchRepository;
+    private final CollectorVehicleObservationRepository vehicleObservationRepository;
+
+    public JpaObservationRepository(
+        CollectorObservationBatchRepository observationBatchRepository,
+        CollectorVehicleObservationRepository vehicleObservationRepository
+    ) {
+        this.observationBatchRepository = observationBatchRepository;
+        this.vehicleObservationRepository = vehicleObservationRepository;
+    }
+
+    @Override
+    public long save(
+        ObservationBatch batch,
+        List<UpstreamObservationRow> storableRows
+    ) {
+        ObservationBatchJpaEntity savedBatch =
+            observationBatchRepository.save(new ObservationBatchJpaEntity(batch));
+
+        vehicleObservationRepository.saveAll(storableRows.stream()
+            .map(row -> new VehicleObservationJpaEntity(
+                savedBatch.getId(),
+                batch.attempt().routeVersionId(),
+                row))
+            .toList());
+
+        return savedBatch.getId();
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/ObservationBatchJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/ObservationBatchJpaEntity.java
@@ -3,6 +3,7 @@ package com.gustler.backend.collector.persistence.jpa;
 import com.gustler.backend.collector.ObservationAttempt;
 import com.gustler.backend.collector.ObservationBatch;
 import com.gustler.backend.collector.ObservationBatchOutcome;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -15,6 +16,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 조회 쪽도 이 표를 매핑한다. 같은 물리 컬럼에 논리명이 둘이면 Hibernate 가
+ * DuplicateMappingException 을 내고 앱이 안 뜬다. 그래서 전 필드에 @Column(name) 을 명시한다.
+ */
 @Entity(name = "CollectorObservationBatch")
 @Table(name = "observation_batch")
 @Getter
@@ -25,27 +30,38 @@ public class ObservationBatchJpaEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "route_version_id")
     private Long routeVersionId;
 
+    @Column(name = "scheduled_at")
     private OffsetDateTime scheduledAt;
 
+    @Column(name = "attempt_number")
     private Integer attemptNumber;
 
+    @Column(name = "attempt_key")
     private String attemptKey;
 
+    @Column(name = "requested_at")
     private OffsetDateTime requestedAt;
 
+    @Column(name = "response_received_at")
     private OffsetDateTime responseReceivedAt;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "outcome")
     private ObservationBatchOutcome outcome;
 
+    @Column(name = "provider_rows")
     private Integer providerRows;
 
+    @Column(name = "stored_rows")
     private Integer storedRows;
 
+    @Column(name = "excluded_rows")
     private Integer excludedRows;
 
+    @Column(name = "normalization_version")
     private String normalizationVersion;
 
     public ObservationBatchJpaEntity(

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/ObservationBatchJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/ObservationBatchJpaEntity.java
@@ -1,0 +1,67 @@
+package com.gustler.backend.collector.persistence.jpa;
+
+import com.gustler.backend.collector.ObservationAttempt;
+import com.gustler.backend.collector.ObservationBatch;
+import com.gustler.backend.collector.ObservationBatchOutcome;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "CollectorObservationBatch")
+@Table(name = "observation_batch")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ObservationBatchJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long routeVersionId;
+
+    private OffsetDateTime scheduledAt;
+
+    private Integer attemptNumber;
+
+    private String attemptKey;
+
+    private OffsetDateTime requestedAt;
+
+    private OffsetDateTime responseReceivedAt;
+
+    @Enumerated(EnumType.STRING)
+    private ObservationBatchOutcome outcome;
+
+    private Integer providerRows;
+
+    private Integer storedRows;
+
+    private Integer excludedRows;
+
+    private String normalizationVersion;
+
+    public ObservationBatchJpaEntity(
+        ObservationBatch batch
+    ) {
+        ObservationAttempt attempt = batch.attempt();
+        this.routeVersionId = attempt.routeVersionId();
+        this.scheduledAt = attempt.scheduledAt();
+        this.attemptNumber = attempt.attemptNumber();
+        this.attemptKey = attempt.attemptKey();
+        this.requestedAt = attempt.requestedAt();
+        this.responseReceivedAt = attempt.responseReceivedAt();
+        this.outcome = batch.outcome();
+        this.providerRows = batch.providerRows();
+        this.storedRows = batch.storedRows();
+        this.excludedRows = batch.excludedRows();
+        this.normalizationVersion = batch.normalizationVersion();
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/VehicleObservationJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/VehicleObservationJpaEntity.java
@@ -1,0 +1,100 @@
+package com.gustler.backend.collector.persistence.jpa;
+
+import com.gustler.backend.collector.RemainingSeats;
+import com.gustler.backend.collector.RemainingSeats.Known;
+import com.gustler.backend.collector.RemainingSeats.Unknown;
+import com.gustler.backend.collector.SeatUnknownReason;
+import com.gustler.backend.collector.UpstreamObservationRow;
+import com.gustler.backend.collector.VehicleObservation;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * vehicle_trip_key 는 매핑하지 않는다. 여정을 어디서 가를지 문턱값이 아직 없어서
+ * 지금 채우면 뜻이 없는 값이 들어간다. 열은 NULL 허용으로 이미 있다.
+ */
+@Entity(name = "CollectorVehicleObservation")
+@Table(name = "vehicle_observation")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VehicleObservationJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long observationBatchId;
+
+    private Long routeVersionId;
+
+    private Integer sourceRowNumber;
+
+    private String vehicleId;
+
+    private String plateNumber;
+
+    private Integer stopOrder;
+
+    private String stopId;
+
+    private Integer passedStopOrder;
+
+    private Integer runningState;
+
+    private Integer remainingSeats;
+
+    @Enumerated(EnumType.STRING)
+    private SeatUnknownReason seatUnknownReason;
+
+    private Integer crowdLevel;
+
+    private Integer vehicleType;
+
+    private Integer routeType;
+
+    private Integer tagless;
+
+    public VehicleObservationJpaEntity(
+        final long observationBatchId,
+        final long routeVersionId,
+        UpstreamObservationRow row
+    ) {
+        VehicleObservation observation = row.observation();
+        this.observationBatchId = observationBatchId;
+        this.routeVersionId = routeVersionId;
+        this.sourceRowNumber = row.sourceRowNumber();
+        this.vehicleId = observation.vehicleId();
+        this.plateNumber = observation.plateNumber();
+        this.stopOrder = observation.stopSequence();
+        this.stopId = observation.stopId();
+        this.passedStopOrder = observation.passedStopOrder();
+        this.runningState = observation.runningState();
+        this.crowdLevel = observation.crowdLevel();
+        this.vehicleType = observation.vehicleType();
+        this.routeType = observation.routeType();
+        this.tagless = observation.tagless();
+        applySeats(observation.remainingSeats());
+    }
+
+    /** 잔여석은 아는 값이거나 모르는 사유다. 둘 중 하나만 채운다. DB 도 CHECK 로 같은 것을 막는다. */
+    private void applySeats(
+        RemainingSeats seats
+    ) {
+        switch (seats) {
+            case Known known -> {
+                this.remainingSeats = known.seats();
+                this.seatUnknownReason = null;
+            }
+            case Unknown unknown -> {
+                this.remainingSeats = null;
+                this.seatUnknownReason = unknown.reason();
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/VehicleObservationJpaEntity.java
+++ b/backend/src/main/java/com/gustler/backend/collector/persistence/jpa/VehicleObservationJpaEntity.java
@@ -6,6 +6,7 @@ import com.gustler.backend.collector.RemainingSeats.Unknown;
 import com.gustler.backend.collector.SeatUnknownReason;
 import com.gustler.backend.collector.UpstreamObservationRow;
 import com.gustler.backend.collector.VehicleObservation;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -17,7 +18,10 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 /**
- * vehicle_trip_key 는 매핑하지 않는다. 여정을 어디서 가를지 문턱값이 아직 없어서
+ * 조회 쪽도 이 표를 매핑한다. 같은 물리 컬럼에 논리명이 둘이면 Hibernate 가
+ * DuplicateMappingException 을 내고 앱이 안 뜬다. 그래서 전 필드에 @Column(name) 을 명시한다.
+ *
+ * <p>vehicle_trip_key 는 매핑하지 않는다. 여정을 어디서 가를지 문턱값이 아직 없어서
  * 지금 채우면 뜻이 없는 값이 들어간다. 열은 NULL 허용으로 이미 있다.
  */
 @Entity(name = "CollectorVehicleObservation")
@@ -29,35 +33,50 @@ public class VehicleObservationJpaEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "observation_batch_id")
     private Long observationBatchId;
 
+    @Column(name = "route_version_id")
     private Long routeVersionId;
 
+    @Column(name = "source_row_number")
     private Integer sourceRowNumber;
 
+    @Column(name = "vehicle_id")
     private String vehicleId;
 
+    @Column(name = "plate_number")
     private String plateNumber;
 
+    @Column(name = "stop_order")
     private Integer stopOrder;
 
+    @Column(name = "stop_id")
     private String stopId;
 
+    @Column(name = "passed_stop_order")
     private Integer passedStopOrder;
 
+    @Column(name = "running_state")
     private Integer runningState;
 
+    @Column(name = "remaining_seats")
     private Integer remainingSeats;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "seat_unknown_reason")
     private SeatUnknownReason seatUnknownReason;
 
+    @Column(name = "crowd_level")
     private Integer crowdLevel;
 
+    @Column(name = "vehicle_type")
     private Integer vehicleType;
 
+    @Column(name = "route_type")
     private Integer routeType;
 
+    @Column(name = "tagless")
     private Integer tagless;
 
     public VehicleObservationJpaEntity(

--- a/backend/src/main/resources/db/migration/V4__observation.sql
+++ b/backend/src/main/resources/db/migration/V4__observation.sql
@@ -31,6 +31,9 @@ ALTER TABLE vehicle_observation
 ALTER TABLE vehicle_observation
     ADD CONSTRAINT ck_observation_running_state_value
         CHECK (running_state IN (0, 1, 2)),
+    -- 첫 정류소에 도착 중이면 0 이다. 그보다 작은 값은 뜻이 없다
+    ADD CONSTRAINT ck_observation_passed_stop_order_not_negative
+        CHECK (passed_stop_order >= 0),
     -- 잔여석은 아는 값이거나 모르는 사유이고, 둘 다이거나 둘 다 아닌 행은 없다
     ADD CONSTRAINT ck_observation_seats_exclusive_with_reason
         CHECK ((remaining_seats IS NULL) <> (seat_unknown_reason IS NULL)),
@@ -48,3 +51,10 @@ ALTER TABLE vehicle_observation
 -- 한 묶음의 행은 같은 규칙으로 접히므로 판 단위로 들고 있는다.
 ALTER TABLE observation_batch
     ADD COLUMN normalization_version varchar(40) NOT NULL;
+
+-- V3 의 주석이 stops_to_target 을 "target_stop_order - 관측 stop_order" 라고 적었는데 틀렸다.
+-- stop_order 는 stationSeq 원문이라 도착 중인 차량에서는 아직 안 지난 정류소를 가리킨다.
+-- 6번에 도착 중인 차가 10번을 예보하면 그 기준으로 4 가 되는데 실제로는 5 다.
+-- V3 은 이미 머지돼서 checksum 때문에 못 고치므로 여기서 열 주석으로 바로잡는다.
+COMMENT ON COLUMN seat_forecast.stops_to_target IS
+    'target_stop_order - vehicle_observation.passed_stop_order. stop_order 가 아니다.';

--- a/backend/src/main/resources/db/migration/V4__observation.sql
+++ b/backend/src/main/resources/db/migration/V4__observation.sql
@@ -1,0 +1,50 @@
+-- 관측 INSERT 를 배선하는 티켓이 값의 범위 규칙(CHECK)을 같이 조인다. SAL-84.
+--
+-- V1__collector.sql 2번 줄이 그 목록을 "SAL-82 · SAL-85 · SAL-88" 이라고 적고 있는데 SAL-84 가 빠져 있다.
+-- V1 은 고치지 않는다. Flyway 의 checksum 은 주석까지 포함해 계산해서, 한 글자만 바꿔도
+-- 그 파일을 이미 돌린 DB 가 기동을 거부한다. 테스트는 매번 새 컨테이너로 V1 부터 다시 돌아서
+-- CI 가 그것을 못 잡는다. 그래서 V1 은 그대로 두고 빠진 몫을 여기에 적는다.
+--
+-- 두 표에 행이 하나도 없다는 전제로 NOT NULL 을 기본값 없이 붙인다.
+-- VehicleObservation.from() 을 부르는 곳이 여태 없어서 관측이 쌓인 적이 없다.
+
+-- observation_batch.response_received_at 과 늘 같은 값이라 중복이다.
+-- 한 묶음에 딸린 행은 관측 시각이 다 같아서 행마다 들고 있을 이유가 없다.
+ALTER TABLE vehicle_observation
+    DROP COLUMN observed_at;
+
+ALTER TABLE vehicle_observation
+    -- 잔여석을 모를 때 왜 모르는지. 아는 값과 둘 중 하나만 있다
+    ADD COLUMN seat_unknown_reason varchar(20),
+    -- 이 버스가 지나온 정류소의 순번. 도착 중이면 그 정류소는 아직 안 지났다.
+    -- 계산은 도메인이 하고 DB 생성 열은 안 쓴다. processor 는 collector 를 못 봐서 이 열이 유일한 통로다.
+    -- 첫 정류소에 도착 중인 버스는 0 이다. 지나온 정류소가 없다는 뜻이라 정상이다
+    ADD COLUMN passed_stop_order integer NOT NULL;
+
+-- 뜻을 모르는 운행 상태의 관측은 저장 단계에서 행 단위로 뺀다.
+-- 그런 행이 하나 들어오면 /vehicles 의 phase 가 ARRIVING · DEPARTED · IN_TRANSIT 셋으로
+-- 고정이라 담을 자리가 없어서 그 노선 응답 전체가 500 으로 나간다.
+-- 거르는 코드가 틀려도 조회가 500 이 안 나도록 DB 가 한 번 더 막는다.
+ALTER TABLE vehicle_observation
+    ALTER COLUMN running_state SET NOT NULL;
+
+ALTER TABLE vehicle_observation
+    ADD CONSTRAINT ck_observation_running_state_value
+        CHECK (running_state IN (0, 1, 2)),
+    -- 잔여석은 아는 값이거나 모르는 사유이고, 둘 다이거나 둘 다 아닌 행은 없다
+    ADD CONSTRAINT ck_observation_seats_exclusive_with_reason
+        CHECK ((remaining_seats IS NULL) <> (seat_unknown_reason IS NULL)),
+    -- 상류가 주는 음수는 "모른다"는 신호라 정규화가 사유로 접는다. 여기 남는 값은 실제 좌석 수다
+    ADD CONSTRAINT ck_observation_seats_not_negative
+        CHECK (remaining_seats >= 0),
+    ADD CONSTRAINT ck_observation_seat_unknown_reason_value
+        CHECK (seat_unknown_reason IN ('REPORTED_UNKNOWN', 'NOT_REPORTED')),
+    -- 상류의 0 은 미제공이라 정규화가 비운다. 여기 남는 값은 실제 혼잡도다
+    ADD CONSTRAINT ck_observation_crowd_level_range
+        CHECK (crowd_level BETWEEN 1 AND 4);
+
+-- 어느 정규화 규칙으로 접힌 값인가. 원문을 따로 안 남겨서 vehicle_observation 이 사실상 원본이고,
+-- 이 값이 있어야 나중에 어느 규칙의 산출물인지 되짚는다.
+-- 한 묶음의 행은 같은 규칙으로 접히므로 판 단위로 들고 있는다.
+ALTER TABLE observation_batch
+    ADD COLUMN normalization_version varchar(40) NOT NULL;

--- a/backend/src/test/java/com/gustler/backend/SchemaMigrationTest.java
+++ b/backend/src/test/java/com/gustler/backend/SchemaMigrationTest.java
@@ -25,12 +25,12 @@ class SchemaMigrationTest {
         // then
         assertThat(actual)
             .extracting(info -> info.getVersion().getVersion())
-            .containsExactly("1", "2", "3");
+            .containsExactly("1", "2", "3", "4");
         assertThat(flyway.info().pending()).isEmpty();
     }
 
     @Test
-    void 앱을_다시_띄우면_기존에_돌았던_V1_V2_V3은_처음_실행됐던_시각을_유지하고_실행되지_않는다() {
+    void 앱을_다시_띄우면_기존에_돌았던_V1부터_V4는_처음_실행됐던_시각을_유지하고_실행되지_않는다() {
         // given
         List<Date> firstRun = installedOn();
 

--- a/backend/src/test/java/com/gustler/backend/VehicleObservationTableTest.java
+++ b/backend/src/test/java/com/gustler/backend/VehicleObservationTableTest.java
@@ -9,6 +9,9 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -22,12 +25,22 @@ class VehicleObservationTableTest {
     private static final String ROUTE_204000057 = "204000057";
     private static final String STOP_205000217 = "205000217";
     private static final int STOP_ORDER = 6;
+    private static final int PASSED_STOP_ORDER = 6;
     private static final String VEHICLE_204000206 = "204000206";
     private static final String VEHICLE_204003542 = "204003542";
     private static final long MISSING_BATCH_ID = 9_999_999L;
     private static final String CONTENT_DIGEST = "0".repeat(64);
+    private static final String NORMALIZATION_VERSION = "normalization-v1.0.0";
     private static final OffsetDateTime OBSERVED_AT = OffsetDateTime.parse("2026-08-19T11:14:04.911+09:00");
     private static final LocalDateTime SEOUL_WALL_CLOCK = LocalDateTime.of(2026, 8, 19, 11, 14, 4, 911_000_000);
+
+    private static final int RUNNING_STATE_DEPARTED = 2;
+    private static final int SEATS_43 = 43;
+    private static final int CROWD_LEVEL_3 = 3;
+    private static final String REPORTED_UNKNOWN = "REPORTED_UNKNOWN";
+    private static final String ATTEMPT_KEY = "204000057-2026-08-19T11:14";
+    private static final String ATTEMPT_KEY_IN_KST = "204000057-2026-08-19T11:14-kst";
+    private static final String ATTEMPT_KEY_IN_UTC = "204000057-2026-08-19T11:14-utc";
 
     @Autowired
     private JdbcClient jdbcClient;
@@ -40,23 +53,23 @@ class VehicleObservationTableTest {
         final long routeId = insertRoute();
         routeVersionId = insertRouteVersion(routeId);
         insertRouteStop(routeVersionId);
-        batchId = insertObservationBatch(routeVersionId);
+        batchId = insertObservationBatch(ATTEMPT_KEY, OBSERVED_AT);
     }
 
     @Test
     void 차량_관측은_수집_묶음이_먼저_있어야_저장된다() {
         // when & then
-        assertThatThrownBy(() -> insertObservation(MISSING_BATCH_ID, VEHICLE_204000206, 0, OBSERVED_AT))
+        assertThatThrownBy(() -> insertObservation(MISSING_BATCH_ID, VEHICLE_204000206, 0))
             .isInstanceOf(DataIntegrityViolationException.class);
     }
 
     @Test
     void 수집이_재시도되어도_같은_묶음의_같은_버스는_한_번만_저장된다() {
         // given
-        insertObservation(batchId, VEHICLE_204000206, 0, OBSERVED_AT);
+        insertObservation(batchId, VEHICLE_204000206, 0);
 
         // when & then
-        assertThatThrownBy(() -> insertObservation(batchId, VEHICLE_204000206, 1, OBSERVED_AT))
+        assertThatThrownBy(() -> insertObservation(batchId, VEHICLE_204000206, 1))
             .isInstanceOf(DataIntegrityViolationException.class);
     }
 
@@ -67,21 +80,103 @@ class VehicleObservationTableTest {
         OffsetDateTime inUtc = OffsetDateTime.parse("2026-08-19T02:14:04.911Z");
 
         // when
-        insertObservation(batchId, VEHICLE_204000206, 0, inKst);
-        insertObservation(batchId, VEHICLE_204003542, 1, inUtc);
+        insertObservationBatch(ATTEMPT_KEY_IN_KST, inKst);
+        insertObservationBatch(ATTEMPT_KEY_IN_UTC, inUtc);
         List<LocalDateTime> actual = jdbcClient
             .sql("""
-                SELECT observed_at AT TIME ZONE 'Asia/Seoul'
-                FROM vehicle_observation
-                WHERE observation_batch_id = ?
-                ORDER BY source_row_number
+                SELECT response_received_at AT TIME ZONE 'Asia/Seoul'
+                FROM observation_batch
+                WHERE attempt_key IN (?, ?)
+                ORDER BY attempt_key
                 """)
-            .param(batchId)
+            .params(ATTEMPT_KEY_IN_KST, ATTEMPT_KEY_IN_UTC)
             .query(LocalDateTime.class)
             .list();
 
         // then
         assertThat(actual).containsExactly(SEOUL_WALL_CLOCK, SEOUL_WALL_CLOCK);
+    }
+
+    @Test
+    void 잔여석을_알면_모르는_사유가_비어_있어야_저장된다() {
+        // when & then
+        assertThatThrownBy(() -> insertObservationWithSeats(SEATS_43, REPORTED_UNKNOWN))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void 잔여석을_모르면_사유만_두고_저장된다() {
+        // when
+        insertObservationWithSeats(null, REPORTED_UNKNOWN);
+
+        // then
+        assertThat(storedRowCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 잔여석과_모르는_사유_중_하나는_있어야_저장된다() {
+        // when & then
+        assertThatThrownBy(() -> insertObservationWithSeats(null, null))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void 아는_잔여석은_0석_이상이어야_저장된다() {
+        // when & then
+        assertThatThrownBy(() -> insertObservationWithSeats(-1, null))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void 잔여석을_모르는_사유는_REPORTED_UNKNOWN과_NOT_REPORTED만_저장된다() {
+        // when & then
+        assertThatThrownBy(() -> insertObservationWithSeats(null, "SENSOR_BROKEN"))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4})
+    void 혼잡도_1부터_4는_그대로_저장된다(
+        final int crowdLevel
+    ) {
+        // when
+        insertObservationWithCrowdLevel(crowdLevel);
+
+        // then
+        assertThat(storedRowCount()).isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 5})
+    void 혼잡도는_1부터_4까지만_저장된다(
+        final int crowdLevel
+    ) {
+        // when & then
+        assertThatThrownBy(() -> insertObservationWithCrowdLevel(crowdLevel))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2})
+    void 운행_상태_0과_1과_2는_그대로_저장된다(
+        final int runningState
+    ) {
+        // when
+        insertObservationWithRunningState(runningState);
+
+        // then
+        assertThat(storedRowCount()).isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(ints = {3, -1})
+    void 운행_상태는_0과_1과_2만_저장된다(
+        Integer runningState
+    ) {
+        // when & then
+        assertThatThrownBy(() -> insertObservationWithRunningState(runningState))
+            .isInstanceOf(DataIntegrityViolationException.class);
     }
 
     private long insertRoute() {
@@ -123,15 +218,20 @@ class VehicleObservationTableTest {
     }
 
     private long insertObservationBatch(
-        final long versionId
+        String attemptKey,
+        OffsetDateTime responseReceivedAt
     ) {
         return jdbcClient.sql("""
                 INSERT INTO observation_batch (
-                    route_version_id, scheduled_at, attempt_number, attempt_key, requested_at, outcome
-                ) VALUES (?, ?, ?, ?, ?, ?)
+                    route_version_id, scheduled_at, attempt_number, attempt_key,
+                    requested_at, response_received_at, outcome, normalization_version
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 RETURNING id
                 """)
-            .params(versionId, OBSERVED_AT, 1, "204000057-2026-08-19T11:14", OBSERVED_AT, "SUCCESS_ROWS")
+            .params(
+                routeVersionId, OBSERVED_AT, 1, attemptKey,
+                OBSERVED_AT, responseReceivedAt, "SUCCESS_ROWS", NORMALIZATION_VERSION
+            )
             .query(Long.class)
             .single();
     }
@@ -139,19 +239,66 @@ class VehicleObservationTableTest {
     private void insertObservation(
         final long targetBatchId,
         String vehicleId,
+        final int sourceRowNumber
+    ) {
+        insertObservation(
+            targetBatchId, vehicleId, sourceRowNumber,
+            RUNNING_STATE_DEPARTED, SEATS_43, null, CROWD_LEVEL_3);
+    }
+
+    private void insertObservationWithSeats(
+        Integer remainingSeats,
+        String seatUnknownReason
+    ) {
+        insertObservation(
+            batchId, VEHICLE_204003542, 0,
+            RUNNING_STATE_DEPARTED, remainingSeats, seatUnknownReason, CROWD_LEVEL_3);
+    }
+
+    private void insertObservationWithCrowdLevel(
+        Integer crowdLevel
+    ) {
+        insertObservation(
+            batchId, VEHICLE_204003542, 0,
+            RUNNING_STATE_DEPARTED, SEATS_43, null, crowdLevel);
+    }
+
+    private void insertObservationWithRunningState(
+        Integer runningState
+    ) {
+        insertObservation(
+            batchId, VEHICLE_204003542, 0,
+            runningState, SEATS_43, null, CROWD_LEVEL_3);
+    }
+
+    private void insertObservation(
+        final long targetBatchId,
+        String vehicleId,
         final int sourceRowNumber,
-        OffsetDateTime observedAt
+        Integer runningState,
+        Integer remainingSeats,
+        String seatUnknownReason,
+        Integer crowdLevel
     ) {
         jdbcClient.sql("""
                 INSERT INTO vehicle_observation (
                     observation_batch_id, route_version_id, source_row_number,
-                    observed_at, vehicle_id, stop_order, stop_id
-                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    vehicle_id, stop_order, stop_id, passed_stop_order,
+                    running_state, remaining_seats, seat_unknown_reason, crowd_level
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """)
             .params(
                 targetBatchId, routeVersionId, sourceRowNumber,
-                observedAt, vehicleId, STOP_ORDER, STOP_205000217
+                vehicleId, STOP_ORDER, STOP_205000217, PASSED_STOP_ORDER,
+                runningState, remainingSeats, seatUnknownReason, crowdLevel
             )
             .update();
+    }
+
+    private int storedRowCount() {
+        return jdbcClient.sql("SELECT count(*) FROM vehicle_observation WHERE observation_batch_id = ?")
+            .param(batchId)
+            .query(Integer.class)
+            .single();
     }
 }

--- a/backend/src/test/java/com/gustler/backend/VehicleObservationTableTest.java
+++ b/backend/src/test/java/com/gustler/backend/VehicleObservationTableTest.java
@@ -179,6 +179,22 @@ class VehicleObservationTableTest {
             .isInstanceOf(DataIntegrityViolationException.class);
     }
 
+    @Test
+    void 통과_순번은_0석_이상이어야_저장된다() {
+        // when & then
+        assertThatThrownBy(() -> insertObservationWithPassedStopOrder(-1))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void 첫_정류소에_도착_중인_차량의_통과_순번_0도_저장된다() {
+        // when
+        insertObservationWithPassedStopOrder(0);
+
+        // then
+        assertThat(storedRowCount()).isEqualTo(1);
+    }
+
     private long insertRoute() {
         return jdbcClient.sql("""
                 INSERT INTO route (
@@ -291,6 +307,24 @@ class VehicleObservationTableTest {
                 targetBatchId, routeVersionId, sourceRowNumber,
                 vehicleId, STOP_ORDER, STOP_205000217, PASSED_STOP_ORDER,
                 runningState, remainingSeats, seatUnknownReason, crowdLevel
+            )
+            .update();
+    }
+
+    private void insertObservationWithPassedStopOrder(
+        final int passedStopOrder
+    ) {
+        jdbcClient.sql("""
+                INSERT INTO vehicle_observation (
+                    observation_batch_id, route_version_id, source_row_number,
+                    vehicle_id, stop_order, stop_id, passed_stop_order,
+                    running_state, remaining_seats, crowd_level
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """)
+            .params(
+                batchId, routeVersionId, 0,
+                VEHICLE_204003542, STOP_ORDER, STOP_205000217, passedStopOrder,
+                RUNNING_STATE_DEPARTED, SEATS_43, CROWD_LEVEL_3
             )
             .update();
     }

--- a/backend/src/test/java/com/gustler/backend/api/board/support/BoardDatabaseFixture.java
+++ b/backend/src/test/java/com/gustler/backend/api/board/support/BoardDatabaseFixture.java
@@ -6,6 +6,12 @@ import org.springframework.jdbc.core.simple.JdbcClient;
 
 public class BoardDatabaseFixture {
 
+    private static final String NORMALIZATION_VERSION = "normalization-v1.0.0";
+    /** 지나온 정류소 순번이 stop_order 와 같아지는 상태다. 이 픽스처는 차량 위치만 쓰고 상태는 안 본다. */
+    private static final int RUNNING_STATE_DEPARTED = 2;
+    /** 잔여석은 아는 값이거나 모르는 사유 둘 중 하나만 있어야 한다. 이 픽스처는 좌석을 안 본다. */
+    private static final String NOT_REPORTED = "NOT_REPORTED";
+
     private final JdbcClient jdbcClient;
 
     public BoardDatabaseFixture(JdbcClient jdbcClient) {
@@ -137,11 +143,13 @@ public class BoardDatabaseFixture {
                 INSERT INTO observation_batch (
                     route_version_id, scheduled_at, attempt_number, attempt_key,
                     requested_at, response_received_at, forecast_completed_at,
-                    completed_at, outcome, provider_rows, stored_rows, excluded_rows
+                    completed_at, outcome, provider_rows, stored_rows, excluded_rows,
+                    normalization_version
                 ) VALUES (
                     :routeVersionId, :scheduledAt, 1, :attemptKey,
                     :requestedAt, :responseReceivedAt, :forecastCompletedAt,
-                    :completedAt, :outcome, :providerRows, :storedRows, 0
+                    :completedAt, :outcome, :providerRows, :storedRows, 0,
+                    :normalizationVersion
                 )
                 RETURNING id
                 """)
@@ -155,10 +163,16 @@ public class BoardDatabaseFixture {
             .param("outcome", outcome)
             .param("providerRows", storedRows)
             .param("storedRows", storedRows)
+            .param("normalizationVersion", NORMALIZATION_VERSION)
             .query(Long.class)
             .single();
     }
 
+    /**
+     * observedAt 은 더 이상 저장되지 않는다. vehicle_observation.observed_at 이 지워졌고
+     * 관측 시각은 묶음의 response_received_at 이 권위다. 이 클래스를 쓰는 테스트가 두 곳에
+     * 같은 값을 넘기고 있어 뜻은 그대로다. 파라미터를 지우려면 호출부까지 손봐야 해서 남겨뒀다.
+     */
     public long insertObservation(
         RouteContext route,
         final long batchId,
@@ -171,20 +185,23 @@ public class BoardDatabaseFixture {
         return jdbcClient.sql("""
                 INSERT INTO vehicle_observation (
                     observation_batch_id, route_version_id, source_row_number,
-                    observed_at, vehicle_id, stop_order, stop_id
+                    vehicle_id, stop_order, stop_id,
+                    passed_stop_order, running_state, seat_unknown_reason
                 ) VALUES (
                     :batchId, :routeVersionId, :sourceRowNumber,
-                    :observedAt, :vehicleId, :stopOrder, :stopId
+                    :vehicleId, :stopOrder, :stopId,
+                    :stopOrder, :runningState, :seatUnknownReason
                 )
                 RETURNING id
                 """)
             .param("batchId", batchId)
             .param("routeVersionId", route.routeVersionId())
             .param("sourceRowNumber", sourceRowNumber)
-            .param("observedAt", observedAt)
             .param("vehicleId", vehicleId)
             .param("stopOrder", stopOrder)
             .param("stopId", stopId)
+            .param("runningState", RUNNING_STATE_DEPARTED)
+            .param("seatUnknownReason", NOT_REPORTED)
             .query(Long.class)
             .single();
     }

--- a/backend/src/test/java/com/gustler/backend/api/vehicle/controller/LiveVehicleApiContractTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/vehicle/controller/LiveVehicleApiContractTest.java
@@ -133,15 +133,16 @@ class LiveVehicleApiContractTest {
     //   애초에 안 쌓는 것  VehicleObservationTableTest.운행_상태는_0과_1과_2만_저장된다
 
     @Test
-    void 상류가_차를_줬어도_내보낼_관측이_없으면_본_차가_없는_것으로_반환한다() throws Exception {
-        // 저장 단계가 전부 뺀 판이다. outcome 은 SUCCESS_ROWS 인데 쌓인 관측이 없다.
+    void 상류가_차량_행을_줬는데_읽어낸_관측이_없으면_모르는_것으로_반환한다() throws Exception {
+        // 저장 단계가 전부 뺀 batch 다. outcome 은 SUCCESS_ROWS 인데 쌓인 관측이 없다.
+        // 상류가 "차가 없다" 고 한 적이 없으므로 NO_VEHICLES_OBSERVED 가 아니다.
         RouteContext route = insertCurrentRoute();
         OffsetDateTime observedAt = NOW.minusMinutes(1);
         insertSuccessfulBatch(route, observedAt, "SUCCESS_ROWS", 0);
 
         mockMvc.perform(get("/api/v1/routes/{routeId}/vehicles", ROUTE_ID))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.observation.state").value("NO_VEHICLES_OBSERVED"))
+            .andExpect(jsonPath("$.observation.state").value("UNKNOWN"))
             .andExpect(jsonPath("$.vehicles").isEmpty());
     }
 

--- a/backend/src/test/java/com/gustler/backend/api/vehicle/controller/LiveVehicleApiContractTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/vehicle/controller/LiveVehicleApiContractTest.java
@@ -133,6 +133,19 @@ class LiveVehicleApiContractTest {
     //   애초에 안 쌓는 것  VehicleObservationTableTest.운행_상태는_0과_1과_2만_저장된다
 
     @Test
+    void 상류가_차를_줬어도_내보낼_관측이_없으면_본_차가_없는_것으로_반환한다() throws Exception {
+        // 저장 단계가 전부 뺀 판이다. outcome 은 SUCCESS_ROWS 인데 쌓인 관측이 없다.
+        RouteContext route = insertCurrentRoute();
+        OffsetDateTime observedAt = NOW.minusMinutes(1);
+        insertSuccessfulBatch(route, observedAt, "SUCCESS_ROWS", 0);
+
+        mockMvc.perform(get("/api/v1/routes/{routeId}/vehicles", ROUTE_ID))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.observation.state").value("NO_VEHICLES_OBSERVED"))
+            .andExpect(jsonPath("$.vehicles").isEmpty());
+    }
+
+    @Test
     void SUCCESS_EMPTY는_운행_종료로_단정하지_않고_빈_배열의_정상_응답을_반환한다() throws Exception {
         RouteContext route = insertCurrentRoute();
         OffsetDateTime observedAt = NOW.minusMinutes(1);

--- a/backend/src/test/java/com/gustler/backend/api/vehicle/controller/LiveVehicleApiContractTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/vehicle/controller/LiveVehicleApiContractTest.java
@@ -37,6 +37,10 @@ class LiveVehicleApiContractTest {
         "2026-08-27T12:00:00+09:00"
     );
     private static final String CONTENT_DIGEST = "5".repeat(64);
+    private static final String NORMALIZATION_VERSION = "normalization-v1.0.0";
+    private static final int RUNNING_STATE_ARRIVING = 1;
+    private static final String SEATS_REPORTED_UNKNOWN = "REPORTED_UNKNOWN";
+    private static final String SEATS_NOT_REPORTED = "NOT_REPORTED";
     private static final DateTimeFormatter JSON_TIME = DateTimeFormatter.ofPattern(
         "uuuu-MM-dd'T'HH:mm:ssXXX"
     );
@@ -72,16 +76,10 @@ class LiveVehicleApiContractTest {
         );
         insertObservation(batchId, route, 0, "204000202", 2, "205000002", 0, 23);
         insertObservation(batchId, route, 1, "204000209", 9, "205000009", 2, 0);
-        insertObservation(batchId, route, 2, "204000206", 6, "205000006", 2, -1);
-        insertObservationWithoutSeats(
-            batchId,
-            route,
-            3,
-            "204000205",
-            5,
-            "205000005",
-            1
-        );
+        insertObservationWithUnknownSeats(
+            batchId, route, 2, "204000206", 6, "205000006", 2, SEATS_REPORTED_UNKNOWN);
+        insertObservationWithUnknownSeats(
+            batchId, route, 3, "204000205", 5, "205000005", 1, SEATS_NOT_REPORTED);
 
         mockMvc.perform(get("/api/v1/routes/{routeId}/vehicles", ROUTE_ID))
             .andExpect(status().isOk())
@@ -127,41 +125,12 @@ class LiveVehicleApiContractTest {
             .andExpect(jsonPath("$.vehicles[3].seat.remaining").value(23));
     }
 
-    @Test
-    void 운행_상태를_해석할_수_없는_관측은_그_행만_빼고_나머지를_반환한다() throws Exception {
-        RouteContext route = insertCurrentRoute();
-        insertStop(route, 3, "205000003", "상행 세 번째", "UP");
-        insertStop(route, 5, "205000005", "상행 다섯 번째", "UP");
-        insertStop(route, 7, "205000007", "상행 일곱 번째", "UP");
-        OffsetDateTime observedAt = NOW.minusMinutes(1);
-        final long batchId = insertSuccessfulBatch(
-            route,
-            observedAt,
-            "SUCCESS_ROWS",
-            3
-        );
-        insertObservationWithoutRunningState(
-            batchId,
-            route,
-            0,
-            "204000203",
-            3,
-            "205000003",
-            12
-        );
-        insertObservation(batchId, route, 1, "204000205", 5, "205000005", 1, 7);
-        insertObservation(batchId, route, 2, "204000207", 7, "205000007", 9, 3);
-
-        mockMvc.perform(get("/api/v1/routes/{routeId}/vehicles", ROUTE_ID))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.observation.state").value("VEHICLES_PRESENT"))
-            .andExpect(jsonPath("$.observation.observedAt").value(jsonTime(observedAt)))
-            .andExpect(jsonPath("$.vehicles.length()").value(1))
-            .andExpect(jsonPath("$.vehicles[0].vehicleId").value("204000205"))
-            .andExpect(jsonPath("$.vehicles[0].currentStopSequence").value(5))
-            .andExpect(jsonPath("$.vehicles[0].phase").value("ARRIVING"))
-            .andExpect(jsonPath("$.vehicles[0].seat.remaining").value(7));
-    }
+    // 운행_상태를_해석할_수_없는_관측은_그_행만_빼고_나머지를_반환한다 는 여기서 못 만든다.
+    // SAL-84 가 running_state 를 NOT NULL + CHECK (0, 1, 2) 로 조여서 그런 행이 DB 에 안 들어간다.
+    // 규칙은 세 곳이 나눠 지킨다.
+    //   값 해석          VehiclePhaseTest.문서_밖_운행_상태는_해석하지_않는다
+    //   행이 빠지는 것    JpaVehicleQueryRepositoryTest.운행_상태를_해석할_수_없는_관측은_그_행만_빼고_나머지를_돌려준다
+    //   애초에 안 쌓는 것  VehicleObservationTableTest.운행_상태는_0과_1과_2만_저장된다
 
     @Test
     void SUCCESS_EMPTY는_운행_종료로_단정하지_않고_빈_배열의_정상_응답을_반환한다() throws Exception {
@@ -320,8 +289,8 @@ class LiveVehicleApiContractTest {
                 INSERT INTO observation_batch (
                     route_version_id, scheduled_at, attempt_number, attempt_key,
                     requested_at, response_received_at, completed_at,
-                    http_status, result_code, outcome, stored_rows
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    http_status, result_code, outcome, stored_rows, normalization_version
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 RETURNING id
                 """)
             .params(
@@ -335,7 +304,8 @@ class LiveVehicleApiContractTest {
                 200,
                 0,
                 outcome,
-                storedRows
+                storedRows,
+                NORMALIZATION_VERSION
             )
             .query(Long.class)
             .single();
@@ -348,8 +318,8 @@ class LiveVehicleApiContractTest {
         jdbcClient.sql("""
                 INSERT INTO observation_batch (
                     route_version_id, scheduled_at, attempt_number, attempt_key,
-                    requested_at, completed_at, outcome, failure_code
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    requested_at, completed_at, outcome, failure_code, normalization_version
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """)
             .params(
                 route.routeVersionId(),
@@ -359,7 +329,8 @@ class LiveVehicleApiContractTest {
                 scheduledAt.plusSeconds(1),
                 scheduledAt.plusSeconds(2),
                 "TRANSPORT_FAILURE",
-                "UPSTREAM_TIMEOUT"
+                "UPSTREAM_TIMEOUT",
+                NORMALIZATION_VERSION
             )
             .update();
     }
@@ -371,8 +342,8 @@ class LiveVehicleApiContractTest {
         jdbcClient.sql("""
                 INSERT INTO observation_batch (
                     route_version_id, scheduled_at, attempt_number, attempt_key,
-                    requested_at, completed_at, outcome, stored_rows
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    requested_at, completed_at, outcome, stored_rows, normalization_version
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """)
             .params(
                 route.routeVersionId(),
@@ -382,7 +353,8 @@ class LiveVehicleApiContractTest {
                 scheduledAt.plusSeconds(1),
                 scheduledAt.plusSeconds(2),
                 "SUCCESS_ROWS",
-                1
+                1,
+                NORMALIZATION_VERSION
             )
             .update();
     }
@@ -397,81 +369,69 @@ class LiveVehicleApiContractTest {
         final int runningState,
         final int remainingSeats
     ) {
-        jdbcClient.sql("""
-                INSERT INTO vehicle_observation (
-                    observation_batch_id, route_version_id, source_row_number,
-                    observed_at, vehicle_id, stop_order, stop_id,
-                    running_state, remaining_seats
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """)
-            .params(
-                batchId,
-                route.routeVersionId(),
-                sourceRowNumber,
-                NOW.minusMinutes(1),
-                vehicleId,
-                stopOrder,
-                stopId,
-                runningState,
-                remainingSeats
-            )
-            .update();
+        insertObservation(
+            batchId, route, sourceRowNumber, vehicleId, stopOrder, stopId,
+            runningState, remainingSeats, null);
     }
 
-    private void insertObservationWithoutRunningState(
+    /**
+     * 잔여석을 모르는 관측. 상류의 음수와 누락은 정규화가 사유로 접어서,
+     * DB 에는 좌석 수가 비고 사유만 남는다. remaining_seats 에 -1 이 들어가는 일은 없다.
+     */
+    private void insertObservationWithUnknownSeats(
         final long batchId,
         RouteContext route,
         final int sourceRowNumber,
         String vehicleId,
         final int stopOrder,
         String stopId,
-        final int remainingSeats
+        final int runningState,
+        String seatUnknownReason
+    ) {
+        insertObservation(
+            batchId, route, sourceRowNumber, vehicleId, stopOrder, stopId,
+            runningState, null, seatUnknownReason);
+    }
+
+    private void insertObservation(
+        final long batchId,
+        RouteContext route,
+        final int sourceRowNumber,
+        String vehicleId,
+        final int stopOrder,
+        String stopId,
+        final int runningState,
+        Integer remainingSeats,
+        String seatUnknownReason
     ) {
         jdbcClient.sql("""
                 INSERT INTO vehicle_observation (
                     observation_batch_id, route_version_id, source_row_number,
-                    observed_at, vehicle_id, stop_order, stop_id, remaining_seats
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    vehicle_id, stop_order, stop_id, passed_stop_order,
+                    running_state, remaining_seats, seat_unknown_reason
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """)
             .params(
                 batchId,
                 route.routeVersionId(),
                 sourceRowNumber,
-                NOW.minusMinutes(1),
                 vehicleId,
                 stopOrder,
                 stopId,
-                remainingSeats
+                passedStopOrderOf(stopOrder, runningState),
+                runningState,
+                remainingSeats,
+                seatUnknownReason
             )
             .update();
     }
 
-    private void insertObservationWithoutSeats(
-        final long batchId,
-        RouteContext route,
-        final int sourceRowNumber,
-        String vehicleId,
+    /** 도착 중(1)인 버스는 그 정류소를 아직 안 지났다. */
+    private int passedStopOrderOf(
         final int stopOrder,
-        String stopId,
         final int runningState
     ) {
-        jdbcClient.sql("""
-                INSERT INTO vehicle_observation (
-                    observation_batch_id, route_version_id, source_row_number,
-                    observed_at, vehicle_id, stop_order, stop_id, running_state
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """)
-            .params(
-                batchId,
-                route.routeVersionId(),
-                sourceRowNumber,
-                NOW.minusMinutes(1),
-                vehicleId,
-                stopOrder,
-                stopId,
-                runningState
-            )
-            .update();
+        return runningState == RUNNING_STATE_ARRIVING ? stopOrder - 1 : stopOrder;
     }
 
     private record RouteContext(long routeVersionId) {

--- a/backend/src/test/java/com/gustler/backend/api/vehicle/persistence/jpa/JpaVehicleQueryRepositoryTest.java
+++ b/backend/src/test/java/com/gustler/backend/api/vehicle/persistence/jpa/JpaVehicleQueryRepositoryTest.java
@@ -9,7 +9,11 @@ import com.gustler.backend.api.http.ServiceUnavailableException;
 import com.gustler.backend.api.route.RouteId;
 import com.gustler.backend.api.route.persistence.jpa.RouteVersionJpaEntity;
 import com.gustler.backend.api.vehicle.application.VehicleSnapshot;
+import com.gustler.backend.api.vehicle.domain.ObservedVehicle;
+import com.gustler.backend.api.vehicle.domain.VehicleDirection;
+import com.gustler.backend.api.vehicle.domain.VehiclePhase;
 import com.gustler.backend.api.vehicle.domain.VehiclePollOutcome;
+import com.gustler.backend.api.vehicle.domain.VehicleSeat;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +61,34 @@ class JpaVehicleQueryRepositoryTest {
         assertThatThrownBy(() -> repository.findVehicles(1L))
             .isInstanceOf(ServiceUnavailableException.class)
             .hasMessage("일시적인 서버 장애가 발생했습니다.");
+    }
+
+    /**
+     * SAL-84 가 running_state 를 NOT NULL + CHECK (0, 1, 2) 로 조여서 해석할 수 없는 값은
+     * 이제 DB 에 들어가지 못한다. 그래서 이 규칙은 DB 픽스처로는 못 만든다.
+     * 행이 빠지는 자리가 여기라서 이 층에서 지킨다.
+     */
+    @Test
+    void 운행_상태를_해석할_수_없는_관측은_그_행만_빼고_나머지를_돌려준다() {
+        VehicleObservationJpaEntity readable = mock(VehicleObservationJpaEntity.class);
+        VehicleObservationJpaEntity unreadable = mock(VehicleObservationJpaEntity.class);
+        ObservedVehicle vehicle = new ObservedVehicle(
+            "204000205",
+            VehicleDirection.UP,
+            5,
+            "205000005",
+            "상행 다섯 번째",
+            VehiclePhase.ARRIVING,
+            VehicleSeat.from(7)
+        );
+        given(readable.toDomain()).willReturn(Optional.of(vehicle));
+        given(unreadable.toDomain()).willReturn(Optional.empty());
+        given(vehicleObservationRepository.findAllByBatchId(1L))
+            .willReturn(List.of(unreadable, readable));
+
+        List<ObservedVehicle> actual = repository.findVehicles(1L);
+
+        assertThat(actual).containsExactly(vehicle);
     }
 
     @Test

--- a/backend/src/test/java/com/gustler/backend/collector/CollectedObservationsTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/CollectedObservationsTest.java
@@ -1,0 +1,120 @@
+package com.gustler.backend.collector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gustler.backend.collector.dto.BusLocationResponse.BusLocation;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CollectedObservationsTest {
+
+    private static final String PLATE_NUMBER = "경기70아0001";
+    private static final String ROUTE_3330 = "204000057";
+    private static final String STOP_205000217 = "205000217";
+    private static final String VEHICLE_204000206 = "204000206";
+    private static final String VEHICLE_204003542 = "204003542";
+    private static final String VEHICLE_204000139 = "204000139";
+
+    private static final int STOP_SEQUENCE_6 = 6;
+    private static final int ROUTE_TYPE_11 = 11;
+    private static final int TAGLESS_1 = 1;
+    private static final int NORMAL_BUS = 0;
+    private static final int SEATS_43 = 43;
+    private static final int CROWD_LEVEL_3 = 3;
+
+    private static final int RUNNING_STATE_MOVING = 0;
+    private static final int RUNNING_STATE_ARRIVED = 1;
+    private static final int RUNNING_STATE_DEPARTED = 2;
+    private static final int RUNNING_STATE_NEVER_OBSERVED = 3;
+
+    @Test
+    void 상류가_준_차량_수를_그대로_센다() {
+        // given
+        List<BusLocation> buses = List.of(
+            bus(VEHICLE_204000206, RUNNING_STATE_MOVING),
+            bus(VEHICLE_204003542, RUNNING_STATE_NEVER_OBSERVED),
+            bus(VEHICLE_204000139, RUNNING_STATE_DEPARTED));
+
+        // when
+        CollectedObservations actual = CollectedObservations.from(buses);
+
+        // then
+        assertThat(actual.providerRows()).isEqualTo(3);
+    }
+
+    @Test
+    void 뜻을_아는_운행_상태의_차량만_쌓을_대상이_된다() {
+        // given
+        List<BusLocation> buses = List.of(
+            bus(VEHICLE_204000206, RUNNING_STATE_MOVING),
+            bus(VEHICLE_204003542, RUNNING_STATE_NEVER_OBSERVED),
+            bus(VEHICLE_204000139, RUNNING_STATE_DEPARTED));
+
+        // when
+        CollectedObservations actual = CollectedObservations.from(buses);
+
+        // then
+        assertThat(actual.storableRows())
+            .extracting(row -> row.observation().vehicleId())
+            .containsExactly(VEHICLE_204000206, VEHICLE_204000139);
+    }
+
+    @Test
+    void 뜻을_모르는_운행_상태의_차량_수를_따로_센다() {
+        // given
+        List<BusLocation> buses = List.of(
+            bus(VEHICLE_204000206, RUNNING_STATE_MOVING),
+            bus(VEHICLE_204003542, RUNNING_STATE_NEVER_OBSERVED),
+            bus(VEHICLE_204000139, null));
+
+        // when
+        CollectedObservations actual = CollectedObservations.from(buses);
+
+        // then
+        assertThat(actual.excludedRows()).hasSize(2);
+    }
+
+    @Test
+    void 쌓을_관측은_상류_응답에서_몇_번째_줄이었는지를_들고_있다() {
+        // given
+        List<BusLocation> buses = List.of(
+            bus(VEHICLE_204000206, RUNNING_STATE_NEVER_OBSERVED),
+            bus(VEHICLE_204003542, RUNNING_STATE_ARRIVED),
+            bus(VEHICLE_204000139, RUNNING_STATE_DEPARTED));
+
+        // when
+        CollectedObservations actual = CollectedObservations.from(buses);
+
+        // then
+        assertThat(actual.storableRows())
+            .extracting(UpstreamObservationRow::sourceRowNumber)
+            .containsExactly(1, 2);
+    }
+
+    @Test
+    void 차량이_한_대도_없으면_쌓을_관측도_없다() {
+        // when
+        CollectedObservations actual = CollectedObservations.from(List.of());
+
+        // then
+        assertThat(actual.storableRows()).isEmpty();
+    }
+
+    private static BusLocation bus(
+        String vehicleId,
+        Integer runningState
+    ) {
+        return new BusLocation(
+            PLATE_NUMBER,
+            vehicleId,
+            NORMAL_BUS,
+            ROUTE_3330,
+            ROUTE_TYPE_11,
+            STOP_205000217,
+            STOP_SEQUENCE_6,
+            runningState,
+            SEATS_43,
+            CROWD_LEVEL_3,
+            TAGLESS_1);
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/collector/CollectedObservationsTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/CollectedObservationsTest.java
@@ -92,12 +92,36 @@ class CollectedObservationsTest {
     }
 
     @Test
+    void 정류소를_모르는_차량은_쌓을_대상에서_빠진다() {
+        // given
+        List<BusLocation> buses = List.of(
+            bus(VEHICLE_204000206, RUNNING_STATE_DEPARTED),
+            busWithoutStopSequence(VEHICLE_204003542));
+
+        // when
+        CollectedObservations actual = CollectedObservations.from(buses);
+
+        // then
+        assertThat(actual.storableRows())
+            .extracting(row -> row.observation().vehicleId())
+            .containsExactly(VEHICLE_204000206);
+    }
+
+    @Test
     void 차량이_한_대도_없으면_쌓을_관측도_없다() {
         // when
         CollectedObservations actual = CollectedObservations.from(List.of());
 
         // then
         assertThat(actual.storableRows()).isEmpty();
+    }
+
+    private static BusLocation busWithoutStopSequence(
+        String vehicleId
+    ) {
+        return new BusLocation(
+            PLATE_NUMBER, vehicleId, NORMAL_BUS, ROUTE_3330, ROUTE_TYPE_11,
+            STOP_205000217, null, RUNNING_STATE_DEPARTED, SEATS_43, CROWD_LEVEL_3, TAGLESS_1);
     }
 
     private static BusLocation bus(

--- a/backend/src/test/java/com/gustler/backend/collector/ObservationLoaderTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/ObservationLoaderTest.java
@@ -1,0 +1,420 @@
+package com.gustler.backend.collector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gustler.backend.collector.dto.BusLocationResponse.BusLocation;
+import com.gustler.backend.support.IntegrationTest;
+import jakarta.persistence.EntityManager;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.transaction.annotation.Transactional;
+
+@IntegrationTest
+@Transactional
+class ObservationLoaderTest {
+
+    private static final String SOURCE_ID = "GBIS";
+    private static final String ROUTE_204000057 = "204000057";
+
+    private static final String STOP_205000217 = "205000217";
+    private static final String STOP_277103149 = "277103149";
+    private static final String STOP_208000069 = "208000069";
+    private static final int TURN_SEQUENCE = 2;
+
+    private static final String VEHICLE_204000206 = "204000206";
+    private static final String VEHICLE_204003542 = "204003542";
+    private static final String VEHICLE_204000139 = "204000139";
+    private static final String PLATE_NUMBER = "경기70아0001";
+
+    private static final int ROUTE_TYPE_11 = 11;
+    private static final int TAGLESS_1 = 1;
+    private static final int NORMAL_BUS = 0;
+    private static final int SEATS_43 = 43;
+    private static final int CROWD_LEVEL_3 = 3;
+    private static final int SEATS_REPORTED_UNKNOWN = -1;
+
+    private static final int RUNNING_STATE_MOVING = 0;
+    private static final int RUNNING_STATE_ARRIVED = 1;
+    private static final int RUNNING_STATE_DEPARTED = 2;
+    private static final int RUNNING_STATE_NEVER_OBSERVED = 3;
+
+    private static final OffsetDateTime SCHEDULED_AT = OffsetDateTime.parse("2026-08-19T11:14:00+09:00");
+    private static final OffsetDateTime REQUESTED_AT = OffsetDateTime.parse("2026-08-19T11:14:04.800+09:00");
+    private static final OffsetDateTime RESPONSE_RECEIVED_AT = OffsetDateTime.parse("2026-08-19T11:14:04.911+09:00");
+    private static final String ATTEMPT_KEY = "204000057-2026-08-19T11:14";
+
+    private static final RouteTimetable TIMETABLE_3330 =
+        new RouteTimetable("05:00", "22:35", "05:00", "23:55");
+
+    @Autowired
+    private ObservationLoader loader;
+
+    @Autowired
+    private RouteVersionLoader routeVersionLoader;
+
+    @Autowired
+    private JdbcClient jdbcClient;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private long routeVersionId;
+
+    @BeforeEach
+    void 노선과_판본과_정류소를_먼저_적재한다() {
+        final long routeId = insertRoute();
+        routeVersionId = routeVersionLoader.load(routeId, threeStops(), TIMETABLE_3330, SCHEDULED_AT);
+    }
+
+    @Test
+    void 차량이_있는_판은_수집_묶음_한_행을_남긴다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busAt(VEHICLE_204000206, 1, STOP_205000217, RUNNING_STATE_DEPARTED)));
+
+        // then
+        assertThat(batchCountOf(batchId)).isEqualTo(1);
+    }
+
+    @Test
+    void 차량이_있는_판은_본_차량만큼_관측을_쌓는다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busAt(VEHICLE_204000206, 1, STOP_205000217, RUNNING_STATE_DEPARTED),
+            busAt(VEHICLE_204003542, 2, STOP_277103149, RUNNING_STATE_MOVING),
+            busAt(VEHICLE_204000139, 3, STOP_208000069, RUNNING_STATE_ARRIVED)));
+
+        // then
+        assertThat(observationCountOf(batchId)).isEqualTo(3);
+    }
+
+    @Test
+    void 차량이_한_대도_없는_판도_묶음_한_행이_남는다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of());
+
+        // then
+        assertThat(batchCountOf(batchId)).isEqualTo(1);
+    }
+
+    @Test
+    void 차량이_한_대도_없는_판의_결말은_SUCCESS_EMPTY다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of());
+
+        // then
+        assertThat(outcomeOf(batchId)).isEqualTo("SUCCESS_EMPTY");
+    }
+
+    @Test
+    void 차량이_있는_판의_결말은_SUCCESS_ROWS다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busAt(VEHICLE_204000206, 1, STOP_205000217, RUNNING_STATE_DEPARTED)));
+
+        // then
+        assertThat(outcomeOf(batchId)).isEqualTo("SUCCESS_ROWS");
+    }
+
+    @Test
+    void 뜻을_모르는_운행_상태의_차량은_빼고_나머지가_저장된다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busAt(VEHICLE_204000206, 1, STOP_205000217, RUNNING_STATE_DEPARTED),
+            busAt(VEHICLE_204003542, 2, STOP_277103149, RUNNING_STATE_NEVER_OBSERVED),
+            busAt(VEHICLE_204000139, 3, STOP_208000069, RUNNING_STATE_MOVING)));
+
+        // then
+        assertThat(vehicleIdsOf(batchId)).containsExactly(VEHICLE_204000206, VEHICLE_204000139);
+    }
+
+    @Test
+    void 뺀_차량이_있어도_상류가_준_행_수는_그대로_남는다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busAt(VEHICLE_204000206, 1, STOP_205000217, RUNNING_STATE_DEPARTED),
+            busAt(VEHICLE_204003542, 2, STOP_277103149, RUNNING_STATE_NEVER_OBSERVED)));
+
+        // then
+        assertThat(providerRowsOf(batchId)).isEqualTo(2);
+    }
+
+    @Test
+    void 뺀_차량_수가_묶음에_남는다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busAt(VEHICLE_204000206, 1, STOP_205000217, RUNNING_STATE_DEPARTED),
+            busAt(VEHICLE_204003542, 2, STOP_277103149, RUNNING_STATE_NEVER_OBSERVED)));
+
+        // then
+        assertThat(excludedRowsOf(batchId)).isEqualTo(1);
+    }
+
+    @Test
+    void 차량을_전부_뺀_판의_결말도_SUCCESS_ROWS다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busAt(VEHICLE_204000206, 1, STOP_205000217, RUNNING_STATE_NEVER_OBSERVED)));
+
+        // then
+        assertThat(outcomeOf(batchId)).isEqualTo("SUCCESS_ROWS");
+    }
+
+    @Test
+    void 정류소를_지난_차량의_통과_순번은_그_정류소_순번이다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busAt(VEHICLE_204000206, 2, STOP_277103149, RUNNING_STATE_DEPARTED)));
+
+        // then
+        assertThat(passedStopOrderOf(batchId)).isEqualTo(2);
+    }
+
+    @Test
+    void 도착_중인_차량의_통과_순번은_직전_정류소_순번이다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busAt(VEHICLE_204000206, 2, STOP_277103149, RUNNING_STATE_ARRIVED)));
+
+        // then
+        assertThat(passedStopOrderOf(batchId)).isEqualTo(1);
+    }
+
+    @Test
+    void 첫_정류소에_도착_중인_차량의_통과_순번은_0이다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busAt(VEHICLE_204000206, 1, STOP_205000217, RUNNING_STATE_ARRIVED)));
+
+        // then
+        assertThat(passedStopOrderOf(batchId)).isZero();
+    }
+
+    @Test
+    void 잔여석을_아는_차량은_좌석_수만_저장된다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busWithSeats(SEATS_43)));
+
+        // then
+        assertThat(storedSeatsOf(batchId)).isEqualTo(new StoredSeats(SEATS_43, null));
+    }
+
+    @Test
+    void 잔여석을_모른다고_알려준_차량은_사유만_저장된다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busWithSeats(SEATS_REPORTED_UNKNOWN)));
+
+        // then
+        assertThat(storedSeatsOf(batchId)).isEqualTo(new StoredSeats(null, "REPORTED_UNKNOWN"));
+    }
+
+    @Test
+    void 잔여석을_안_알려준_차량은_사유만_저장된다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busWithSeats(null)));
+
+        // then
+        assertThat(storedSeatsOf(batchId)).isEqualTo(new StoredSeats(null, "NOT_REPORTED"));
+    }
+
+    @Test
+    void 관측은_상류_응답에서_몇_번째_줄이었는지를_그대로_쌓는다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busAt(VEHICLE_204000206, 1, STOP_205000217, RUNNING_STATE_NEVER_OBSERVED),
+            busAt(VEHICLE_204003542, 2, STOP_277103149, RUNNING_STATE_MOVING)));
+
+        // then
+        assertThat(sourceRowNumbersOf(batchId)).containsExactly(1);
+    }
+
+    @Test
+    void 정규화_판이_묶음에_남는다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of());
+
+        // then
+        assertThat(normalizationVersionOf(batchId))
+            .isEqualTo(ObservationBatch.CURRENT_NORMALIZATION_VERSION);
+    }
+
+    private record StoredSeats(
+        Integer remainingSeats,
+        String seatUnknownReason
+    ) {
+    }
+
+    private ObservationAttempt attempt() {
+        return new ObservationAttempt(
+            routeVersionId, SCHEDULED_AT, 1, ATTEMPT_KEY, REQUESTED_AT, RESPONSE_RECEIVED_AT);
+    }
+
+    private RouteStops threeStops() {
+        return RouteStops.from(TURN_SEQUENCE, List.of(
+            new UpstreamRouteStop(1, STOP_205000217, "범계역"),
+            new UpstreamRouteStop(2, STOP_277103149, "안양대교(경유)"),
+            new UpstreamRouteStop(3, STOP_208000069, "안양역")));
+    }
+
+    private static BusLocation busAt(
+        String vehicleId,
+        final int stopSequence,
+        String stopId,
+        final int runningState
+    ) {
+        return bus(vehicleId, stopSequence, stopId, runningState, SEATS_43);
+    }
+
+    private static BusLocation busWithSeats(
+        Integer remainingSeatCount
+    ) {
+        return bus(VEHICLE_204000206, 1, STOP_205000217, RUNNING_STATE_DEPARTED, remainingSeatCount);
+    }
+
+    private static BusLocation bus(
+        String vehicleId,
+        final int stopSequence,
+        String stopId,
+        final int runningState,
+        Integer remainingSeatCount
+    ) {
+        return new BusLocation(
+            PLATE_NUMBER,
+            vehicleId,
+            NORMAL_BUS,
+            ROUTE_204000057,
+            ROUTE_TYPE_11,
+            stopId,
+            stopSequence,
+            runningState,
+            remainingSeatCount,
+            CROWD_LEVEL_3,
+            TAGLESS_1);
+    }
+
+    private long insertRoute() {
+        return jdbcClient.sql("""
+                INSERT INTO route (
+                    public_route_id, source_id, source_route_id,
+                    display_name, start_stop_name, end_stop_name
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                RETURNING id
+                """)
+            .params(ROUTE_204000057, SOURCE_ID, ROUTE_204000057, "3330", "범계역", "강남역")
+            .query(Long.class)
+            .single();
+    }
+
+    private int batchCountOf(
+        final long batchId
+    ) {
+        return queryForInt("SELECT count(*) FROM observation_batch WHERE id = ?", batchId);
+    }
+
+    private int observationCountOf(
+        final long batchId
+    ) {
+        return queryForInt(
+            "SELECT count(*) FROM vehicle_observation WHERE observation_batch_id = ?", batchId);
+    }
+
+    private int providerRowsOf(
+        final long batchId
+    ) {
+        return queryForInt("SELECT provider_rows FROM observation_batch WHERE id = ?", batchId);
+    }
+
+    private int excludedRowsOf(
+        final long batchId
+    ) {
+        return queryForInt("SELECT excluded_rows FROM observation_batch WHERE id = ?", batchId);
+    }
+
+    private int passedStopOrderOf(
+        final long batchId
+    ) {
+        return queryForInt(
+            "SELECT passed_stop_order FROM vehicle_observation WHERE observation_batch_id = ?", batchId);
+    }
+
+    private String outcomeOf(
+        final long batchId
+    ) {
+        entityManager.flush();
+        return jdbcClient.sql("SELECT outcome FROM observation_batch WHERE id = ?")
+            .param(batchId)
+            .query(String.class)
+            .single();
+    }
+
+    private String normalizationVersionOf(
+        final long batchId
+    ) {
+        entityManager.flush();
+        return jdbcClient.sql("SELECT normalization_version FROM observation_batch WHERE id = ?")
+            .param(batchId)
+            .query(String.class)
+            .single();
+    }
+
+    private List<String> vehicleIdsOf(
+        final long batchId
+    ) {
+        entityManager.flush();
+        return jdbcClient.sql("""
+                SELECT vehicle_id FROM vehicle_observation
+                WHERE observation_batch_id = ?
+                ORDER BY source_row_number
+                """)
+            .param(batchId)
+            .query(String.class)
+            .list();
+    }
+
+    private List<Integer> sourceRowNumbersOf(
+        final long batchId
+    ) {
+        entityManager.flush();
+        return jdbcClient.sql("""
+                SELECT source_row_number FROM vehicle_observation
+                WHERE observation_batch_id = ?
+                ORDER BY source_row_number
+                """)
+            .param(batchId)
+            .query(Integer.class)
+            .list();
+    }
+
+    private StoredSeats storedSeatsOf(
+        final long batchId
+    ) {
+        entityManager.flush();
+        return jdbcClient.sql("""
+                SELECT remaining_seats, seat_unknown_reason FROM vehicle_observation
+                WHERE observation_batch_id = ?
+                """)
+            .param(batchId)
+            .query((rs, rowNumber) -> new StoredSeats(
+                rs.getObject("remaining_seats", Integer.class),
+                rs.getString("seat_unknown_reason")))
+            .single();
+    }
+
+    private int queryForInt(
+        final String sql,
+        final long batchId
+    ) {
+        entityManager.flush();
+        return jdbcClient.sql(sql)
+            .param(batchId)
+            .query(Integer.class)
+            .single();
+    }
+}

--- a/backend/src/test/java/com/gustler/backend/collector/ObservationLoaderTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/ObservationLoaderTest.java
@@ -133,6 +133,28 @@ class ObservationLoaderTest {
     }
 
     @Test
+    void 정류소_순번이_빈_차량이_섞여도_나머지가_저장된다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busAt(VEHICLE_204000206, 1, STOP_205000217, RUNNING_STATE_DEPARTED),
+            busWithoutStopSequence(VEHICLE_204003542),
+            busAt(VEHICLE_204000139, 3, STOP_208000069, RUNNING_STATE_MOVING)));
+
+        // then
+        assertThat(vehicleIdsOf(batchId)).containsExactly(VEHICLE_204000206, VEHICLE_204000139);
+    }
+
+    @Test
+    void 정류소_순번이_빈_차량이_있어도_수집_묶음은_남는다() {
+        // when
+        final long batchId = loader.load(attempt(), List.of(
+            busWithoutStopSequence(VEHICLE_204003542)));
+
+        // then
+        assertThat(batchCountOf(batchId)).isEqualTo(1);
+    }
+
+    @Test
     void 뺀_차량이_있어도_상류가_준_행_수는_그대로_남는다() {
         // when
         final long batchId = loader.load(attempt(), List.of(
@@ -270,6 +292,14 @@ class ObservationLoaderTest {
         final int runningState
     ) {
         return bus(vehicleId, stopSequence, stopId, runningState, SEATS_43);
+    }
+
+    private static BusLocation busWithoutStopSequence(
+        String vehicleId
+    ) {
+        return new BusLocation(
+            PLATE_NUMBER, vehicleId, NORMAL_BUS, ROUTE_204000057, ROUTE_TYPE_11,
+            STOP_205000217, null, RUNNING_STATE_DEPARTED, SEATS_43, CROWD_LEVEL_3, TAGLESS_1);
     }
 
     private static BusLocation busWithSeats(

--- a/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
@@ -27,6 +27,7 @@ class VehicleObservationTest {
 
     private static final int RUNNING_STATE_ARRIVED = 1;
     private static final int RUNNING_STATE_DEPARTED = 2;
+    private static final int RUNNING_STATE_NEVER_OBSERVED = 3;
 
     private static final int SEATS_43 = 43;
     private static final int CROWD_LEVEL_3 = 3;
@@ -267,6 +268,45 @@ class VehicleObservationTest {
 
         // then
         assertThat(actual.passedStopOrder()).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2})
+    void 운행_상태_0과_1과_2는_뜻을_아는_값이다(
+        final int runningState
+    ) {
+        // given
+        BusLocation bus = busAt(STOP_SEQUENCE_6, runningState);
+
+        // when
+        VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.hasKnownRunningState()).isTrue();
+    }
+
+    @Test
+    void 운행_상태가_비어_있으면_뜻을_모르는_값이다() {
+        // given
+        BusLocation bus = bus(STOP_SEQUENCE_6, null, SEATS_43, CROWD_LEVEL_3, NORMAL_BUS);
+
+        // when
+        VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.hasKnownRunningState()).isFalse();
+    }
+
+    @Test
+    void 운행_상태가_3이면_뜻을_모르는_값이다() {
+        // given
+        BusLocation bus = busAt(STOP_SEQUENCE_6, RUNNING_STATE_NEVER_OBSERVED);
+
+        // when
+        VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.hasKnownRunningState()).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
+++ b/backend/src/test/java/com/gustler/backend/collector/VehicleObservationTest.java
@@ -270,6 +270,30 @@ class VehicleObservationTest {
         assertThat(actual.passedStopOrder()).isNull();
     }
 
+    @Test
+    void 정류소_순번과_정류소_ID가_다_있으면_어느_정류소의_관측인지_안다() {
+        // given
+        BusLocation bus = busAt(STOP_SEQUENCE_6, RUNNING_STATE_DEPARTED);
+
+        // when
+        VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.hasKnownStop()).isTrue();
+    }
+
+    @Test
+    void 정류소_순번이_비면_어느_정류소의_관측인지_모른다() {
+        // given
+        BusLocation bus = bus(null, RUNNING_STATE_DEPARTED, SEATS_43, CROWD_LEVEL_3, NORMAL_BUS);
+
+        // when
+        VehicleObservation actual = VehicleObservation.from(bus);
+
+        // then
+        assertThat(actual.hasKnownStop()).isFalse();
+    }
+
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2})
     void 운행_상태_0과_1과_2는_뜻을_아는_값이다(


### PR DESCRIPTION
## 요약

수집한 버스 위치를 DB 에 쌓습니다. 호출 한 판을 `observation_batch` 한 행으로,
그때 본 차량들을 `vehicle_observation` 행으로 남깁니다.
SAL-82 가 만든 `VehicleObservation.from()` 은 여태 **부르는 데가 한 군데도 없었는데**, 그 마지막 칸을 잇습니다.

<br/>

## 변경사항

- 호출 한 판과 그 판의 차량을 한 트랜잭션에 넣습니다. 차가 0대인 판도 묶음 행은 남깁니다
- `V4` 로 열 셋을 세우고(`seat_unknown_reason` · `passed_stop_order` · `normalization_version`)
  중복이던 `vehicle_observation.observed_at` 을 지웁니다. CHECK 여섯을 겁니다
- 상류가 뜻 모를 운행 상태를 주거나 정류소를 안 알려주면 **그 행만** 빼고 나머지를 쌓습니다. DB 도 같은 것을 막습니다
- 조회 쪽과 같은 표를 매핑하는 자리에 `@Column(name)` 을 명시합니다. 안 하면 머지될 때 앱이 안 뜹니다
- 스키마를 조이면서 깨지는 `api/vehicle` · `api/board` 의 테스트 픽스처를 같이 고칩니다
- `/vehicles` 가 "차량 있음" 인데 목록이 비던 것과, 못 읽은 것을 "차 없음" 으로 내던 것을 고칩니다

**테스트 347개 전부 통과합니다.** `dev`(`6961669`) 기준입니다.

<br/>

## 설계 결정

### 뜻을 모르는 운행 상태는 그 행만 빼고, DB 가 한 번 더 막습니다

`stateCd` 는 실측으로 0 · 1 · 2 만 왔습니다. 그런데 열이 nullable 이고 CHECK 도 없었습니다.
그런 행이 하나 들어오면 조회 쪽 `phase` 계약(`ARRIVING` · `DEPARTED` · `IN_TRANSIT`)에 담을 자리가 없습니다.

두 갈래를 놓고 봤습니다.

| | 나쁜 값 한 대가 왔을 때 |
| --- | --- |
| **그 행만 뺀다** | 그 한 대만 빠집니다. 나머지 16대는 그대로 쌓입니다 |
| 그 판을 통째로 실패로 | 17대가 전부 사라집니다. 그 노선 예보가 멈춥니다 |

행만 빼는 쪽으로 갔습니다. 결정적이었던 건 **스키마가 이미 그걸 쓰라고 칸을 파 놨다**는 겁니다.
`observation_batch` 에 `provider_rows` · `stored_rows` · `excluded_rows` 가 셋 다 있는데,
판을 통째로 버리면 `excluded_rows` 는 영원히 0 입니다. 쓰라고 만든 열이 죽어요.

그리고 티켓이 같은 상황을 이미 이렇게 정해뒀습니다.
*"`station_id` 에 FK 를 걸지 않는다. 상류가 모르는 정류장을 주는 순간 INSERT 가 터지고 수집이 멈춘다."*
`running_state` 만 반대로 갈 이유를 못 찾았습니다.

**거르는 코드가 틀려도 조회가 500 이 안 나게 DB 에도 걸었습니다.**

```sql
ALTER TABLE vehicle_observation ALTER COLUMN running_state SET NOT NULL;
ALTER TABLE vehicle_observation
    ADD CONSTRAINT ck_observation_running_state_value
        CHECK (running_state IN (0, 1, 2));   -- <<<<<< 여기
```

**한계**: 어떤 값이 왔는지는 영영 모릅니다. 응답 원문을 안 남기니까요. `excluded_rows` 로 몇 건인지만 압니다.
보완으로 뺀 행마다 WARN 한 줄을 찍는데 **판본 · 시도 키 · 상류 행 번호 · 운행 상태 · 정류소 순번 다섯뿐**입니다.
번호판과 차량 아이디는 안 찍습니다. `gradlew test -i` 로 앱 로그 231줄을 받아 훑었고 **번호판 0건**입니다.

<br/>

### 결말은 상류가 준 행 수로 정합니다. 우리가 쌓은 수가 아닙니다

차가 셋 왔는데 셋 다 빠지면 `SUCCESS_ROWS` 에 `stored_rows = 0` 입니다. `SUCCESS_EMPTY` 가 아닙니다.

"상류가 차 없다고 했다" 와 "차는 있었는데 우리가 다 뺐다" 는 다른 사실이고,
관측 간격 90초 판정에서 연결이 끊긴 자리를 가릴 때 뜻이 갈립니다.

여기에 딸린 문제가 하나 있었습니다. 차가 **전부** 빠지면 조회 쪽이 `SUCCESS_ROWS` 를 보고
`VEHICLES_PRESENT` 로 내보내는데 목록이 빕니다. 계약이 어긋나요. 동키가 리뷰에서 짚어주셨습니다.

**`LiveVehicleQueryService` 에서 고쳤습니다.** 처음엔 목록이 비면 `NO_VEHICLES_OBSERVED` 로 냈는데,
동키가 **그러면 서로 다른 두 상황이 같은 응답이 된다**고 다시 짚어주셨습니다. 맞는 말이라 한 번 더 고쳤습니다.

| 무슨 일 | 응답 |
| --- | --- |
| 상류가 "차가 없다" 고 답함 (`SUCCESS_EMPTY`) | `NO_VEHICLES_OBSERVED` |
| 상류는 차량 행을 줬는데 하나도 못 읽음 | **`UNKNOWN`** |

두 번째를 "차가 없다" 로 내면, 상류가 필드 형식을 바꿔서 모든 행이 걸러지는 날에도
**클라이언트에는 멀쩡한 0대로 보여서 아무도 이상을 못 알아챕니다.** 조용히 죽는 게 제일 나쁩니다.

`UNKNOWN` 은 이미 "지금 상태를 말해줄 수 없다" 는 자리라 **응답 형식을 안 바꾸고** 담깁니다.
운영이 알아채라고 그 자리에 WARN 도 남깁니다. 계속 나면 상류 계약이 바뀐 겁니다.

**`api/vehicle` 을 만졌습니다.** 저장 쪽에서 `stored_rows` 로 결말을 정하는 안도 봤는데,
그러면 위 표의 구분이 저장 단계에서 사라져서 안 그랬습니다.

<br/>

### 로더가 `GbisLocationResult` 를 안 받고 차량 목록을 받습니다

`GbisLocationResult` 는 갈래가 열입니다. 그런데 그걸 결말 아홉 값으로 옮기는 일은
**SAL-85 가 자기 몫으로 적고 선행에 SAL-84 를 걸어놨습니다.** 로더가 열 갈래를 받으면 그 일을 미리 하는 셈이라
`load(ObservationAttempt, List<BusLocation>)` 로 뒀습니다. **빈 목록이 곧 `SUCCESS_EMPTY` 입니다.**

**한계**: 실패한 호출은 아직 묶음이 안 남습니다. `http_status` · `result_code` · `failure_code` ·
`completed_at` 도 안 채웁니다. 넷 다 nullable 이라 INSERT 는 됩니다. SAL-85 가 채웁니다.

<br/>

### 버전 축 셋 중 하나만 만들고, 기본값은 일부러 안 줬습니다

티켓은 판 단위 버전 축을 셋으로 적고 있습니다. `normalization_version` ·
`collection_strategy_version` · `source_contract_version` 인데 **하나만 만들었습니다.**

나머지 둘은 수집 주기를 정하는 코드와 상류 계약 판을 아는 코드가 아직 없습니다.
지금 열을 만들면 채울 값이 없어서 상수 하나를 지어 박게 되는데, **그러면 값이 거짓말이 됩니다.**
"어느 밀도에서 모은 관측인가" 를 되짚으려고 두는 열인데 아무 값이나 들어가 있으면 뜻이 없어요.

만든 하나에는 **기본값을 안 줬습니다.** `NOT NULL` 이고 `DEFAULT` 가 없습니다.
기본값을 주면 열을 빠뜨린 INSERT 가 조용히 통과하고 그 판이 실제로 어느 규칙으로 접힌 건지 모르는 채로 남습니다.
INSERT 를 쓰는 쪽이 매번 명시하게 두는 게 이 열을 만든 이유에 맞습니다.
**대가는 바로 아래입니다.** 남의 픽스처가 이것 때문에 깨집니다.

<br/>

### 남의 테스트 픽스처를 두 번 고쳤습니다

여기가 리뷰에서 제일 걸리실 것 같아서 먼저 적습니다. **`api/vehicle` 과 `api/board` 의 테스트를 만졌습니다.**

`V4` 가 스키마를 조이면서 남의 픽스처가 깨집니다. 두 겹으로 막는 설계(쓸 때 DB 가 막고 읽을 때 코드가 거른다)의
값입니다. 조회 쪽은 원래 읽을 때 걸렀는데, 이제 그런 행이 아예 안 들어가서 **픽스처로 만들 수가 없어요.**

| 어디 | 무엇이 깨지나 | 어떻게 했나 |
| --- | --- | --- |
| `api/vehicle` (#32) | 6개 | 이 PR 에서 고쳤습니다 |
| `api/board` (#33) | 5개 | 이 PR 에서 고쳤습니다 |

`#33` 은 **그쪽 PR 에서 미리 고치지 않았습니다.** 그때는 `dev` 에서 멀쩡했고 우리 `V4` 가 들어간 뒤에야 깨지거든요.
아직 안 깨진 걸 미리 고치라고 하면 그쪽 PR 이 이유 없이 커집니다.
`#33` 이 머지된 뒤에 여기서 같이 치웠습니다. 깨뜨린 쪽이 치우는 게 맞다고 봤습니다.

층을 하나씩 벗겨가며 쟀습니다. 한 번에 고치면 앞 층이 뒷 층을 가려서 숫자가 틀리더라고요.
저도 처음엔 5개인 줄 알았는데 실은 다섯 중 셋이 `normalization_version` 하나에 가려져 있었습니다.

| 층 | 고친 것 | 남은 실패 |
| --- | --- | --- |
| 0 | 그대로 합침 | 5 |
| 1 | `normalization_version` | 2 |
| 2 | `observed_at` → `passed_stop_order` | 2 |
| 3 | `running_state` | 2 |
| 4 | `seat_unknown_reason` | **0** |

<br/>

### 못 만들게 된 테스트는 지우지 않고 아래층으로 내렸습니다

`운행_상태를_해석할_수_없는_관측은_그_행만_빼고_나머지를_반환한다` 하나가 DB 로는 못 만들어집니다.
**지우면 검증이 사라지니까** 행이 실제로 빠지는 자리를 찾아서 거기서 지키게 했습니다.

```java
// JpaVehicleQueryRepository.findVehicles
    .map(VehicleObservationJpaEntity::toDomain)
    .flatMap(Optional::stream)      // <<<<<< 행이 빠지는 자리가 여기
```

`JpaVehicleQueryRepositoryTest` 가 이미 Mockito 로 이 클래스를 보고 있어서
**DB 도 프로덕션 코드도 안 건드리고** 같은 규칙을 세울 수 있었습니다.

규칙이 세 곳으로 나뉩니다. 값 해석은 `VehiclePhaseTest`(원래 있던 것),
행 제외는 위의 단위 테스트, 애초에 안 쌓는 건 `VehicleObservationTableTest` 입니다.
지운 자리에 세 곳을 가리키는 주석을 남겼습니다.

<br/>

### `@Column(name)` 을 두 엔티티 전 필드에 붙였습니다

동키(`DongKey777`)가 #36 으로 세운 규약입니다. 같은 표를 양쪽이 매핑하면 양쪽 다 명시하는 것.
안 붙이면 이렇게 죽습니다. 합쳐서 실제로 띄워봤습니다.

```
DuplicateMappingException: Table [observation_batch] contains physical column name
[attempt_number] referred to by multiple logical column names: [attemptNumber], [attempt_number]
```

리포지터리 이름도 `Collector` 를 앞에 붙였습니다. Spring Data 인터페이스는 빈이고 빈 이름이
단순 클래스 이름에서 나와서, 조회 쪽과 같은 이름이면 `BeanDefinitionOverrideException` 이 납니다.
이것도 같은 이름 하나를 더 만들어 띄워보고 확인했습니다.

`@Id` 에는 안 붙였습니다. #36 이 고친 네 파일이 전부 안 붙였고 필드명이 `id` 라 갈릴 수가 없습니다.

<br/>

### `V1__collector.sql` 의 낡은 주석은 그대로 뒀습니다

`V1` 2번 줄이 CHECK 를 조일 티켓 목록에서 SAL-84 를 빼먹고 있습니다. 고치고 싶었는데 못 고칩니다.
**Flyway checksum 은 주석까지 계산해서**, 한 글자만 바꿔도 그 파일을 이미 돌린 DB 가 기동을 거부합니다.

무서운 건 **CI 가 이걸 못 잡는다**는 겁니다. 테스트는 매번 새 컨테이너로 `V1` 부터 다시 도니까 초록이 뜹니다.
깨지는 건 마이그레이션을 이미 돌려둔 DB 뿐이에요. 그래서 `V4` 머리말에 빠진 몫을 적어뒀습니다.

<br/>

## 확인 사항

**`V3` 의 `stops_to_target` 주석이 틀려서 `V4` 에서 열 주석으로 바로잡았습니다.**
주석은 `target_stop_order - 관측 stop_order` 인데 `VehicleStopTarget` 은 `passedStopOrder` 로 뺍니다.
6번 정류소에 **도착 중인** 버스가 10번을 예보하면 주석 기준 4, 코드 기준 5 이고 코드가 맞습니다.
`V3` 은 Flyway 라 못 고치니 `COMMENT ON COLUMN` 으로 덮었습니다. 동키 제안입니다.

**노선이 개편되면 묶음 행까지 사라집니다.** 상류에 정류소가 하나 끼면 `stationSeq` 가 밀려서
`fk_observation_route_stop` 이 거절하는데, 한 트랜잭션이라 `observation_batch` 행도 안 남습니다.
실측으로 확인했어요(남은 묶음 0 · 관측 0). 그러면 90초 간격 판정에서 **"개편 중이었다" 와 "수집기가 죽어 있었다" 가 구분이 안 됩니다.**
2026-08-25 에 "FK 를 유지하고 재시도는 안 넣는다" 로 결정된 건이라 이번엔 그대로 뒀습니다.

그래서 `V1__collector.sql` 115번 줄이 아직 이렇게 적혀 있습니다.
*"노선 개편으로 상류 순번과 우리 정류소 목록이 어긋나는 동안 관측이 버려진다. SAL-84 · SAL-88 몫."*
**우리 몫이라고 적힌 걸 안 하고 갑니다.** 고쳐 적고 싶은데 `V1` 은 Flyway 라 한 글자도 못 건드립니다.

**`/board` 는 아직 아무것도 못 찾습니다.** `forecast_completed_at IS NOT NULL` 인 묶음만 보는데
그 열은 예보 배치가 채웁니다. 스키마 주석대로 `processor` 몫입니다.
