### PR TITLE
setup(SAL-101): FE 자동 배포 buildspec 추가

### DIFF
--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -25,11 +25,11 @@ phases:
       - pnpm build
   post_build:
     commands:
-      # build가 실패해도 post_build는 실행되므로 이 줄이 배포 진입을 막는다
+      # build가 실패해도 post_build는 실행되므로 아래 라인이 배포를 막는 역할을 한다
       - test "$CODEBUILD_BUILD_SUCCEEDING" = "1"
       - cd "${CODEBUILD_SRC_DIR}/frontend"
       - APP_VERSION="$(echo "$CODEBUILD_RESOLVED_SOURCE_VERSION" | cut -c1-7)"
-      # 업로드 순서 고정 (SAL-100 결정 2): 자산 -> releases 사본 -> index.html -> invalidation
+      # 업로드 순서 (SAL-100 결정2): assets → releases 사본 → index.html → CloudFront 무효화
       - aws s3 sync dist/assets "${S3_BASE}/assets" --cache-control "public, max-age=31536000, immutable"
       - aws s3 cp "dist/index.html" "${S3_BASE}/releases/index-${APP_VERSION}.html" --cache-control "no-cache" --content-type "text/html"
       - aws s3 cp "dist/index.html" "${S3_BASE}/index.html" --cache-control "no-cache" --content-type "text/html"

--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -1,0 +1,36 @@
+version: 0.2
+
+env:
+  shell: bash
+  variables:
+    S3_BASE: "s3://techcourse-project-2026/salmonbus"
+    CLOUDFRONT_DISTRIBUTION_ID: "E1SSFHW3MNNQB8"
+
+phases:
+  install:
+    runtime-versions:
+      nodejs: 24
+    commands:
+      - corepack enable
+  pre_build:
+    commands:
+      - cd "${CODEBUILD_SRC_DIR}/frontend"
+      - pnpm install --frozen-lockfile
+      - pnpm typecheck
+      - pnpm lint
+  build:
+    commands:
+      - cd "${CODEBUILD_SRC_DIR}/frontend"
+      - export APP_VERSION="$(echo "$CODEBUILD_RESOLVED_SOURCE_VERSION" | cut -c1-7)"
+      - pnpm build
+  post_build:
+    commands:
+      # build가 실패해도 post_build는 실행되므로 이 줄이 배포 진입을 막는다
+      - test "$CODEBUILD_BUILD_SUCCEEDING" = "1"
+      - cd "${CODEBUILD_SRC_DIR}/frontend"
+      - APP_VERSION="$(echo "$CODEBUILD_RESOLVED_SOURCE_VERSION" | cut -c1-7)"
+      # 업로드 순서 고정 (SAL-100 결정 2): 자산 -> releases 사본 -> index.html -> invalidation
+      - aws s3 sync dist/assets "${S3_BASE}/assets" --cache-control "public, max-age=31536000, immutable"
+      - aws s3 cp "dist/index.html" "${S3_BASE}/releases/index-${APP_VERSION}.html" --cache-control "no-cache" --content-type "text/html"
+      - aws s3 cp "dist/index.html" "${S3_BASE}/index.html" --cache-control "no-cache" --content-type "text/html"
+      - aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" --paths "/*"


### PR DESCRIPTION
## 작업 내용

SAL-101(CodePipeline + CodeBuild 자동 배포)의 저장소 쪽 코드입니다. CodeBuild가 실행할 CD 정의 `frontend/buildspec.yml` 파일 하나를 추가합니다. 콘솔 쪽 작업(CodeBuild 프로젝트, CodePipeline 생성)은 티켓에서 별도로 진행 중입니다.

흐름은 SAL-100 운영 문서의 수동 배포 절차를 그대로 옮긴 것입니다.

| phase | 하는 일 |
|---|---|
| install | Node 24 런타임 + corepack(pnpm 11) |
| pre_build | `pnpm install --frozen-lockfile` → `typecheck` → `lint` (실패 시 빌드 미진입) |
| build | 커밋 SHA 7자를 `APP_VERSION`으로 주입 후 `pnpm build` (index.html meta 태그로 들어감) |
| post_build | 자산 sync(immutable, 누적) → releases 사본(no-cache) → index.html(no-cache) → invalidation `/*` |

설계 포인트 세 가지입니다.

1. **post_build 첫 줄의 `test "$CODEBUILD_BUILD_SUCCEEDING" = "1"`**: CodeBuild는 build가 실패해도 post_build를 실행합니다. 이 가드가 없으면 검증 실패한 산출물이 그대로 배포됩니다.
2. **`aws s3 sync`에 `--delete` 없음**: 누적 업로드(SAL-100 결정 1). 열린 탭의 지연 청크 요청이 깨지지 않게 하는 안전장치이고, 애초에 삭제 권한도 없습니다.
3. **매 phase에서 `cd "${CODEBUILD_SRC_DIR}/frontend"` 절대 경로**: phase 사이 작업 디렉터리 유지 여부가 이미지에 따라 달라 양쪽 모두에서 안전한 형태로 뒀습니다.

## 확인 사항

- [x] 로컬에서 정상 동작을 확인했습니다. (YAML 파싱 통과, `env/.env` 없이 셸 환경 변수만으로 빌드해 `WEBPACK_AMPLITUDE_API_KEY`가 번들에 주입되는 것 실측)
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다. (앱 코드 변경 0, CodeBuild만 읽는 파일)

## 참고 사항

- Amplitude 키는 이 파일이 아니라 CodeBuild 프로젝트의 환경 변수로 주입합니다. 저장소 어디에도 자격 증명이 없습니다.
- 파이프라인 소스 브랜치는 dev로 시작하고, 안정화 후 main으로 전환하기로 했습니다 (SAL-101 본문에 결정 기록). 즉 머지 후에는 dev 머지마다 자동 배포가 돌게 됩니다. 버전 1 소스는 경로 필터가 없어 백엔드 커밋에도 실행되는데, 빌드 몇 분 낭비는 허용하기로 한 사항입니다.
- 파일 위치가 리포 루트가 아니라 `frontend/`인 이유: CodeBuild 프로젝트 설정에서 경로를 지정하고, 루트는 나중에 BE 파이프라인이 쓸 수 있게 비워뒀습니다.
- 리뷰 포인트: post_build의 업로드 순서가 운영 문서(Confluence 11)의 수동 절차와 동일한지 봐주시면 됩니다.