### PR TITLE
setup(SAL-107): 검증부터 EC2 제자리 교체까지 잇는 배포 파이프라인

### DIFF
--- a/backend/buildspec.yml
+++ b/backend/buildspec.yml
@@ -1,0 +1,90 @@
+version: 0.2
+
+env:
+  shell: bash
+
+phases:
+  install:
+    runtime-versions:
+      java: corretto21
+
+  pre_build:
+    commands:
+      - cd "${CODEBUILD_SRC_DIR}/backend"
+      - java -version
+      # post_build 의 지문 계산이 이 셋을 쓴다. 없으면 여기서 알아보게 세운다
+      - for c in unzip sha256sum awk; do command -v "$c" >/dev/null || { echo "$c 가 없다"; exit 1; }; done
+      # backend-ci.yml 과 같은 검사다. 멀티모듈로 쪼갠 뒤 루트에 소스가 남으면 조용히 안 돈다
+      - test ! -d src
+
+  build:
+    commands:
+      - cd "${CODEBUILD_SRC_DIR}/backend"
+      # CI 와 같은 명령이다. 테스트 912개 중 35개 클래스가 Testcontainers 로 도커를 쓴다.
+      # 이 프로젝트에 특권 모드가 꺼져 있으면 여기서 실패한다
+      - ./gradlew clean build
+
+  post_build:
+    commands:
+      # build 가 실패해도 post_build 는 실행된다. 이 줄이 없으면 깨진 빌드가 배포로 나간다
+      - test "$CODEBUILD_BUILD_SUCCEEDING" = "1"
+      - cd "${CODEBUILD_SRC_DIR}/backend"
+      - |
+        set -euo pipefail
+
+        # build 는 실행 못 하는 -plain.jar 도 같이 만든다. 이름으로 걸러낸다
+        API_JAR="$(ls api-app/build/libs/api-app-*.jar | grep -v -- '-plain\.jar$')"
+        WORKER_JAR="$(ls worker-app/build/libs/worker-app-*.jar | grep -v -- '-plain\.jar$')"
+
+        RELEASE=build/release
+        rm -rf "$RELEASE"
+        mkdir -p "$RELEASE/jars" "$RELEASE/scripts" "$RELEASE/systemd"
+
+        cp "$API_JAR"    "$RELEASE/jars/api-app.jar"
+        cp "$WORKER_JAR" "$RELEASE/jars/worker-app.jar"
+        cp deploy/appspec.yml   "$RELEASE/appspec.yml"
+        cp deploy/scripts/*.sh  "$RELEASE/scripts/"
+        cp deploy/systemd/*.service "$RELEASE/systemd/"
+        chmod +x "$RELEASE/scripts/"*.sh
+      - |
+        set -euo pipefail
+        RELEASE=build/release
+
+        # 같은 커밋을 두 번 빌드해도 JAR 지문이 달라진다. 다른 항목은 build-info.properties 하나뿐이고
+        # 거기 든 build.time 이 매번 바뀐다. 그 항목을 빼고 세면 지문이 재현된다
+        stable_digest() {
+          unzip -v "$1" \
+            | awk 'NF>=8 {print $7, $8}' \
+            | grep -v 'META-INF/build-info.properties' \
+            | sort | sha256sum | cut -d' ' -f1
+        }
+
+        {
+          echo "commit=${CODEBUILD_RESOLVED_SOURCE_VERSION}"
+          echo "buildNumber=${CODEBUILD_BUILD_NUMBER}"
+          echo "builtAt=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "apiJarSha256=$(sha256sum "$RELEASE/jars/api-app.jar" | cut -d' ' -f1)"
+          echo "workerJarSha256=$(sha256sum "$RELEASE/jars/worker-app.jar" | cut -d' ' -f1)"
+          echo "apiDigest=$(stable_digest "$RELEASE/jars/api-app.jar")"
+          echo "workerDigest=$(stable_digest "$RELEASE/jars/worker-app.jar")"
+        } > "$RELEASE/release-manifest.txt"
+
+        cat "$RELEASE/release-manifest.txt"
+      - |
+        set -euo pipefail
+        # 비밀이 배포판에 섞였는지 본다. 걸리면 여기서 세운다. 값은 안 찍는다
+        if find build/release -name '.env*' | grep -q .; then
+          echo "배포판에 env 파일이 들어 있다"; exit 1
+        fi
+        for jar in build/release/jars/*.jar; do
+          if unzip -l "$jar" | grep -qiE '\.env|secret|\.pem|\.jks'; then
+            echo "JAR 안에 비밀로 보이는 항목이 있다: $jar"; exit 1
+          fi
+        done
+        echo "비밀 검사 통과"
+
+artifacts:
+  # appspec.yml 은 배포판 압축 파일의 최상단에 있어야 한다. base-directory 가 그 최상단을 정한다
+  base-directory: backend/build/release
+  files:
+    - '**/*'

--- a/backend/buildspec.yml
+++ b/backend/buildspec.yml
@@ -90,6 +90,20 @@ phases:
           if unzip -l "$jar" | grep -qiE '\.env|secret|\.pem|\.jks'; then
             echo "JAR 안에 비밀로 보이는 항목이 있다: $jar"; exit 1
           fi
+          # 항목 이름만 보면 application.yml 안에 값이 박힌 것을 못 잡는다.
+          # 자리표시자가 그대로 남아 있는지를 본다. 값이 박히면 ${...} 가 없어진다
+          for yml in $(unzip -Z1 "$jar" | grep -E '^BOOT-INF/classes/application.*\.(yml|yaml|properties)$'); do
+            body="$(unzip -p "$jar" "$yml")"
+            for key in DB_PASSWORD DB_USERNAME DB_URL; do
+              if printf '%s' "$body" | grep -q "$key" \
+                 && ! printf '%s' "$body" | grep -q "\${$key"; then
+                echo "$jar 의 $yml 에 $key 가 자리표시자가 아닌 값으로 들어 있다"; exit 1
+              fi
+            done
+            if printf '%s' "$body" | grep -qE 'service-key: *[A-Za-z0-9%+/=]{20,}'; then
+              echo "$jar 의 $yml 에 인증키로 보이는 값이 박혀 있다"; exit 1
+            fi
+          done
         done
         echo "비밀 검사 통과"
 

--- a/backend/buildspec.yml
+++ b/backend/buildspec.yml
@@ -108,6 +108,11 @@ phases:
         echo "비밀 검사 통과"
 
 artifacts:
+  # secondary-artifacts 만 쓸 때도 CodeBuild 는 최상위 files 를 요구한다.
+  # 없으면 YAML 파싱은 되는데 산출물이 안 만들어진다
+  files:
+    - '**/*'
+  base-directory: backend/build/revision
   # CodeDeploy 배포 그룹이 둘이라 revision 도 둘로 낸다.
   # 여기 이름은 CodeBuild 프로젝트의 secondary artifact 식별자와 같아야 한다
   secondary-artifacts:

--- a/backend/buildspec.yml
+++ b/backend/buildspec.yml
@@ -80,32 +80,8 @@ phases:
 
         pack api    "$API_JAR"    "$API_DIGEST"
         pack worker "$WORKER_JAR" "$WORKER_DIGEST"
-      - |
-        set -euo pipefail
-        # 비밀이 배포판에 섞였는지 본다. 걸리면 여기서 세운다. 값은 안 찍는다
-        if find build/revision -name '.env*' -o -name '*.pem' -o -name '*.jks' | grep -q .; then
-          echo "배포판에 비밀 파일이 들어 있다"; exit 1
-        fi
-        for jar in build/revision/*/jars/*.jar; do
-          if unzip -l "$jar" | grep -qiE '\.env|secret|\.pem|\.jks'; then
-            echo "JAR 안에 비밀로 보이는 항목이 있다: $jar"; exit 1
-          fi
-          # 항목 이름만 보면 application.yml 안에 값이 박힌 것을 못 잡는다.
-          # 자리표시자가 그대로 남아 있는지를 본다. 값이 박히면 ${...} 가 없어진다
-          for yml in $(unzip -Z1 "$jar" | grep -E '^BOOT-INF/classes/application.*\.(yml|yaml|properties)$'); do
-            body="$(unzip -p "$jar" "$yml")"
-            for key in DB_PASSWORD DB_USERNAME DB_URL; do
-              if printf '%s' "$body" | grep -q "$key" \
-                 && ! printf '%s' "$body" | grep -q "\${$key"; then
-                echo "$jar 의 $yml 에 $key 가 자리표시자가 아닌 값으로 들어 있다"; exit 1
-              fi
-            done
-            if printf '%s' "$body" | grep -qE 'service-key: *[A-Za-z0-9%+/=]{20,}'; then
-              echo "$jar 의 $yml 에 인증키로 보이는 값이 박혀 있다"; exit 1
-            fi
-          done
-        done
-        echo "비밀 검사 통과"
+      # 비밀 검사는 예행연습이 같은 파일을 돌린다. 한쪽만 고치면 어긋난다
+      - bash deploy/verify-revision.sh build/revision
 
 artifacts:
   # secondary-artifacts 만 쓸 때도 CodeBuild 는 최상위 files 를 요구한다.

--- a/backend/buildspec.yml
+++ b/backend/buildspec.yml
@@ -12,17 +12,17 @@ phases:
     commands:
       - cd "${CODEBUILD_SRC_DIR}/backend"
       - java -version
-      # post_build 의 지문 계산이 이 셋을 쓴다. 없으면 여기서 알아보게 세운다
-      - for c in unzip sha256sum awk; do command -v "$c" >/dev/null || { echo "$c 가 없다"; exit 1; }; done
+      # post_build 의 지문 계산이 이 넷을 쓴다. 없으면 여기서 알아보게 세운다
+      - for c in unzip sha256sum awk find; do command -v "$c" >/dev/null || { echo "$c 가 없다"; exit 1; }; done
       # backend-ci.yml 과 같은 검사다. 멀티모듈로 쪼갠 뒤 루트에 소스가 남으면 조용히 안 돈다
       - test ! -d src
 
   build:
     commands:
       - cd "${CODEBUILD_SRC_DIR}/backend"
-      # CI 와 같은 명령이다. 테스트 912개 중 35개 클래스가 Testcontainers 로 도커를 쓴다.
-      # 이 프로젝트에 특권 모드가 꺼져 있으면 여기서 실패한다
-      - ./gradlew clean build
+      # CI 와 같은 명령이다. Testcontainers 를 쓰는 35개 클래스와 boot JAR 두 개를 실제로 띄우는
+      # 테스트까지 다시 돈다. 프로젝트에 privileged mode 가 켜져 있어야 한다
+      - ./gradlew clean build --no-daemon
 
   post_build:
     commands:
@@ -32,51 +32,61 @@ phases:
       - |
         set -euo pipefail
 
+        # 재시작 여부는 JAR 지문으로 못 잰다. buildInfo() 가 넣는 build.time 때문에
+        # 같은 소스를 다시 빌드해도 JAR SHA-256 이 달라진다. 실측으로 확인했다.
+        # 그래서 런타임에 들어가는 소스 파일만 모아 센다.
+        # 테스트·문서·프론트만 바뀌면 이 값이 안 변해서 서비스를 안 건드린다
+        source_digest() {
+          find "$@" -type f -print0 2>/dev/null \
+            | LC_ALL=C sort -z \
+            | xargs -0 sha256sum \
+            | sha256sum | cut -d' ' -f1
+        }
+
+        COMMON="common/src/main common/build.gradle build.gradle settings.gradle gradle/wrapper/gradle-wrapper.properties"
+        API_DIGEST="$(source_digest api-app/src/main api-app/build.gradle $COMMON)"
+        WORKER_DIGEST="$(source_digest worker-app/src/main worker-app/build.gradle $COMMON)"
+
         # build 는 실행 못 하는 -plain.jar 도 같이 만든다. 이름으로 걸러낸다
         API_JAR="$(ls api-app/build/libs/api-app-*.jar | grep -v -- '-plain\.jar$')"
         WORKER_JAR="$(ls worker-app/build/libs/worker-app-*.jar | grep -v -- '-plain\.jar$')"
 
-        RELEASE=build/release
-        rm -rf "$RELEASE"
-        mkdir -p "$RELEASE/jars" "$RELEASE/scripts" "$RELEASE/systemd"
+        # 스키마 정본은 common 한 곳이라 두 앱이 같은 값을 싣는다
+        FLYWAY_MAX="$(ls common/src/main/resources/db/migration/V*__*.sql \
+          | sed 's#.*/V\([0-9][0-9]*\)__.*#\1#' | sort -n | tail -1)"
+        APP_VERSION="$(unzip -p "$API_JAR" META-INF/build-info.properties | sed -n 's/^build.version=//p')"
+        JAVA_VERSION="$(java -version 2>&1 | head -1 | sed 's/.*"\(.*\)".*/\1/')"
 
-        cp "$API_JAR"    "$RELEASE/jars/api-app.jar"
-        cp "$WORKER_JAR" "$RELEASE/jars/worker-app.jar"
-        cp deploy/appspec.yml   "$RELEASE/appspec.yml"
-        cp deploy/scripts/*.sh  "$RELEASE/scripts/"
-        cp deploy/systemd/*.service "$RELEASE/systemd/"
-        chmod +x "$RELEASE/scripts/"*.sh
-      - |
-        set -euo pipefail
-        RELEASE=build/release
-
-        # 같은 커밋을 두 번 빌드해도 JAR 지문이 달라진다. 다른 항목은 build-info.properties 하나뿐이고
-        # 거기 든 build.time 이 매번 바뀐다. 그 항목을 빼고 세면 지문이 재현된다
-        stable_digest() {
-          unzip -v "$1" \
-            | awk 'NF>=8 {print $7, $8}' \
-            | grep -v 'META-INF/build-info.properties' \
-            | sort | sha256sum | cut -d' ' -f1
+        pack() {
+          local component="$1" jar="$2" digest="$3"
+          local out="build/revision/$component"
+          rm -rf "$out"; mkdir -p "$out/jars" "$out/scripts" "$out/systemd"
+          cp "$jar" "$out/jars/$component-app.jar"
+          cp "deploy/appspec-$component.yml" "$out/appspec.yml"
+          cp deploy/scripts/*.sh "$out/scripts/"; chmod +x "$out/scripts/"*.sh
+          cp "deploy/systemd/salmonbus-$component.service" "$out/systemd/"
+          {
+            echo "component=$component"
+            echo "commit=${CODEBUILD_RESOLVED_SOURCE_VERSION}"
+            echo "sourceDigest=$digest"
+            echo "artifactSha256=$(sha256sum "$out/jars/$component-app.jar" | cut -d' ' -f1)"
+            echo "javaVersion=$JAVA_VERSION"
+            echo "appVersion=$APP_VERSION"
+            echo "flywayMaxVersion=$FLYWAY_MAX"
+            echo "builtAt=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } > "$out/release-manifest.txt"
+          echo "--- $component ---"; cat "$out/release-manifest.txt"
         }
 
-        {
-          echo "commit=${CODEBUILD_RESOLVED_SOURCE_VERSION}"
-          echo "buildNumber=${CODEBUILD_BUILD_NUMBER}"
-          echo "builtAt=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          echo "apiJarSha256=$(sha256sum "$RELEASE/jars/api-app.jar" | cut -d' ' -f1)"
-          echo "workerJarSha256=$(sha256sum "$RELEASE/jars/worker-app.jar" | cut -d' ' -f1)"
-          echo "apiDigest=$(stable_digest "$RELEASE/jars/api-app.jar")"
-          echo "workerDigest=$(stable_digest "$RELEASE/jars/worker-app.jar")"
-        } > "$RELEASE/release-manifest.txt"
-
-        cat "$RELEASE/release-manifest.txt"
+        pack api    "$API_JAR"    "$API_DIGEST"
+        pack worker "$WORKER_JAR" "$WORKER_DIGEST"
       - |
         set -euo pipefail
         # 비밀이 배포판에 섞였는지 본다. 걸리면 여기서 세운다. 값은 안 찍는다
-        if find build/release -name '.env*' | grep -q .; then
-          echo "배포판에 env 파일이 들어 있다"; exit 1
+        if find build/revision -name '.env*' -o -name '*.pem' -o -name '*.jks' | grep -q .; then
+          echo "배포판에 비밀 파일이 들어 있다"; exit 1
         fi
-        for jar in build/release/jars/*.jar; do
+        for jar in build/revision/*/jars/*.jar; do
           if unzip -l "$jar" | grep -qiE '\.env|secret|\.pem|\.jks'; then
             echo "JAR 안에 비밀로 보이는 항목이 있다: $jar"; exit 1
           fi
@@ -84,7 +94,14 @@ phases:
         echo "비밀 검사 통과"
 
 artifacts:
-  # appspec.yml 은 배포판 압축 파일의 최상단에 있어야 한다. base-directory 가 그 최상단을 정한다
-  base-directory: backend/build/release
-  files:
-    - '**/*'
+  # CodeDeploy 배포 그룹이 둘이라 revision 도 둘로 낸다.
+  # 여기 이름은 CodeBuild 프로젝트의 secondary artifact 식별자와 같아야 한다
+  secondary-artifacts:
+    ApiRevision:
+      base-directory: backend/build/revision/api
+      files:
+        - '**/*'
+    WorkerRevision:
+      base-directory: backend/build/revision/worker
+      files:
+        - '**/*'

--- a/backend/deploy/RUNBOOK.md
+++ b/backend/deploy/RUNBOOK.md
@@ -1,0 +1,155 @@
+# 배포와 복구 절차
+
+담당자가 아닌 사람이 이 문서만 보고 배포와 되돌리기를 할 수 있어야 한다.
+
+## 무엇이 어디 있나
+
+```
+/opt/salmonbus/releases/<커밋7자>-<빌드번호>/   판마다 따로 쌓인다. 셋만 남기고 지운다
+/opt/salmonbus/current                        지금 도는 판을 가리키는 바로가기
+/opt/salmonbus/previous                       직전 판을 가리키는 바로가기
+/etc/salmonbus/api.env                        api-app 이 읽는 값
+/etc/salmonbus/worker.env                     worker-app 이 읽는 값
+```
+
+**배포는 `/opt/salmonbus/` 만 갈아엎고 `/etc/salmonbus/` 는 손대지 않는다.**
+`appspec.yml` 의 `file_exists_behavior` 가 `OVERWRITE` 라 목적지 안의 파일은 덮어쓴다.
+그래서 배포가 지우면 안 되는 것을 목적지 안에 두지 않는다. 계수 파일도 같다.
+
+## 최초 1회. 서버에서 사람이 한다
+
+```bash
+sudo mkdir -p /opt/salmonbus /etc/salmonbus
+sudo useradd -r -s /sbin/nologin salmonbus
+
+sudo install -m 600 -o root -g root /dev/null /etc/salmonbus/api.env
+sudo install -m 600 -o root -g root /dev/null /etc/salmonbus/worker.env
+sudo vi /etc/salmonbus/api.env       # DB_URL · DB_USERNAME · DB_PASSWORD
+sudo vi /etc/salmonbus/worker.env    # 위 셋 + GBIS_SERVICE_KEY · COLLECTION_ENABLED
+```
+
+**`api.env` 에 `GBIS_SERVICE_KEY` 를 넣지 않는다.** `api-app` 은 그 값을 읽는 자리가 없다.
+빌드된 JAR 안에 `gbis` 라는 글자가 0개다. 넣으면 안 쓰는 곳에 비밀을 퍼뜨리는 것이다.
+
+자바 21 과 CodeDeploy agent 가 있어야 한다. 없으면 `preflight.sh` 가 배포를 세운다.
+
+systemd 유닛은 배포가 알아서 넣는다. 손으로 넣을 필요가 없다.
+
+### 값을 적을 때 조심할 것
+
+env 파일 값은 셸이 읽는 규칙을 탄다. 실측으로 확인한 것이다.
+
+| 값에 든 것 | 결과 |
+| --- | --- |
+| `+` `/` `=` `%` | 그대로 간다. 공공데이터포털 인증키는 여기 해당한다 |
+| `$` | **뒤가 조용히 잘린다** |
+| 따옴표 | 파일 읽기가 통째로 깨진다 |
+| 줄 끝이 CRLF | 값 끝에 안 보이는 바이트가 붙는다. 13자가 14자가 된다 |
+
+`vi` 로 직접 치면 안 생기고, 다른 데서 붙여넣을 때 생긴다.
+
+## 배포하기
+
+CodePipeline 화면에서 `Release change` 를 누른다. 단계가 넷이다.
+
+```
+Source          GitHub 에서 코드를 받는다
+Build           CodeBuild 가 backend/buildspec.yml 을 읽고 테스트와 빌드를 돌린다
+ManualApproval   사람이 승인 버튼을 누른다
+Deploy          CodeDeploy 가 EC2 에 올린다
+```
+
+**승인 전에 Build 로그의 마지막 부분을 본다.** `release-manifest.txt` 가 찍혀 있다.
+
+```
+commit=...          이번에 나가는 커밋
+apiDigest=...       api-app 의 내용 지문
+workerDigest=...    worker-app 의 내용 지문
+```
+
+## 바뀐 것만 다시 뜬다
+
+`install.sh` 가 새 목록과 지금 도는 판의 목록을 대조해서, **지문이 다른 서비스만** 다시 띄운다.
+
+```
+api 만 고친 배포     salmonbus-api 만 재시작. 수집이 안 끊긴다
+common 을 고친 배포   둘 다 재시작
+아무것도 안 바뀌면    둘 다 그대로 둔다. 죽어 있으면 올린다
+```
+
+지문은 JAR 을 통째로 센 값이 아니다. **`META-INF/build-info.properties` 를 빼고 센다.**
+그 안에 빌드 시각이 들어 있어서, 같은 커밋을 두 번 빌드해도 JAR 지문이 달라진다.
+빼고 세면 재현돼서 대조가 구실을 한다.
+
+## 되돌리기
+
+**대부분은 자동으로 된다.** `validate.sh` 가 실패하면 CodeDeploy 가 직전 성공 판을 다시 배포한다.
+배포 그룹에 `배포 실패 시 롤백` 이 켜져 있어야 한다.
+
+손으로 되돌릴 때는 이렇게 한다.
+
+```bash
+sudo ln -sfn "$(readlink -f /opt/salmonbus/previous)" /opt/salmonbus/current
+sudo systemctl restart salmonbus-api salmonbus-worker
+curl -s http://127.0.0.1:8080/actuator/health
+curl -s http://127.0.0.1:8081/actuator/health
+```
+
+**스키마는 안 돌아온다.** Flyway 마이그레이션은 앞으로만 간다.
+새 판이 `V13` 을 돌린 뒤에 되돌리면 코드는 옛 판인데 스키마는 `V13` 이다.
+두 앱 다 `ddl-auto: validate` 라, 열을 지우거나 이름을 바꾼 마이그레이션이었으면 **되돌린 쪽도 안 뜬다.**
+그런 마이그레이션을 낼 때는 되돌리기가 구실을 못 한다고 보고 배포해야 한다.
+
+## 값을 바꿀 때
+
+배포와 상관없이 언제든 할 수 있다. **파일을 고치는 것만으로는 안 바뀐다.**
+
+```bash
+sudo vi /etc/salmonbus/worker.env
+sudo systemctl restart salmonbus-worker
+```
+
+환경변수는 프로세스가 뜰 때 한 번 붙는다. 다시 띄워야 새 값을 쓴다.
+
+**`worker-app` 을 두 벌 띄우지 마라.** 하루 호출 한도가 정확히 두 배로 나간다.
+한도 10,000회에 두 노선 수집이 8,556회를 쓴다. `systemctl restart` 는 내린 뒤에 올려서 안 겹친다.
+
+## 값을 안 찍고 확인하기
+
+```bash
+stat -c '%a' /etc/salmonbus/worker.env                          # 600 이어야 한다
+grep -c '^GBIS_SERVICE_KEY=' /etc/salmonbus/worker.env          # 1 이어야 한다
+grep '^GBIS_SERVICE_KEY=' /etc/salmonbus/worker.env | cut -d= -f2- | tr -d '\n' | sha256sum | cut -c1-8
+```
+
+마지막 줄의 앞 8자를 포털 화면의 값과 대조한다. `grep -c` 의 `-c` 를 빼면 값이 그대로 찍힌다.
+
+**앱이 떴다는 것은 키가 맞다는 증거가 못 된다.** 틀린 키로도 4초에 뜨고 health 가 200 으로 온다.
+게다가 노선 버전이 없는 DB 에서는 수집이 Open API 를 부르지도 않아서 오류도 안 난다.
+
+## 상태 보기
+
+```bash
+systemctl status salmonbus-api salmonbus-worker
+journalctl -u salmonbus-worker -n 100 --no-pager
+curl -s http://127.0.0.1:8080/actuator/health      # api. 밖에서도 열린다
+curl -s http://127.0.0.1:8081/actuator/health      # worker. 이 기계 안에서만 열린다
+cat /opt/salmonbus/current/release-manifest.txt    # 지금 도는 커밋
+```
+
+**`/actuator/health/readiness` 를 쓰지 마라.** DB 가 끊겨도 200 `UP` 이 온다.
+그 그룹에는 `readinessState` 하나만 들어 있다. DB 까지 보는 것은 `/actuator/health` 쪽이고
+끊기면 503 `DOWN` 이 온다. `validate.sh` 도 그쪽을 본다.
+
+## 훅 스크립트를 고칠 때
+
+**`set -x` 를 쓰지 마라.** 훅 로그가 인스턴스에 남는다. env 값이 찍히면 파일 권한이 소용없다.
+
+AWS 없이 돌려볼 수 있다. 도커만 있으면 된다.
+
+```bash
+bash backend/deploy/rehearsal/run.sh
+```
+
+리눅스 컨테이너를 띄워 `systemctl` · `curl` · `java` 를 흉내로 바꿔 끼우고 배포를 네 번 돌린다.
+첫 배포, api 만 바뀐 배포, 아무것도 안 바뀐 배포, health 가 안 오르는 배포다. 검사 28개가 돈다.

--- a/backend/deploy/RUNBOOK.md
+++ b/backend/deploy/RUNBOOK.md
@@ -6,7 +6,7 @@
 
 API 와 Worker 를 따로 배포한다. 배포판도 따로, systemd 서비스도 따로다.
 
-```
+```text
 /opt/salmonbus/api/releases/<소스지문>/       판마다 따로 쌓인다. 셋만 남긴다
 /opt/salmonbus/api/current                    지금 도는 판을 가리키는 바로가기
 /opt/salmonbus/api/previous                   직전 판
@@ -21,7 +21,7 @@ API 와 Worker 를 따로 배포한다. 배포판도 따로, systemd 서비스�
 
 ## 포트
 
-```
+```text
 8080   API 클라이언트.  밖에 열린다
 8082   API Actuator.    127.0.0.1 에만 묶인다
 8081   Worker.          127.0.0.1 에만 묶인다. Actuator 도 여기다
@@ -45,7 +45,7 @@ sudo vi /etc/salmonbus/worker.env    # 위 셋 + GBIS_SERVICE_KEY · COLLECTION_
 
 첫 배포는 수집과 예보를 끈 채로 한다.
 
-```
+```text
 COLLECTION_ENABLED=false
 FORECAST_ENABLED=false
 ```
@@ -69,22 +69,28 @@ aws ssm get-parameter --name /salmonbus/probe --with-decryption --region ap-nort
 
 ### 값을 적을 때 조심할 것
 
-env 파일 값은 셸이 읽는 규칙을 탄다. 실측으로 확인한 것이다.
+**이 파일을 읽는 쪽이 둘이고 규칙이 다르다.** systemd 252 와 bash 로 각각 재봤다.
 
-| 값에 든 것 | 결과 |
-| --- | --- |
-| `+` `/` `=` `%` | 그대로 간다. 공공데이터포털 인증키는 여기 해당한다 |
-| `$` | **뒤가 조용히 잘린다** |
-| 따옴표 | 파일 읽기가 통째로 깨진다 |
-| 줄 끝이 CRLF | 값 끝에 안 보이는 바이트가 붙는다. 13자가 14자가 된다 |
+| 값에 든 것 | **앱에 들어갈 때**(systemd `EnvironmentFile=`) | 확인 명령을 돌릴 때(`set -a; . 파일`) |
+| --- | --- | --- |
+| `+` `/` `=` `%` | 그대로 | 그대로 |
+| `$` | 그대로. systemd 는 안 푼다 | **뒤가 조용히 잘린다** |
+| 따옴표 하나 | 그대로 | **파일 읽기가 통째로 깨진다** |
+| 줄 끝이 CRLF | **CR 을 떼어낸다** | 값 끝에 안 보이는 바이트가 붙는다 |
+| 끝에 공백 | **떼어낸다** | 그대로 남는다 |
 
-`vi` 로 직접 치면 안 생기고, 다른 데서 붙여넣을 때 생긴다.
+**앱 쪽은 systemd 가 다 정리해 준다.** 지금 포털이 주는 인증키는 영문과 숫자 64자라
+어느 쪽으로도 안 깨진다.
+
+**문제가 되는 것은 아래 확인 명령 쪽이다.** 파일이 CRLF 로 저장돼 있으면
+`sha256sum` 으로 뜬 값이 포털 값과 달라진다. 앱은 멀쩡히 도는데 대조만 어긋나서
+키가 틀린 줄 알고 헛짚게 된다. 그럴 때는 `sed -i 's/\r$//'` 로 줄 끝을 먼저 고친다.
 
 ## 배포하기
 
 CodePipeline `salmonbus-backend-cd` 에서 `Release change` 를 누른다.
 
-```
+```text
 Source           GitHub dev 에서 코드를 받는다
 BuildAndTest     salmonbus-backend-build 가 backend/buildspec.yml 을 읽는다
                  ./gradlew clean build --no-daemon 으로 테스트를 전부 다시 돌리고
@@ -98,7 +104,7 @@ DeployWorker     run order 2
 
 승인 전에 Build 로그 끝에 찍힌 배포판 목록을 본다.
 
-```
+```text
 component=api
 commit=...
 sourceDigest=...        <-- 이 값이 그대로면 그 서비스는 재시작 안 한다
@@ -113,7 +119,7 @@ flywayMaxVersion=12
 
 `sourceDigest` 는 JAR 이 아니라 **런타임에 들어가는 소스 파일**을 센 값이다.
 
-```
+```text
 api     api-app/src/main · api-app/build.gradle
         + common/src/main · common/build.gradle · build.gradle · settings.gradle · gradle-wrapper.properties
 worker  worker-app/ 쪽으로 같은 목록
@@ -231,6 +237,23 @@ bash backend/deploy/rehearsal/run.sh
 
 리눅스 컨테이너를 띄워 `systemctl` · `curl` · `java` 를 흉내로 바꿔 끼우고 배포를 여러 번 돌린다.
 첫 배포, api 만 바뀐 배포, 아무것도 안 바뀐 배포, 배포끼리 겹칠 때, 옛 프로세스가 응답할 때,
-health 가 안 오를 때다. 검사 27개가 돈다.
+health 가 안 오를 때, 그리고 되돌리기까지다. 검사 34개가 돈다.
+
+흉내는 **모르는 입력에 실패한다.** `systemctl` 이 모르는 명령을 받거나 `curl` 이 모르는 주소를
+받으면 거기서 멈춘다. 훅이 포트나 경로를 틀리면 예행연습이 통과하지 않는다.
 
 `digest.sh` 의 `source_digest` 는 `buildspec.yml` 에 있는 것과 같은 함수다. **한쪽을 고치면 둘 다 고친다.**
+
+예행연습의 `systemctl` 은 흉내라서 systemd 가 실제로 유닛을 읽는 것은 못 본다.
+그쪽은 systemd 252 를 컨테이너에 띄워 따로 쟀고, 아래 아홉이 확인됐다.
+
+```text
+유닛이 systemd-analyze verify 를 통과한다
+salmonbus 사용자로 뜬다
+0600 root:root 인 /etc/salmonbus/api.env 가 읽힌다
+판별용 release.env 도 같이 읽힌다
+MANAGEMENT_SERVER_PORT 가 유닛에서 들어간다
+current 바로가기의 JAR 로 뜬다
+0 이 아닌 코드로 죽으면 Restart=on-failure 가 다시 띄운다
+143 으로 끝나면 SuccessExitStatus=143 이 성공으로 본다
+```

--- a/backend/deploy/RUNBOOK.md
+++ b/backend/deploy/RUNBOOK.md
@@ -53,8 +53,11 @@ FORECAST_ENABLED=false
 **`api.env` 에 `GBIS_SERVICE_KEY` 를 넣지 않는다.** API 는 그 값을 읽는 자리가 없다.
 빌드된 JAR 안에 `gbis` 라는 글자가 0개다. 넣으면 안 쓰는 곳에 비밀을 퍼뜨리는 것이다.
 
-자바 21 과 CodeDeploy agent 가 있어야 한다. 없으면 `preflight.sh` 가 배포를 세운다.
-systemd 유닛은 배포가 알아서 넣는다.
+`/usr/bin/java` 가 21 이어야 하고 CodeDeploy agent 가 있어야 한다.
+없으면 `preflight.sh` 가 배포를 세운다.
+
+**systemd 유닛은 배포가 알아서 넣고 `enable` 까지 한다.** 손으로 할 것이 없다.
+`validate.sh` 가 `is-enabled` 로 확인해서, 재부팅 뒤에 안 올라오는 상태면 배포가 실패한다.
 
 ### 비밀을 어디 둘지 먼저 한 번 재 본다
 
@@ -134,6 +137,13 @@ JAR 의 SHA-256 이 달라진다. 실측으로 확인했다. 소스 지문으로
 **대부분 자동으로 된다.** `validate.sh` 가 실패하면 CodeDeploy 가 그 배포 그룹의 직전 성공 판을
 다시 배포한다. `salmonbus-api-prod` 와 `salmonbus-worker-prod` 가 따로라
 **API 가 실패해도 Worker 는 안 건드린다.** 반대도 같다.
+
+되돌리기가 오면 그 판이 `previous` 로 이미 디스크에 있다. `install.sh` 는 **그것을 지우지 않고
+그대로 쓰고 `current` 만 옮긴다.** 지우고 다시 풀면 되돌릴 것이 없어진다.
+
+실패한 배포는 `validate.sh` 까지 못 가서 배포 잠금을 쥔 채 끝난다. 그래서 같은 서비스의
+다음 배포는 그 잠금을 **넘겨받는다.** 안 그러면 자동 롤백이 자기가 남긴 잠금에 막힌다.
+다른 서비스가 잡고 있으면 그때는 기다리지 않고 멈춘다.
 
 손으로 되돌릴 때는 한쪽만 고른다.
 
@@ -225,6 +235,27 @@ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/api/v1/routes
 `db` · `diskSpace` · `ping` · `ssl` 같은 기본 항목뿐이라 API 와 응답이 같다.
 수집을 켠 뒤에는 `observation_batch` 의 최근 행을 보고 판단한다.
 
+```sql
+select max(started_at) from observation_batch;
+```
+
+## 후속으로 남긴 것
+
+**Worker 의 수집 신선도를 배포 확인에 넣는 일은 이 티켓에서 안 했다.**
+지금 `validate.sh` 는 프로세스와 DB 만 본다. 수집 작업이 멈추거나 Open API 호출이
+계속 실패해도 배포가 통과한다.
+
+첫 배포는 `COLLECTION_ENABLED=false` 로 나가서 볼 것이 없다.
+**넣는 시점은 수집을 켜는 때다.** 그때 둘 중 하나가 필요하다.
+
+| 무엇 | 어디를 고치나 |
+| --- | --- |
+| 최근 성공 시각을 보는 health 항목 | `worker-app` 에 `HealthIndicator` 를 하나 만든다 |
+| 스케줄러 heartbeat | 수집 회차마다 시각을 남기고 그것을 health 에 붙인다 |
+
+둘 다 애플리케이션 코드를 고치는 일이라 배포 티켓 밖으로 봤다.
+켜는 배포 전에 티켓을 세워야 한다.
+
 ## 훅 스크립트를 고칠 때
 
 **`set -x` 를 쓰지 마라.** 훅 로그가 인스턴스에 남는다. env 값이 찍히면 파일 권한이 소용없다.
@@ -237,7 +268,7 @@ bash backend/deploy/rehearsal/run.sh
 
 리눅스 컨테이너를 띄워 `systemctl` · `curl` · `java` 를 흉내로 바꿔 끼우고 배포를 여러 번 돌린다.
 첫 배포, api 만 바뀐 배포, 아무것도 안 바뀐 배포, 배포끼리 겹칠 때, 옛 프로세스가 응답할 때,
-health 가 안 오를 때, 그리고 되돌리기까지다. 검사 34개가 돈다.
+health 가 안 오를 때, 되돌리기, 손댄 배포판 목록까지다. 검사 42개가 돈다.
 
 흉내는 **모르는 입력에 실패한다.** `systemctl` 이 모르는 명령을 받거나 `curl` 이 모르는 주소를
 받으면 거기서 멈춘다. 훅이 포트나 경로를 틀리면 예행연습이 통과하지 않는다.

--- a/backend/deploy/RUNBOOK.md
+++ b/backend/deploy/RUNBOOK.md
@@ -4,36 +4,68 @@
 
 ## 무엇이 어디 있나
 
+API 와 Worker 를 따로 배포한다. 배포판도 따로, systemd 서비스도 따로다.
+
 ```
-/opt/salmonbus/releases/<커밋7자>-<빌드번호>/   판마다 따로 쌓인다. 셋만 남기고 지운다
-/opt/salmonbus/current                        지금 도는 판을 가리키는 바로가기
-/opt/salmonbus/previous                       직전 판을 가리키는 바로가기
-/etc/salmonbus/api.env                        api-app 이 읽는 값
-/etc/salmonbus/worker.env                     worker-app 이 읽는 값
+/opt/salmonbus/api/releases/<소스지문>/       판마다 따로 쌓인다. 셋만 남긴다
+/opt/salmonbus/api/current                    지금 도는 판을 가리키는 바로가기
+/opt/salmonbus/api/previous                   직전 판
+/opt/salmonbus/worker/...                     같은 모양으로 하나 더
+
+/etc/salmonbus/api.env                        API 가 읽는 값
+/etc/salmonbus/worker.env                     Worker 가 읽는 값
+/var/lib/salmonbus/model/current/             계수 파일. 사람이 갖다 놓는다
 ```
 
-**배포는 `/opt/salmonbus/` 만 갈아엎고 `/etc/salmonbus/` 는 손대지 않는다.**
-`appspec.yml` 의 `file_exists_behavior` 가 `OVERWRITE` 라 목적지 안의 파일은 덮어쓴다.
-그래서 배포가 지우면 안 되는 것을 목적지 안에 두지 않는다. 계수 파일도 같다.
+**배포는 `/opt/salmonbus/` 만 갈아엎는다.** `/etc/salmonbus/` 와 `/var/lib/salmonbus/` 는 손대지 않는다.
+
+## 포트
+
+```
+8080   API 클라이언트.  밖에 열린다
+8082   API Actuator.    127.0.0.1 에만 묶인다
+8081   Worker.          127.0.0.1 에만 묶인다. Actuator 도 여기다
+```
+
+**API 의 Actuator 를 클라이언트 포트에서 뗐다.** systemd 유닛의 `MANAGEMENT_SERVER_PORT` 와
+`MANAGEMENT_SERVER_ADDRESS` 로 옮긴 것이라 `application.yml` 은 안 고쳤다.
 
 ## 최초 1회. 서버에서 사람이 한다
 
 ```bash
-sudo mkdir -p /opt/salmonbus /etc/salmonbus
 sudo useradd -r -s /sbin/nologin salmonbus
+sudo mkdir -p /opt/salmonbus /etc/salmonbus /var/lib/salmonbus/model/current
+sudo chown -R salmonbus:salmonbus /var/lib/salmonbus
 
 sudo install -m 600 -o root -g root /dev/null /etc/salmonbus/api.env
 sudo install -m 600 -o root -g root /dev/null /etc/salmonbus/worker.env
 sudo vi /etc/salmonbus/api.env       # DB_URL · DB_USERNAME · DB_PASSWORD
-sudo vi /etc/salmonbus/worker.env    # 위 셋 + GBIS_SERVICE_KEY · COLLECTION_ENABLED
+sudo vi /etc/salmonbus/worker.env    # 위 셋 + GBIS_SERVICE_KEY · COLLECTION_ENABLED · FORECAST_ENABLED
 ```
 
-**`api.env` 에 `GBIS_SERVICE_KEY` 를 넣지 않는다.** `api-app` 은 그 값을 읽는 자리가 없다.
+첫 배포는 수집과 예보를 끈 채로 한다.
+
+```
+COLLECTION_ENABLED=false
+FORECAST_ENABLED=false
+```
+
+**`api.env` 에 `GBIS_SERVICE_KEY` 를 넣지 않는다.** API 는 그 값을 읽는 자리가 없다.
 빌드된 JAR 안에 `gbis` 라는 글자가 0개다. 넣으면 안 쓰는 곳에 비밀을 퍼뜨리는 것이다.
 
 자바 21 과 CodeDeploy agent 가 있어야 한다. 없으면 `preflight.sh` 가 배포를 세운다.
+systemd 유닛은 배포가 알아서 넣는다.
 
-systemd 유닛은 배포가 알아서 넣는다. 손으로 넣을 필요가 없다.
+### 비밀을 어디 둘지 먼저 한 번 재 본다
+
+인스턴스 역할이 Parameter Store 를 읽을 수 있으면 그쪽이 낫다. 서버에서 한 번만 재면 된다.
+
+```bash
+aws ssm get-parameter --name /salmonbus/probe --with-decryption --region ap-northeast-2
+```
+
+`ParameterNotFound` 가 오면 **권한은 있는 것이다.** `AccessDeniedException` 이 오면 없는 것이고,
+그때는 아래 env 파일 방식으로 간다. 지금 이 문서는 env 파일을 전제로 쓰여 있다.
 
 ### 값을 적을 때 조심할 것
 
@@ -50,55 +82,70 @@ env 파일 값은 셸이 읽는 규칙을 탄다. 실측으로 확인한 것이�
 
 ## 배포하기
 
-CodePipeline 화면에서 `Release change` 를 누른다. 단계가 넷이다.
+CodePipeline `salmonbus-backend-cd` 에서 `Release change` 를 누른다.
 
 ```
-Source          GitHub 에서 코드를 받는다
-Build           CodeBuild 가 backend/buildspec.yml 을 읽고 테스트와 빌드를 돌린다
+Source           GitHub dev 에서 코드를 받는다
+BuildAndTest     salmonbus-backend-build 가 backend/buildspec.yml 을 읽는다
+                 ./gradlew clean build --no-daemon 으로 테스트를 전부 다시 돌리고
+                 ApiRevision · WorkerRevision 두 벌을 낸다
 ManualApproval   사람이 승인 버튼을 누른다
-Deploy          CodeDeploy 가 EC2 에 올린다
+DeployApi        run order 1
+DeployWorker     run order 2
 ```
 
-**승인 전에 Build 로그의 마지막 부분을 본다.** `release-manifest.txt` 가 찍혀 있다.
+**API 를 먼저 올리고 확인한 뒤에 Worker 가 나간다.** 두 프로세스를 같이 재시작하지 않는다.
+
+승인 전에 Build 로그 끝에 찍힌 배포판 목록을 본다.
 
 ```
-commit=...          이번에 나가는 커밋
-apiDigest=...       api-app 의 내용 지문
-workerDigest=...    worker-app 의 내용 지문
+component=api
+commit=...
+sourceDigest=...        <-- 이 값이 그대로면 그 서비스는 재시작 안 한다
+artifactSha256=...      <-- 무결성 확인용
+flywayMaxVersion=12
 ```
 
 ## 바뀐 것만 다시 뜬다
 
-`install.sh` 가 새 목록과 지금 도는 판의 목록을 대조해서, **지문이 다른 서비스만** 다시 띄운다.
+`install.sh` 가 새 배포판의 `sourceDigest` 와 지금 도는 판의 값을 대조한다.
+다르면 내렸다 올리고, 같으면 그대로 둔다.
+
+`sourceDigest` 는 JAR 이 아니라 **런타임에 들어가는 소스 파일**을 센 값이다.
 
 ```
-api 만 고친 배포     salmonbus-api 만 재시작. 수집이 안 끊긴다
-common 을 고친 배포   둘 다 재시작
-아무것도 안 바뀌면    둘 다 그대로 둔다. 죽어 있으면 올린다
+api     api-app/src/main · api-app/build.gradle
+        + common/src/main · common/build.gradle · build.gradle · settings.gradle · gradle-wrapper.properties
+worker  worker-app/ 쪽으로 같은 목록
 ```
 
-지문은 JAR 을 통째로 센 값이 아니다. **`META-INF/build-info.properties` 를 빼고 센다.**
-그 안에 빌드 시각이 들어 있어서, 같은 커밋을 두 번 빌드해도 JAR 지문이 달라진다.
-빼고 세면 재현돼서 대조가 구실을 한다.
+**JAR 지문으로는 못 잰다.** `buildInfo()` 가 넣는 `build.time` 때문에 같은 소스를 다시 빌드해도
+JAR 의 SHA-256 이 달라진다. 실측으로 확인했다. 소스 지문으로 재면 테스트·문서·프론트만 바뀐 배포에
+서비스를 안 건드린다.
 
 ## 되돌리기
 
-**대부분은 자동으로 된다.** `validate.sh` 가 실패하면 CodeDeploy 가 직전 성공 판을 다시 배포한다.
-배포 그룹에 `배포 실패 시 롤백` 이 켜져 있어야 한다.
+**대부분 자동으로 된다.** `validate.sh` 가 실패하면 CodeDeploy 가 그 배포 그룹의 직전 성공 판을
+다시 배포한다. `salmonbus-api-prod` 와 `salmonbus-worker-prod` 가 따로라
+**API 가 실패해도 Worker 는 안 건드린다.** 반대도 같다.
 
-손으로 되돌릴 때는 이렇게 한다.
+손으로 되돌릴 때는 한쪽만 고른다.
 
 ```bash
-sudo ln -sfn "$(readlink -f /opt/salmonbus/previous)" /opt/salmonbus/current
-sudo systemctl restart salmonbus-api salmonbus-worker
-curl -s http://127.0.0.1:8080/actuator/health
-curl -s http://127.0.0.1:8081/actuator/health
+C=api            # 또는 worker
+sudo ln -sfn "$(readlink -f /opt/salmonbus/$C/previous)" /opt/salmonbus/$C/current
+sudo systemctl restart salmonbus-$C
+curl -s http://127.0.0.1:8082/actuator/info     # api. 지금 도는 판을 확인한다
+curl -s http://127.0.0.1:8081/actuator/info     # worker
 ```
 
 **스키마는 안 돌아온다.** Flyway 마이그레이션은 앞으로만 간다.
 새 판이 `V13` 을 돌린 뒤에 되돌리면 코드는 옛 판인데 스키마는 `V13` 이다.
-두 앱 다 `ddl-auto: validate` 라, 열을 지우거나 이름을 바꾼 마이그레이션이었으면 **되돌린 쪽도 안 뜬다.**
-그런 마이그레이션을 낼 때는 되돌리기가 구실을 못 한다고 보고 배포해야 한다.
+두 앱 다 `ddl-auto: validate` 라 **열을 지우거나 이름을 바꾼 마이그레이션이었으면 되돌린 쪽도 안 뜬다.**
+
+그래서 한 배포에 들어가는 마이그레이션은 **직전 API 와 직전 Worker 가 그대로 뜰 수 있는 것만** 낸다.
+열·테이블·제약을 지우거나 이름을 바꾸는 것은, 옛 코드가 그것을 안 쓰게 만든 배포를 먼저 낸 뒤
+다음 배포에서 따로 한다.
 
 ## 값을 바꿀 때
 
@@ -109,10 +156,34 @@ sudo vi /etc/salmonbus/worker.env
 sudo systemctl restart salmonbus-worker
 ```
 
-환경변수는 프로세스가 뜰 때 한 번 붙는다. 다시 띄워야 새 값을 쓴다.
+환경변수는 프로세스가 뜰 때 한 번 붙는다.
 
-**`worker-app` 을 두 벌 띄우지 마라.** 하루 호출 한도가 정확히 두 배로 나간다.
-한도 10,000회에 두 노선 수집이 8,556회를 쓴다. `systemctl restart` 는 내린 뒤에 올려서 안 겹친다.
+**`salmonbus-worker` 를 두 벌 띄우지 마라.** 하루 호출 한도가 정확히 두 배로 나간다.
+한도 10,000회에 두 노선 수집이 8,556회를 쓴다. `start.sh` 는 `restart` 를 안 쓰고
+`stop` 한 뒤 프로세스가 완전히 사라진 것을 보고 나서 `start` 한다.
+
+## 수집을 켜고 끄기
+
+```bash
+sudo sed -i 's/^COLLECTION_ENABLED=.*/COLLECTION_ENABLED=true/' /etc/salmonbus/worker.env
+sudo systemctl restart salmonbus-worker
+```
+
+**켜면 15초마다 Open API 로 실호출이 나간다.** 켠 뒤에는 Worker 배포를 KST 01:00~04:00 에 한다.
+다른 시간대는 수집 간격이 15~20초라 Worker 가 내려가 있는 동안 관측이 빈다.
+
+## 계수 파일 갈아 끼우기
+
+```bash
+sudo -u salmonbus cp manifest.json weights.safetensors /var/lib/salmonbus/model/current/
+sudo sed -i 's/^MODEL_BUNDLE_PROMOTE_ON_START=.*/MODEL_BUNDLE_PROMOTE_ON_START=true/' /etc/salmonbus/worker.env
+sudo systemctl restart salmonbus-worker
+# 올라간 것을 확인한 뒤 반드시 다시 끈다
+sudo sed -i 's/^MODEL_BUNDLE_PROMOTE_ON_START=.*/MODEL_BUNDLE_PROMOTE_ON_START=false/' /etc/salmonbus/worker.env
+```
+
+**켠 채로 두면 배포로 재기동할 때마다 디스크에 있는 계수가 올라간다.**
+운영 기본값은 `false` 이고 systemd 유닛에도 그렇게 박혀 있다.
 
 ## 값을 안 찍고 확인하기
 
@@ -132,14 +203,21 @@ grep '^GBIS_SERVICE_KEY=' /etc/salmonbus/worker.env | cut -d= -f2- | tr -d '\n' 
 ```bash
 systemctl status salmonbus-api salmonbus-worker
 journalctl -u salmonbus-worker -n 100 --no-pager
-curl -s http://127.0.0.1:8080/actuator/health      # api. 밖에서도 열린다
-curl -s http://127.0.0.1:8081/actuator/health      # worker. 이 기계 안에서만 열린다
-cat /opt/salmonbus/current/release-manifest.txt    # 지금 도는 커밋
+
+curl -s http://127.0.0.1:8082/actuator/health    # api
+curl -s http://127.0.0.1:8082/actuator/info      # component · commit · sourcedigest
+curl -s http://127.0.0.1:8081/actuator/health    # worker
+curl -s http://127.0.0.1:8081/actuator/info
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/api/v1/routes
 ```
 
 **`/actuator/health/readiness` 를 쓰지 마라.** DB 가 끊겨도 200 `UP` 이 온다.
 그 그룹에는 `readinessState` 하나만 들어 있다. DB 까지 보는 것은 `/actuator/health` 쪽이고
 끊기면 503 `DOWN` 이 온다. `validate.sh` 도 그쪽을 본다.
+
+**수집이 실제로 도는지는 health 가 말해주지 않는다.** 지금 Worker 의 health 에는
+`db` · `diskSpace` · `ping` · `ssl` 같은 기본 항목뿐이라 API 와 응답이 같다.
+수집을 켠 뒤에는 `observation_batch` 의 최근 행을 보고 판단한다.
 
 ## 훅 스크립트를 고칠 때
 
@@ -151,5 +229,8 @@ AWS 없이 돌려볼 수 있다. 도커만 있으면 된다.
 bash backend/deploy/rehearsal/run.sh
 ```
 
-리눅스 컨테이너를 띄워 `systemctl` · `curl` · `java` 를 흉내로 바꿔 끼우고 배포를 네 번 돌린다.
-첫 배포, api 만 바뀐 배포, 아무것도 안 바뀐 배포, health 가 안 오르는 배포다. 검사 28개가 돈다.
+리눅스 컨테이너를 띄워 `systemctl` · `curl` · `java` 를 흉내로 바꿔 끼우고 배포를 여러 번 돌린다.
+첫 배포, api 만 바뀐 배포, 아무것도 안 바뀐 배포, 배포끼리 겹칠 때, 옛 프로세스가 응답할 때,
+health 가 안 오를 때다. 검사 27개가 돈다.
+
+`digest.sh` 의 `source_digest` 는 `buildspec.yml` 에 있는 것과 같은 함수다. **한쪽을 고치면 둘 다 고친다.**

--- a/backend/deploy/RUNBOOK.md
+++ b/backend/deploy/RUNBOOK.md
@@ -37,6 +37,7 @@ sudo useradd -r -s /sbin/nologin salmonbus
 sudo mkdir -p /opt/salmonbus /etc/salmonbus /var/lib/salmonbus/model/current
 sudo chown -R salmonbus:salmonbus /var/lib/salmonbus
 
+# 권한 600 과 주인 root:root 를 preflight.sh 가 확인한다. 다르면 배포가 멈춘다
 sudo install -m 600 -o root -g root /dev/null /etc/salmonbus/api.env
 sudo install -m 600 -o root -g root /dev/null /etc/salmonbus/worker.env
 sudo vi /etc/salmonbus/api.env       # DB_URL · DB_USERNAME · DB_PASSWORD
@@ -118,7 +119,17 @@ flywayMaxVersion=12
 ## 바뀐 것만 다시 뜬다
 
 `install.sh` 가 새 배포판의 `sourceDigest` 와 지금 도는 판의 값을 대조한다.
-다르면 내렸다 올리고, 같으면 그대로 둔다.
+다르면 내렸다 올린다.
+
+**같아도 재시작하는 경우가 있다.** systemd 유닛 파일이 바뀌었을 때다.
+`MANAGEMENT_SERVER_PORT` · `Restart=` · `EnvironmentFile=` · 힙 크기는 소스가 아니라 유닛에 있어서
+`sourceDigest` 가 그대로여도 바뀔 수 있다. 그러면 다시 띄워야 새 설정이 먹는다.
+
+```text
+소스 지문이 다르다            내렸다 올린다
+소스 지문이 같고 유닛이 다르다   내렸다 올린다
+둘 다 같다                   그대로 둔다. 다만 안 돌고 있으면 올린다
+```
 
 `sourceDigest` 는 JAR 이 아니라 **런타임에 들어가는 소스 파일**을 센 값이다.
 
@@ -168,11 +179,13 @@ curl -s http://127.0.0.1:8081/actuator/info     # worker
 배포와 상관없이 언제든 할 수 있다. **파일을 고치는 것만으로는 안 바뀐다.**
 
 ```bash
-sudo vi /etc/salmonbus/worker.env
-sudo systemctl restart salmonbus-worker
+C=worker          # 또는 api
+sudo vi "/etc/salmonbus/${C}.env"
+sudo systemctl restart "salmonbus-${C}"
 ```
 
-환경변수는 프로세스가 뜰 때 한 번 붙는다.
+환경변수는 프로세스가 뜰 때 한 번 붙는다. **`api.env` 를 고쳤으면 `salmonbus-api` 를 띄워야 한다.**
+`worker` 만 재시작하면 API 는 옛 값을 계속 쓴다.
 
 **`salmonbus-worker` 를 두 벌 띄우지 마라.** 하루 호출 한도가 정확히 두 배로 나간다.
 한도 10,000회에 두 노선 수집이 8,556회를 쓴다. `start.sh` 는 `restart` 를 안 쓰고
@@ -268,7 +281,11 @@ bash backend/deploy/rehearsal/run.sh
 
 리눅스 컨테이너를 띄워 `systemctl` · `curl` · `java` 를 흉내로 바꿔 끼우고 배포를 여러 번 돌린다.
 첫 배포, api 만 바뀐 배포, 아무것도 안 바뀐 배포, 배포끼리 겹칠 때, 옛 프로세스가 응답할 때,
-health 가 안 오를 때, 되돌리기, 손댄 배포판 목록까지다. 검사 42개가 돈다.
+health 가 안 오를 때, 되돌리기, 손댄 배포판 목록, 잠금을 둘이 동시에 잡을 때까지다.
+검사 48개가 돈다.
+
+배포판에 비밀이 섞였는지 보는 `verify-revision.sh` 도 여기서 같이 돈다.
+**CodeBuild 가 부르는 것과 같은 파일이다.** `scripts/` 밖에 있어서 EC2 로는 안 나간다.
 
 흉내는 **모르는 입력에 실패한다.** `systemctl` 이 모르는 명령을 받거나 `curl` 이 모르는 주소를
 받으면 거기서 멈춘다. 훅이 포트나 경로를 틀리면 예행연습이 통과하지 않는다.

--- a/backend/deploy/appspec-api.yml
+++ b/backend/deploy/appspec-api.yml
@@ -3,18 +3,18 @@ os: linux
 
 # 받은 것을 바로 쓰는 자리에 풀지 않고 staging 에 푼다.
 # 판마다 폴더를 따로 두려면 목적지가 판마다 달라야 하는데 appspec 은 값을 못 받는다.
-# 그래서 install.sh 가 staging 에서 releases/<판> 으로 옮긴다
+# 그래서 install.sh 가 staging 에서 releases/<소스지문> 으로 옮긴다
 files:
   - source: /
-    destination: /opt/salmonbus/staging
+    destination: /opt/salmonbus/api/staging
 
 # 지난 배포가 안 놓은 파일이 목적지에 있으면 기본값(DISALLOW)은 배포를 실패시킨다.
 # staging 에는 우리 것만 있어서 덮어써도 된다.
-# env 파일은 /etc/salmonbus/ 에 있어서 이 설정이 안 닿는다
+# 비밀은 /etc/salmonbus/, 계수 파일은 /var/lib/salmonbus/ 에 있어서 이 설정이 안 닿는다
 file_exists_behavior: OVERWRITE
 
 permissions:
-  - object: /opt/salmonbus/staging
+  - object: /opt/salmonbus/api/staging
     owner: root
     group: root
     mode: "755"
@@ -22,15 +22,13 @@ permissions:
       - directory
       - file
 
-# ApplicationStop 을 안 쓴다.
-# 여기서 두 서비스를 내리면 api 만 바뀐 배포에도 worker 가 멈춘다.
-# 지금 구조는 판마다 폴더가 따로라 옛 JAR 을 열어둔 프로세스가 그대로 돌아도 안전하다.
-# 그래서 start.sh 에서 바뀐 서비스만 systemctl restart 로 내렸다 올린다.
-# restart 는 내린 뒤에 올리니까 worker 가 두 벌 겹치는 구간이 안 생긴다
+# ApplicationStop 을 안 쓴다. 그 훅은 이전 revision 의 스크립트가 도는 자리라
+# 새 배포 로직을 두면 옛 판이 새 규칙을 모르는 채로 실행한다.
+# 서비스를 내리는 것은 start.sh 가 한다
 hooks:
   BeforeInstall:
     - location: scripts/preflight.sh
-      timeout: 120
+      timeout: 180
       runas: root
   AfterInstall:
     - location: scripts/install.sh

--- a/backend/deploy/appspec-worker.yml
+++ b/backend/deploy/appspec-worker.yml
@@ -1,0 +1,44 @@
+version: 0.0
+os: linux
+
+# 받은 것을 바로 쓰는 자리에 풀지 않고 staging 에 푼다.
+# 판마다 폴더를 따로 두려면 목적지가 판마다 달라야 하는데 appspec 은 값을 못 받는다.
+# 그래서 install.sh 가 staging 에서 releases/<소스지문> 으로 옮긴다
+files:
+  - source: /
+    destination: /opt/salmonbus/worker/staging
+
+# 지난 배포가 안 놓은 파일이 목적지에 있으면 기본값(DISALLOW)은 배포를 실패시킨다.
+# staging 에는 우리 것만 있어서 덮어써도 된다.
+# 비밀은 /etc/salmonbus/, 계수 파일은 /var/lib/salmonbus/ 에 있어서 이 설정이 안 닿는다
+file_exists_behavior: OVERWRITE
+
+permissions:
+  - object: /opt/salmonbus/worker/staging
+    owner: root
+    group: root
+    mode: "755"
+    type:
+      - directory
+      - file
+
+# ApplicationStop 을 안 쓴다. 그 훅은 이전 revision 의 스크립트가 도는 자리라
+# 새 배포 로직을 두면 옛 판이 새 규칙을 모르는 채로 실행한다.
+# 서비스를 내리는 것은 start.sh 가 한다
+hooks:
+  BeforeInstall:
+    - location: scripts/preflight.sh
+      timeout: 180
+      runas: root
+  AfterInstall:
+    - location: scripts/install.sh
+      timeout: 300
+      runas: root
+  ApplicationStart:
+    - location: scripts/start.sh
+      timeout: 300
+      runas: root
+  ValidateService:
+    - location: scripts/validate.sh
+      timeout: 300
+      runas: root

--- a/backend/deploy/appspec.yml
+++ b/backend/deploy/appspec.yml
@@ -1,0 +1,46 @@
+version: 0.0
+os: linux
+
+# 받은 것을 바로 쓰는 자리에 풀지 않고 staging 에 푼다.
+# 판마다 폴더를 따로 두려면 목적지가 판마다 달라야 하는데 appspec 은 값을 못 받는다.
+# 그래서 install.sh 가 staging 에서 releases/<판> 으로 옮긴다
+files:
+  - source: /
+    destination: /opt/salmonbus/staging
+
+# 지난 배포가 안 놓은 파일이 목적지에 있으면 기본값(DISALLOW)은 배포를 실패시킨다.
+# staging 에는 우리 것만 있어서 덮어써도 된다.
+# env 파일은 /etc/salmonbus/ 에 있어서 이 설정이 안 닿는다
+file_exists_behavior: OVERWRITE
+
+permissions:
+  - object: /opt/salmonbus/staging
+    owner: root
+    group: root
+    mode: "755"
+    type:
+      - directory
+      - file
+
+# ApplicationStop 을 안 쓴다.
+# 여기서 두 서비스를 내리면 api 만 바뀐 배포에도 worker 가 멈춘다.
+# 지금 구조는 판마다 폴더가 따로라 옛 JAR 을 열어둔 프로세스가 그대로 돌아도 안전하다.
+# 그래서 start.sh 에서 바뀐 서비스만 systemctl restart 로 내렸다 올린다.
+# restart 는 내린 뒤에 올리니까 worker 가 두 벌 겹치는 구간이 안 생긴다
+hooks:
+  BeforeInstall:
+    - location: scripts/preflight.sh
+      timeout: 120
+      runas: root
+  AfterInstall:
+    - location: scripts/install.sh
+      timeout: 300
+      runas: root
+  ApplicationStart:
+    - location: scripts/start.sh
+      timeout: 300
+      runas: root
+  ValidateService:
+    - location: scripts/validate.sh
+      timeout: 300
+      runas: root

--- a/backend/deploy/rehearsal/digest.sh
+++ b/backend/deploy/rehearsal/digest.sh
@@ -1,0 +1,6 @@
+stable_digest() {
+  unzip -v "$1" \
+    | awk 'NF>=8 {print $7, $8}' \
+    | grep -v 'META-INF/build-info.properties' \
+    | sort | sha256sum | cut -d' ' -f1
+}

--- a/backend/deploy/rehearsal/digest.sh
+++ b/backend/deploy/rehearsal/digest.sh
@@ -1,6 +1,8 @@
-stable_digest() {
-  unzip -v "$1" \
-    | awk 'NF>=8 {print $7, $8}' \
-    | grep -v 'META-INF/build-info.properties' \
-    | sort | sha256sum | cut -d' ' -f1
+# buildspec.yml 의 post_build 에 있는 것과 같은 함수다.
+# 여기서 고치면 buildspec 도 같이 고쳐야 한다
+source_digest() {
+  find "$@" -type f -print0 2>/dev/null \
+    | LC_ALL=C sort -z \
+    | xargs -0 sha256sum \
+    | sha256sum | cut -d' ' -f1
 }

--- a/backend/deploy/rehearsal/makejar.py
+++ b/backend/deploy/rehearsal/makejar.py
@@ -1,0 +1,15 @@
+import sys, zipfile, time
+path, artifact, body, built_at = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+with zipfile.ZipFile(path, 'w', zipfile.ZIP_DEFLATED) as z:
+    # bootJar 처럼 모든 항목 시각을 고정한다
+    def add(name, data):
+        info = zipfile.ZipInfo(name, date_time=(1980, 2, 1, 0, 0, 0))
+        info.compress_type = zipfile.ZIP_DEFLATED
+        z.writestr(info, data)
+    add('META-INF/MANIFEST.MF',
+        'Manifest-Version: 1.0\nMain-Class: org.springframework.boot.loader.launch.JarLauncher\n')
+    add('META-INF/build-info.properties',
+        f'build.artifact={artifact}\nbuild.group=com.gustler\nbuild.name={artifact}\n'
+        f'build.time={built_at}\nbuild.version=0.0.1-SNAPSHOT\n')
+    add('BOOT-INF/classes/application.yml', body)
+    add('BOOT-INF/classes/com/gustler/Main.class', body * 40)

--- a/backend/deploy/rehearsal/makejar.py
+++ b/backend/deploy/rehearsal/makejar.py
@@ -1,13 +1,15 @@
-import sys, zipfile, time
+# 진짜 boot JAR 과 같은 구조로 가짜를 만든다.
+# 항목 시각을 1980-02-01 로 눌러 두는 것까지 bootJar 과 같다
+import sys, zipfile
 path, artifact, body, built_at = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 with zipfile.ZipFile(path, 'w', zipfile.ZIP_DEFLATED) as z:
-    # bootJar 처럼 모든 항목 시각을 고정한다
     def add(name, data):
         info = zipfile.ZipInfo(name, date_time=(1980, 2, 1, 0, 0, 0))
         info.compress_type = zipfile.ZIP_DEFLATED
         z.writestr(info, data)
     add('META-INF/MANIFEST.MF',
-        'Manifest-Version: 1.0\nMain-Class: org.springframework.boot.loader.launch.JarLauncher\n')
+        'Manifest-Version: 1.0\n'
+        'Main-Class: org.springframework.boot.loader.launch.JarLauncher\n')
     add('META-INF/build-info.properties',
         f'build.artifact={artifact}\nbuild.group=com.gustler\nbuild.name={artifact}\n'
         f'build.time={built_at}\nbuild.version=0.0.1-SNAPSHOT\n')

--- a/backend/deploy/rehearsal/rehearse.sh
+++ b/backend/deploy/rehearsal/rehearse.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# EC2 를 흉내낸 예행연습.
+# CodeDeploy 는 배포판을 자기 폴더(/archive)에 풀고 거기서 훅을 돌린다.
+# files: 섹션이 그 내용을 /opt/salmonbus/staging 으로 복사한다. 그 흐름 그대로 흉내낸다
+set -uo pipefail
+PASS=0; FAIL=0
+ok()  { echo "  통과: $*"; PASS=$((PASS+1)); }
+bad() { echo "  실패: $*"; FAIL=$((FAIL+1)); }
+sec() { echo; echo "======== $* ========"; }
+
+DEPLOY=/deploy
+WORK=/work
+ARCHIVE=/archive
+
+sec "0. 서버 흉내 준비"
+dnf -q install -y unzip findutils util-linux shadow-utils python3 diffutils >/dev/null 2>&1
+useradd -r -s /sbin/nologin salmonbus 2>/dev/null || true
+id salmonbus >/dev/null 2>&1 && ok "salmonbus 사용자" || bad "사용자 생성 실패"
+
+mkdir -p /etc/salmonbus "$WORK" /etc/systemd/system   # EC2 에는 systemd 가 있어서 이 디렉터리가 있다
+printf 'DB_URL=jdbc:postgresql://rds:5432/salmonbus\nDB_USERNAME=x\nDB_PASSWORD=y\n' > /etc/salmonbus/api.env
+printf 'DB_URL=jdbc:postgresql://rds:5432/salmonbus\nDB_USERNAME=x\nDB_PASSWORD=y\nGBIS_SERVICE_KEY=z\n' > /etc/salmonbus/worker.env
+chmod 600 /etc/salmonbus/*.env
+
+printf '#!/bin/sh\necho "openjdk version \\"21.0.12\\"" >&2\n' > /usr/local/bin/java
+cat > /usr/local/bin/systemctl <<'EOF'
+#!/bin/bash
+echo "$*" >> /work/systemctl.log
+case "$1" in
+  is-active) grep -qx "$3" /work/running 2>/dev/null && exit 0 || exit 3 ;;
+  restart)   grep -qx "$2" /work/running 2>/dev/null || echo "$2" >> /work/running; exit 0 ;;
+esac
+exit 0
+EOF
+cat > /usr/local/bin/curl <<'EOF'
+#!/bin/bash
+[ "$(cat /work/health 2>/dev/null || echo UP)" = "UP" ] \
+  && { echo '{"groups":["liveness","readiness"],"status":"UP"}'; exit 0; }
+echo '{"status":"DOWN"}'; exit 22
+EOF
+chmod +x /usr/local/bin/java /usr/local/bin/systemctl /usr/local/bin/curl
+echo UP > "$WORK/health"; : > "$WORK/running"; : > "$WORK/systemctl.log"
+ok "java · systemctl · curl 흉내"
+
+source /rehearse/digest.sh
+
+make_archive() {
+  local api_body="$1" worker_body="$2" commit="$3" build="$4" stamp="$5"
+  rm -rf "$ARCHIVE"; mkdir -p "$ARCHIVE/jars" "$ARCHIVE/scripts" "$ARCHIVE/systemd"
+  python3 /rehearse/makejar.py "$ARCHIVE/jars/api-app.jar"    api-app    "$api_body"    "$stamp"
+  python3 /rehearse/makejar.py "$ARCHIVE/jars/worker-app.jar" worker-app "$worker_body" "$stamp"
+  cp "$DEPLOY/appspec.yml"    "$ARCHIVE/appspec.yml"
+  cp "$DEPLOY/scripts/"*.sh   "$ARCHIVE/scripts/"; chmod +x "$ARCHIVE/scripts/"*.sh
+  cp "$DEPLOY/systemd/"*.service "$ARCHIVE/systemd/"
+  {
+    echo "commit=$commit"; echo "buildNumber=$build"; echo "builtAt=$stamp"
+    echo "apiDigest=$(stable_digest "$ARCHIVE/jars/api-app.jar")"
+    echo "workerDigest=$(stable_digest "$ARCHIVE/jars/worker-app.jar")"
+  } > "$ARCHIVE/release-manifest.txt"
+}
+
+# CodeDeploy 흉내. Install 이벤트가 archive 를 staging 으로 복사한다
+run_deploy() {
+  local label="$1"
+  echo "--- $label ---"
+  bash "$ARCHIVE/scripts/preflight.sh" > "$WORK/preflight.out" 2>&1 \
+    && ok "preflight" || { bad "preflight"; sed 's/^/      /' "$WORK/preflight.out"; return 1; }
+  rm -rf /opt/salmonbus/staging; mkdir -p /opt/salmonbus/staging
+  cp -a "$ARCHIVE/." /opt/salmonbus/staging/
+  bash "$ARCHIVE/scripts/install.sh" > "$WORK/install.out" 2>&1 \
+    && ok "install" || { bad "install"; sed 's/^/      /' "$WORK/install.out"; return 1; }
+  bash "$ARCHIVE/scripts/start.sh" > "$WORK/start.out" 2>&1 \
+    && ok "start" || { bad "start"; sed 's/^/      /' "$WORK/start.out"; return 1; }
+  bash "$ARCHIVE/scripts/validate.sh" > "$WORK/validate.out" 2>&1 \
+    && ok "validate" || { bad "validate"; sed 's/^/      /' "$WORK/validate.out"; return 1; }
+  return 0
+}
+
+sec "1. 빌드 시각만 다르면 지문이 같은가"
+python3 /rehearse/makejar.py "$WORK/a1.jar" api-app SAME    "2026-09-02T01:00:00Z"
+python3 /rehearse/makejar.py "$WORK/a2.jar" api-app SAME    "2026-09-02T09:30:00Z"
+python3 /rehearse/makejar.py "$WORK/a3.jar" api-app CHANGED "2026-09-02T01:00:00Z"
+s1=$(sha256sum "$WORK/a1.jar"|cut -d' ' -f1); s2=$(sha256sum "$WORK/a2.jar"|cut -d' ' -f1)
+d1=$(stable_digest "$WORK/a1.jar"); d2=$(stable_digest "$WORK/a2.jar"); d3=$(stable_digest "$WORK/a3.jar")
+[ "$s1" != "$s2" ] && ok "그냥 sha256 은 매번 달라진다" || bad "sha256 이 같다"
+[ "$d1" = "$d2" ]  && ok "stable_digest 는 같다" || bad "stable_digest 가 다르다"
+[ "$d1" != "$d3" ] && ok "내용이 바뀌면 stable_digest 도 바뀐다" || bad "내용이 바뀌었는데 지문이 같다"
+
+sec "2. 첫 배포 (/opt/salmonbus 이 아예 없는 상태)"
+rm -rf /opt/salmonbus
+make_archive APIv1 WORKERv1 aaaaaaa1111 1 "2026-09-02T01:00:00Z"
+run_deploy "1차"
+[ "$(readlink -f /opt/salmonbus/current)" = "/opt/salmonbus/releases/aaaaaaa-1" ] \
+  && ok "current 가 첫 판을 가리킨다" || bad "current=$(readlink -f /opt/salmonbus/current 2>/dev/null)"
+grep -qx salmonbus-api /work/running && grep -qx salmonbus-worker /work/running \
+  && ok "첫 배포에 둘 다 올라갔다" || bad "안 올라간 서비스가 있다"
+
+sec "3. api 만 바뀐 배포"
+: > /work/systemctl.log
+make_archive APIv2 WORKERv1 bbbbbbb2222 2 "2026-09-02T02:00:00Z"
+run_deploy "2차"
+grep -q 'restart salmonbus-api' /work/systemctl.log \
+  && ok "api 는 재시작했다" || bad "api 가 재시작 안 됐다"
+grep -q 'restart salmonbus-worker' /work/systemctl.log \
+  && bad "worker 도 재시작했다. 바뀐 것만 재시작이 안 된다" || ok "worker 는 안 건드렸다"
+[ "$(readlink -f /opt/salmonbus/previous)" = "/opt/salmonbus/releases/aaaaaaa-1" ] \
+  && ok "previous 가 직전 판을 가리킨다" || bad "previous=$(readlink -f /opt/salmonbus/previous 2>/dev/null)"
+
+sec "4. 아무것도 안 바뀐 배포"
+: > /work/systemctl.log
+make_archive APIv2 WORKERv1 ccccccc3333 3 "2026-09-02T03:00:00Z"
+run_deploy "3차"
+grep -q restart /work/systemctl.log \
+  && bad "안 바뀌었는데 재시작했다" || ok "둘 다 안 건드렸다"
+
+sec "5. health 가 안 오르면 실패로 끝나는가 (되돌리기가 걸리는 자리)"
+echo DOWN > /work/health
+make_archive APIv3 WORKERv1 ddddddd4444 4 "2026-09-02T04:00:00Z"
+rm -rf /opt/salmonbus/staging; mkdir -p /opt/salmonbus/staging
+cp -a "$ARCHIVE/." /opt/salmonbus/staging/
+bash "$ARCHIVE/scripts/preflight.sh" >/dev/null 2>&1
+bash "$ARCHIVE/scripts/install.sh"   >/dev/null 2>&1
+bash "$ARCHIVE/scripts/start.sh"     >/dev/null 2>&1
+if bash "$ARCHIVE/scripts/validate.sh" > "$WORK/v.out" 2>&1; then
+  bad "health 가 DOWN 인데 validate 가 통과했다"
+else
+  ok "validate 가 실패로 끝난다 -> CodeDeploy 가 되돌린다"
+fi
+echo UP > /work/health
+
+sec "6. 판을 셋만 남기는가"
+n=$(ls -1d /opt/salmonbus/releases/*/ 2>/dev/null | wc -l)
+[ "$n" -le 3 ] && ok "판 $n 개만 남았다" || bad "판이 $n 개다"
+
+sec "7. env 파일을 안 건드렸는가"
+[ "$(stat -c '%a' /etc/salmonbus/worker.env)" = "600" ] \
+  && ok "worker.env 권한 600 그대로" || bad "권한이 바뀌었다"
+grep -qc '^GBIS_SERVICE_KEY=' /etc/salmonbus/worker.env \
+  && ok "키 줄이 그대로 있다" || bad "키 줄이 없어졌다"
+
+sec "8. 훅 로그에 값이 새지 않았는가"
+if grep -rqE 'GBIS_SERVICE_KEY=[^$]|DB_PASSWORD=[^$]' "$WORK"/*.out 2>/dev/null; then
+  bad "훅 출력에 값이 찍혔다"
+else
+  ok "훅 출력에 값이 안 찍혔다"
+fi
+
+echo; echo "======== 결과: 통과 $PASS · 실패 $FAIL ========"
+exit $([ "$FAIL" -eq 0 ] && echo 0 || echo 1)

--- a/backend/deploy/rehearsal/rehearse.sh
+++ b/backend/deploy/rehearsal/rehearse.sh
@@ -23,13 +23,15 @@ printf 'DB_URL=jdbc:postgresql://rds:5432/salmonbus\nDB_USERNAME=x\nDB_PASSWORD=
 printf 'DB_URL=jdbc:postgresql://rds:5432/salmonbus\nDB_USERNAME=x\nDB_PASSWORD=y\nGBIS_SERVICE_KEY=z\n' > /etc/salmonbus/worker.env
 chmod 600 /etc/salmonbus/*.env
 
-printf '#!/bin/sh\necho "openjdk version \\"21.0.12\\"" >&2\n' > /usr/local/bin/java
+printf '#!/bin/sh\necho "openjdk version \\"21.0.12\\" 2026-08-18" >&2\n' > /usr/bin/java
 
 cat > /usr/local/bin/systemctl <<'EOF'
 #!/bin/bash
 echo "$*" >> /work/systemctl.log
 case "$1" in
   is-active)     grep -qx "$3" /work/running 2>/dev/null && exit 0 || exit 3 ;;
+  enable)        grep -qx "$2" /work/enabled 2>/dev/null || echo "$2" >> /work/enabled; exit 0 ;;
+  is-enabled)    grep -qx "$3" /work/enabled 2>/dev/null && exit 0 || exit 1 ;;
   stop)          grep -vx "$2" /work/running > /work/r.tmp 2>/dev/null || true; mv /work/r.tmp /work/running; exit 0 ;;
   start)         grep -qx "$2" /work/running 2>/dev/null || echo "$2" >> /work/running; exit 0 ;;
   daemon-reload) exit 0 ;;
@@ -77,8 +79,9 @@ case "$url" in
 esac
 echo "curl 흉내가 모르는 경로다: $url" >&2; exit 2
 EOF
-chmod +x /usr/local/bin/java /usr/local/bin/systemctl /usr/local/bin/curl
-echo UP > "$WORK/health"; : > "$WORK/running"; : > "$WORK/systemctl.log"; rm -f "$WORK/stale"
+chmod +x /usr/bin/java /usr/local/bin/systemctl /usr/local/bin/curl
+echo UP > "$WORK/health"; : > "$WORK/running"; : > "$WORK/enabled"
+: > "$WORK/systemctl.log"; rm -f "$WORK/stale"
 ok "java · systemctl · curl 흉내"
 
 source /rehearse/digest.sh
@@ -105,9 +108,12 @@ make_revision() {
 }
 
 # CodeDeploy 흉내. Install 이벤트가 revision 을 staging 으로 복사한다
+DEPLOY_SEQ=0
 deploy() {
   local component="$1" expect="${2:-ok}"
   local a="$ARCHIVE/$component" rc=0
+  DEPLOY_SEQ=$((DEPLOY_SEQ + 1))
+  export DEPLOYMENT_ID="d-$component-$DEPLOY_SEQ" 
   for hook in preflight install start validate; do
     if [ "$hook" = "install" ]; then
       rm -rf "/opt/salmonbus/$component/staging"
@@ -151,7 +157,9 @@ deploy worker
   && ok "api current 가 소스 지문으로 이름 붙은 판을 가리킨다" || bad "api current=$(readlink -f /opt/salmonbus/api/current 2>/dev/null)"
 grep -qx salmonbus-api /work/running && grep -qx salmonbus-worker /work/running \
   && ok "둘 다 올라갔다" || bad "안 올라간 것이 있다"
-[ ! -f /opt/salmonbus/.deploying ] && ok "배포 표시가 지워졌다" || bad "배포 표시가 남았다"
+[ ! -d /opt/salmonbus/.deploying ] && ok "배포 잠금이 풀렸다" || bad "배포 잠금이 남았다"
+grep -qx salmonbus-api /work/enabled && grep -qx salmonbus-worker /work/enabled \
+  && ok "둘 다 enable 됐다. 재부팅해도 올라온다" || bad "enable 안 된 것이 있다"
 
 sec "3. api 소스만 바뀐 배포"
 : > /work/systemctl.log
@@ -185,13 +193,37 @@ grep -qE 'stop salmonbus' /work/systemctl.log \
   && ok "돌고 있는 판을 안 지웠다" || bad "돌고 있는 판이 사라졌다"
 
 sec "5. api 배포가 도는 중이면 worker 가 안 끼어드나"
-printf 'api %s\n' "$(date +%s)" > /opt/salmonbus/.deploying
+mkdir -p /opt/salmonbus/.deploying
+printf 'api d-api-999 %s\n' "$(date +%s)" > /opt/salmonbus/.deploying/owner
 if bash "$ARCHIVE/worker/scripts/preflight.sh" > "$WORK/lock.out" 2>&1; then
   bad "api 배포 중인데 worker 가 들어왔다"
 else
   grep -q '도는 중' "$WORK/lock.out" && ok "worker 가 막혔다" || bad "막히긴 했는데 이유가 다르다"
 fi
-rm -f /opt/salmonbus/.deploying
+rm -rf /opt/salmonbus/.deploying
+
+sec "5-2. 한 번 실패한 직후 바로 되돌리기 (CodeDeploy 가 하는 순서)"
+# 성공 -> 실패 -> 그 직전 판 재배포. 이때 current 는 실패한 판, previous 는 직전 성공 판이다
+RB_GOOD=aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666777788889999aaaa
+RB_BAD=bbbb2222cccc3333dddd4444eeee5555ffff6666777788889999aaaabbbb1111
+make_revision api RBGOOD ggggggg0001 "$RB_GOOD" "2026-09-02T06:00:00Z"
+deploy api
+echo DOWN > /work/health
+make_revision api RBBAD bbbbbbb0002 "$RB_BAD" "2026-09-02T06:10:00Z"
+deploy api fail
+echo UP > /work/health
+[ "$(readlink -f /opt/salmonbus/api/current)" = "/opt/salmonbus/api/releases/$RB_BAD" ] \
+  && ok "실패한 판이 current 다" || bad "current=$(readlink -f /opt/salmonbus/api/current)"
+[ "$(readlink -f /opt/salmonbus/api/previous)" = "/opt/salmonbus/api/releases/$RB_GOOD" ] \
+  && ok "직전 성공 판이 previous 다" || bad "previous=$(readlink -f /opt/salmonbus/api/previous)"
+# CodeDeploy 의 자동 롤백은 직전 성공 revision 을 그대로 다시 배포하는 것이다
+: > /work/systemctl.log
+make_revision api RBGOOD ggggggg0001 "$RB_GOOD" "2026-09-02T06:00:00Z"
+deploy api
+[ "$(readlink -f /opt/salmonbus/api/current)" = "/opt/salmonbus/api/releases/$RB_GOOD" ] \
+  && ok "current 가 직전 성공 판으로 돌아왔다" || bad "current=$(readlink -f /opt/salmonbus/api/current)"
+grep -qx salmonbus-api /work/running \
+  && ok "되돌린 뒤에도 서비스가 돈다" || bad "되돌렸는데 안 돈다"
 
 sec "6. 옛 프로세스가 응답하면 validate 가 잡나"
 : > /work/systemctl.log
@@ -206,23 +238,6 @@ make_revision api APIv4 eeeeeee5555 4444dddd5555eeee6666ffff7777000088889999aaaa
 deploy api fail
 echo UP > /work/health
 
-sec "7-2. 되돌리기가 실제로 도는가"
-# CodeDeploy 의 자동 롤백은 직전 성공 revision 을 다시 배포하는 것이다. 그것을 그대로 흉내낸다
-GOOD_DIGEST=2222bbbb3333cccc4444dddd5555eeee6666ffff7777000088889999aaaa1111
-before="$(readlink -f /opt/salmonbus/api/current)"
-[ "$before" != "/opt/salmonbus/api/releases/$GOOD_DIGEST" ] \
-  && ok "실패한 배포가 current 를 옮겨 놓은 상태다" || bad "실패 전후가 같아서 되돌릴 것이 없다"
-: > /work/systemctl.log
-make_revision api APIv2 bbbbbbb2222 "$GOOD_DIGEST" "2026-09-02T02:00:00Z"
-deploy api
-[ "$(readlink -f /opt/salmonbus/api/current)" = "/opt/salmonbus/api/releases/$GOOD_DIGEST" ] \
-  && ok "current 가 직전 성공 판으로 돌아왔다" || bad "current=$(readlink -f /opt/salmonbus/api/current)"
-grep -qx salmonbus-api /work/running \
-  && ok "되돌린 뒤에도 서비스가 돌고 있다" || bad "되돌렸는데 안 돈다"
-info_digest="$(sed -n 's/^INFO_SOURCEDIGEST=//p' /opt/salmonbus/api/current/release.env)"
-[ "$info_digest" = "$GOOD_DIGEST" ] \
-  && ok "info 가 직전 성공 판을 가리킨다" || bad "info=$info_digest"
-
 sec "8. 판을 셋만 남기는가"
 n=$(/bin/ls -1d /opt/salmonbus/api/releases/*/ 2>/dev/null | wc -l)
 [ "$n" -le 3 ] && ok "api 판 $n 개" || bad "api 판이 $n 개다"
@@ -234,6 +249,25 @@ grep -qc '^GBIS_SERVICE_KEY=' /etc/salmonbus/worker.env \
   && ok "키 줄이 그대로 있다" || bad "키 줄이 없어졌다"
 [ -d /var/lib/salmonbus/model/current ] \
   && ok "계수 파일 자리가 배포 밖에 만들어졌다" || bad "계수 파일 자리가 없다"
+
+sec "9-2. 배포판 목록을 손대면 releases 밖을 건드리나"
+before_count=$(/bin/ls -1d /opt/salmonbus/api/releases/*/ 2>/dev/null | wc -l)
+mkdir -p /opt/salmonbus/바깥/지워지면안됨 && touch /opt/salmonbus/바깥/지워지면안됨/파일
+for evil in "../../../바깥/지워지면안됨" "짧은지문" "$(printf 'z%.0s' $(seq 1 64))"; do
+  make_revision api EVIL zzzzzzz9999 1111aaaa2222bbbb3333cccc4444dddd5555eeee6666ffff7777000088889999 "2026-09-02T09:00:00Z"
+  sed -i "s#^sourceDigest=.*#sourceDigest=$evil#" "$ARCHIVE/api/release-manifest.txt"
+  if bash "$ARCHIVE/api/scripts/preflight.sh" > "$WORK/evil.out" 2>&1; then
+    bad "손댄 목록이 preflight 를 통과했다: $evil"
+  else
+    ok "손댄 목록을 preflight 가 막았다"
+  fi
+done
+[ -f /opt/salmonbus/바깥/지워지면안됨/파일 ] \
+  && ok "releases 밖 파일이 그대로다" || bad "releases 밖이 지워졌다"
+after_count=$(/bin/ls -1d /opt/salmonbus/api/releases/*/ 2>/dev/null | wc -l)
+[ "$before_count" = "$after_count" ] \
+  && ok "판 수가 안 바뀌었다" || bad "판이 $before_count 에서 $after_count 로 바뀌었다"
+rm -rf /opt/salmonbus/바깥
 
 sec "10. 훅 로그에 값이 새지 않았는가"
 if grep -rqE 'GBIS_SERVICE_KEY=[^$]|DB_PASSWORD=[^$]' "$WORK"/*.out 2>/dev/null; then

--- a/backend/deploy/rehearsal/rehearse.sh
+++ b/backend/deploy/rehearsal/rehearse.sh
@@ -29,11 +29,13 @@ cat > /usr/local/bin/systemctl <<'EOF'
 #!/bin/bash
 echo "$*" >> /work/systemctl.log
 case "$1" in
-  is-active) grep -qx "$3" /work/running 2>/dev/null && exit 0 || exit 3 ;;
-  stop)      grep -vx "$2" /work/running > /work/r.tmp 2>/dev/null; mv /work/r.tmp /work/running; exit 0 ;;
-  start)     grep -qx "$2" /work/running 2>/dev/null || echo "$2" >> /work/running; exit 0 ;;
+  is-active)     grep -qx "$3" /work/running 2>/dev/null && exit 0 || exit 3 ;;
+  stop)          grep -vx "$2" /work/running > /work/r.tmp 2>/dev/null || true; mv /work/r.tmp /work/running; exit 0 ;;
+  start)         grep -qx "$2" /work/running 2>/dev/null || echo "$2" >> /work/running; exit 0 ;;
+  daemon-reload) exit 0 ;;
+  # 흉내가 모르는 명령에 성공을 돌려주면 깨진 훅이 여기를 그냥 통과한다
+  *) echo "systemctl 흉내가 모르는 명령이다: $*" >&2; exit 64 ;;
 esac
-exit 0
 EOF
 
 # /actuator 를 흉내낸다. info 는 지금 도는 판의 release.env 를 읽어 답한다.
@@ -47,11 +49,16 @@ for a in "$@"; do
     '%{http_code}') want_code=1 ;;
   esac
 done
-state="$(cat /work/health 2>/dev/null || echo UP)"
-comp=""
+[ -n "$url" ] || { echo "curl 흉내: 주소가 없다" >&2; exit 2; }
+# 상태 파일이 없으면 UP 으로 넘기지 않는다. 준비가 빠진 것을 통과시키면 안 된다
+[ -f /work/health ] || { echo "curl 흉내: /work/health 가 없다" >&2; exit 2; }
+state="$(cat /work/health)"
+# 아는 주소만 답한다. 포트나 경로가 틀리면 여기서 걸린다
 case "$url" in
-  *:8082/*) comp=api ;;
-  *:8081/*) comp=worker ;;
+  http://127.0.0.1:8082/actuator/health|http://127.0.0.1:8082/actuator/info) comp=api ;;
+  http://127.0.0.1:8081/actuator/health|http://127.0.0.1:8081/actuator/info) comp=worker ;;
+  http://127.0.0.1:8080/api/v1/routes) comp=api ;;
+  *) echo "curl 흉내가 모르는 주소다: $url" >&2; exit 2 ;;
 esac
 if [ "$want_code" = "1" ]; then
   [ "$state" = "UP" ] && { echo 200; exit 0; }
@@ -68,7 +75,7 @@ case "$url" in
     echo "{\"sourcedigest\":\"$d\",\"component\":\"$c\",\"build\":{}}"
     exit 0 ;;
 esac
-exit 0
+echo "curl 흉내가 모르는 경로다: $url" >&2; exit 2
 EOF
 chmod +x /usr/local/bin/java /usr/local/bin/systemctl /usr/local/bin/curl
 echo UP > "$WORK/health"; : > "$WORK/running"; : > "$WORK/systemctl.log"; rm -f "$WORK/stale"
@@ -156,6 +163,13 @@ grep -q 'stop salmonbus-api' /work/systemctl.log \
   && ok "api 는 내렸다 올렸다" || bad "api 가 재시작 안 됐다"
 grep -q 'stop salmonbus-worker' /work/systemctl.log \
   && bad "worker 도 내렸다. 바뀐 것만 재시작이 안 된다" || ok "worker 는 안 건드렸다"
+# 겹침이 나는 길은 restart 를 쓰거나 stop 없이 start 하는 것이다
+grep -q '^restart ' /work/systemctl.log \
+  && bad "restart 를 썼다. 내렸다 올리는 것을 눈으로 못 본다" || ok "restart 를 안 쓴다"
+stop_line=$(grep -n '^stop salmonbus-api$' /work/systemctl.log | head -1 | cut -d: -f1)
+start_line=$(grep -n '^start salmonbus-api$' /work/systemctl.log | head -1 | cut -d: -f1)
+[ -n "$stop_line" ] && [ -n "$start_line" ] && [ "$stop_line" -lt "$start_line" ] \
+  && ok "stop 이 start 보다 먼저다" || bad "stop=$stop_line start=$start_line 순서가 아니다"
 [ "$(readlink -f /opt/salmonbus/api/previous)" = "/opt/salmonbus/api/releases/1111aaaa2222bbbb3333cccc4444dddd5555eeee6666ffff7777000088889999" ] \
   && ok "api previous 가 직전 판을 가리킨다" || bad "api previous=$(readlink -f /opt/salmonbus/api/previous 2>/dev/null)"
 
@@ -186,11 +200,28 @@ make_revision api APIv3 ddddddd4444 3333cccc4444dddd5555eeee6666ffff777700008888
 deploy api fail
 rm -f /work/stale
 
-sec "7. health 가 안 오르면 실패로 끝나는가 (되돌리기가 걸리는 자리)"
+sec "7. health 가 안 오르면 실패로 끝나는가"
 echo DOWN > /work/health
 make_revision api APIv4 eeeeeee5555 4444dddd5555eeee6666ffff7777000088889999aaaa1111bbbb2222cccc3333 "2026-09-02T05:00:00Z"
 deploy api fail
 echo UP > /work/health
+
+sec "7-2. 되돌리기가 실제로 도는가"
+# CodeDeploy 의 자동 롤백은 직전 성공 revision 을 다시 배포하는 것이다. 그것을 그대로 흉내낸다
+GOOD_DIGEST=2222bbbb3333cccc4444dddd5555eeee6666ffff7777000088889999aaaa1111
+before="$(readlink -f /opt/salmonbus/api/current)"
+[ "$before" != "/opt/salmonbus/api/releases/$GOOD_DIGEST" ] \
+  && ok "실패한 배포가 current 를 옮겨 놓은 상태다" || bad "실패 전후가 같아서 되돌릴 것이 없다"
+: > /work/systemctl.log
+make_revision api APIv2 bbbbbbb2222 "$GOOD_DIGEST" "2026-09-02T02:00:00Z"
+deploy api
+[ "$(readlink -f /opt/salmonbus/api/current)" = "/opt/salmonbus/api/releases/$GOOD_DIGEST" ] \
+  && ok "current 가 직전 성공 판으로 돌아왔다" || bad "current=$(readlink -f /opt/salmonbus/api/current)"
+grep -qx salmonbus-api /work/running \
+  && ok "되돌린 뒤에도 서비스가 돌고 있다" || bad "되돌렸는데 안 돈다"
+info_digest="$(sed -n 's/^INFO_SOURCEDIGEST=//p' /opt/salmonbus/api/current/release.env)"
+[ "$info_digest" = "$GOOD_DIGEST" ] \
+  && ok "info 가 직전 성공 판을 가리킨다" || bad "info=$info_digest"
 
 sec "8. 판을 셋만 남기는가"
 n=$(/bin/ls -1d /opt/salmonbus/api/releases/*/ 2>/dev/null | wc -l)

--- a/backend/deploy/rehearsal/rehearse.sh
+++ b/backend/deploy/rehearsal/rehearse.sh
@@ -21,7 +21,7 @@ id salmonbus >/dev/null 2>&1 && ok "salmonbus 사용자" || bad "사용자 생�
 mkdir -p /etc/salmonbus "$WORK" /etc/systemd/system   # EC2 에는 systemd 가 있어서 이 디렉터리가 있다
 printf 'DB_URL=jdbc:postgresql://rds:5432/salmonbus\nDB_USERNAME=x\nDB_PASSWORD=y\n' > /etc/salmonbus/api.env
 printf 'DB_URL=jdbc:postgresql://rds:5432/salmonbus\nDB_USERNAME=x\nDB_PASSWORD=y\nGBIS_SERVICE_KEY=z\n' > /etc/salmonbus/worker.env
-chmod 600 /etc/salmonbus/*.env
+chmod 600 /etc/salmonbus/*.env; chown root:root /etc/salmonbus/*.env
 
 printf '#!/bin/sh\necho "openjdk version \\"21.0.12\\" 2026-08-18" >&2\n' > /usr/bin/java
 
@@ -268,6 +268,65 @@ after_count=$(/bin/ls -1d /opt/salmonbus/api/releases/*/ 2>/dev/null | wc -l)
 [ "$before_count" = "$after_count" ] \
   && ok "판 수가 안 바뀌었다" || bad "판이 $before_count 에서 $after_count 로 바뀌었다"
 rm -rf /opt/salmonbus/바깥
+
+sec "9-3. env 파일 권한이 헐거우면 막나"
+chmod 644 /etc/salmonbus/api.env
+make_revision api APIPERM ppppppp1111 1111aaaa2222bbbb3333cccc4444dddd5555eeee6666ffff7777000088889999 "2026-09-02T10:00:00Z"
+if bash "$ARCHIVE/api/scripts/preflight.sh" > "$WORK/perm.out" 2>&1; then
+  bad "644 인 env 파일이 통과했다"
+else
+  grep -q '권한이 644' "$WORK/perm.out" && ok "헐거운 권한을 막았다" || bad "막긴 했는데 이유가 다르다"
+fi
+chmod 600 /etc/salmonbus/api.env
+
+sec "9-4. 잠금을 둘이 동시에 잡으면 하나만 되나"
+rm -rf /opt/salmonbus/.deploying
+cat > "$WORK/race.sh" <<'RACE'
+#!/bin/bash
+export DEPLOYMENT_ID="$2"
+source /archive/$1/scripts/common.sh
+claim_deploy && echo "$1 잡았다" >> /work/race.out
+sleep 2
+RACE
+chmod +x "$WORK/race.sh"
+: > "$WORK/race.out"
+"$WORK/race.sh" api d-race-api > /dev/null 2>&1 &
+"$WORK/race.sh" worker d-race-worker > /dev/null 2>&1 &
+wait
+won=$(wc -l < "$WORK/race.out")
+[ "$won" = "1" ] && ok "둘이 동시에 잡으러 가서 하나만 잡았다" || bad "$won 개가 잡았다"
+rm -rf /opt/salmonbus/.deploying
+
+sec "9-5. 실패한 훅이 잠금을 남기나"
+rm -rf /opt/salmonbus/.deploying
+chmod 644 /etc/salmonbus/api.env
+bash "$ARCHIVE/api/scripts/preflight.sh" > /dev/null 2>&1 || true
+chmod 600 /etc/salmonbus/api.env
+[ ! -d /opt/salmonbus/.deploying ] \
+  && ok "실패한 훅이 잠금을 풀고 나갔다" || bad "잠금이 남았다"
+
+sec "9-6. 값이 박힌 JAR 을 배포판 검사가 막나"
+mkdir -p "$WORK/rev-ok/jars" "$WORK/rev-bad/jars"
+python3 /rehearse/makejar.py "$WORK/rev-ok/jars/api-app.jar" api-app   'spring:
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/salmonbus}
+    password: ${DB_PASSWORD:salmonbus}
+' "2026-09-02T10:00:00Z"
+python3 /rehearse/makejar.py "$WORK/rev-bad/jars/api-app.jar" api-app   'spring:
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/salmonbus}
+    password: ${DB_PASSWORD:salmonbus}
+  other:
+    password: 실제로박힌값1234
+' "2026-09-02T10:00:00Z"
+bash /deploy/verify-revision.sh "$WORK/rev-ok" > /dev/null 2>&1 \
+  && ok "자리표시자만 있는 JAR 은 통과한다" || bad "멀쩡한 JAR 을 막았다"
+if bash /deploy/verify-revision.sh "$WORK/rev-bad" > "$WORK/vr.out" 2>&1; then
+  bad "값이 박힌 JAR 이 통과했다"
+else
+  ok "값이 박힌 JAR 을 막았다"
+  grep -q '실제로박힌값' "$WORK/vr.out" && bad "오류 문구에 값이 찍혔다" || ok "오류 문구에 값이 안 찍혔다"
+fi
 
 sec "10. 훅 로그에 값이 새지 않았는가"
 if grep -rqE 'GBIS_SERVICE_KEY=[^$]|DB_PASSWORD=[^$]' "$WORK"/*.out 2>/dev/null; then

--- a/backend/deploy/rehearsal/rehearse.sh
+++ b/backend/deploy/rehearsal/rehearse.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # EC2 를 흉내낸 예행연습.
-# CodeDeploy 는 배포판을 자기 폴더(/archive)에 풀고 거기서 훅을 돌린다.
-# files: 섹션이 그 내용을 /opt/salmonbus/staging 으로 복사한다. 그 흐름 그대로 흉내낸다
+# CodeDeploy 는 revision 을 자기 폴더에 풀고 거기서 훅을 돌린다.
+# files: 섹션이 그 내용을 /opt/salmonbus/<component>/staging 으로 복사한다. 그 흐름 그대로 흉내낸다.
+# revision 이 둘(api·worker)이라 배포도 둘씩 돈다
 set -uo pipefail
 PASS=0; FAIL=0
 ok()  { echo "  통과: $*"; PASS=$((PASS+1)); }
@@ -13,7 +14,7 @@ WORK=/work
 ARCHIVE=/archive
 
 sec "0. 서버 흉내 준비"
-dnf -q install -y unzip findutils util-linux shadow-utils python3 diffutils >/dev/null 2>&1
+dnf -q install -y unzip findutils util-linux shadow-utils python3 diffutils procps-ng >/dev/null 2>&1
 useradd -r -s /sbin/nologin salmonbus 2>/dev/null || true
 id salmonbus >/dev/null 2>&1 && ok "salmonbus 사용자" || bad "사용자 생성 실패"
 
@@ -23,122 +24,187 @@ printf 'DB_URL=jdbc:postgresql://rds:5432/salmonbus\nDB_USERNAME=x\nDB_PASSWORD=
 chmod 600 /etc/salmonbus/*.env
 
 printf '#!/bin/sh\necho "openjdk version \\"21.0.12\\"" >&2\n' > /usr/local/bin/java
+
 cat > /usr/local/bin/systemctl <<'EOF'
 #!/bin/bash
 echo "$*" >> /work/systemctl.log
 case "$1" in
   is-active) grep -qx "$3" /work/running 2>/dev/null && exit 0 || exit 3 ;;
-  restart)   grep -qx "$2" /work/running 2>/dev/null || echo "$2" >> /work/running; exit 0 ;;
+  stop)      grep -vx "$2" /work/running > /work/r.tmp 2>/dev/null; mv /work/r.tmp /work/running; exit 0 ;;
+  start)     grep -qx "$2" /work/running 2>/dev/null || echo "$2" >> /work/running; exit 0 ;;
 esac
 exit 0
 EOF
+
+# /actuator 를 흉내낸다. info 는 지금 도는 판의 release.env 를 읽어 답한다.
+# /work/stale 이 있으면 옛 프로세스가 아직 응답하는 상황이 된다
 cat > /usr/local/bin/curl <<'EOF'
 #!/bin/bash
-[ "$(cat /work/health 2>/dev/null || echo UP)" = "UP" ] \
-  && { echo '{"groups":["liveness","readiness"],"status":"UP"}'; exit 0; }
-echo '{"status":"DOWN"}'; exit 22
+url=""; want_code=0
+for a in "$@"; do
+  case "$a" in
+    http*) url="$a" ;;
+    '%{http_code}') want_code=1 ;;
+  esac
+done
+state="$(cat /work/health 2>/dev/null || echo UP)"
+comp=""
+case "$url" in
+  *:8082/*) comp=api ;;
+  *:8081/*) comp=worker ;;
+esac
+if [ "$want_code" = "1" ]; then
+  [ "$state" = "UP" ] && { echo 200; exit 0; }
+  echo 503; exit 0
+fi
+[ "$state" = "UP" ] || { echo '{"status":"DOWN"}'; exit 22; }
+case "$url" in
+  */health) echo '{"groups":["liveness","readiness"],"status":"UP"}'; exit 0 ;;
+  */info)
+    envf="/opt/salmonbus/$comp/current/release.env"
+    d="$(sed -n 's/^INFO_SOURCEDIGEST=//p' "$envf" 2>/dev/null)"
+    c="$(sed -n 's/^INFO_COMPONENT=//p' "$envf" 2>/dev/null)"
+    [ -f /work/stale ] && d="$(cat /work/stale)"
+    echo "{\"sourcedigest\":\"$d\",\"component\":\"$c\",\"build\":{}}"
+    exit 0 ;;
+esac
+exit 0
 EOF
 chmod +x /usr/local/bin/java /usr/local/bin/systemctl /usr/local/bin/curl
-echo UP > "$WORK/health"; : > "$WORK/running"; : > "$WORK/systemctl.log"
+echo UP > "$WORK/health"; : > "$WORK/running"; : > "$WORK/systemctl.log"; rm -f "$WORK/stale"
 ok "java · systemctl · curl 흉내"
 
 source /rehearse/digest.sh
 
-make_archive() {
-  local api_body="$1" worker_body="$2" commit="$3" build="$4" stamp="$5"
-  rm -rf "$ARCHIVE"; mkdir -p "$ARCHIVE/jars" "$ARCHIVE/scripts" "$ARCHIVE/systemd"
-  python3 /rehearse/makejar.py "$ARCHIVE/jars/api-app.jar"    api-app    "$api_body"    "$stamp"
-  python3 /rehearse/makejar.py "$ARCHIVE/jars/worker-app.jar" worker-app "$worker_body" "$stamp"
-  cp "$DEPLOY/appspec.yml"    "$ARCHIVE/appspec.yml"
-  cp "$DEPLOY/scripts/"*.sh   "$ARCHIVE/scripts/"; chmod +x "$ARCHIVE/scripts/"*.sh
-  cp "$DEPLOY/systemd/"*.service "$ARCHIVE/systemd/"
+# revision 한 벌을 만든다. buildspec 의 pack() 과 같은 모양이다
+make_revision() {
+  local component="$1" body="$2" commit="$3" digest="$4" stamp="$5"
+  local a="$ARCHIVE/$component"
+  rm -rf "$a"; mkdir -p "$a/jars" "$a/scripts" "$a/systemd"
+  python3 /rehearse/makejar.py "$a/jars/$component-app.jar" "$component-app" "$body" "$stamp"
+  cp "$DEPLOY/appspec-$component.yml" "$a/appspec.yml"
+  cp "$DEPLOY/scripts/"*.sh "$a/scripts/"; chmod +x "$a/scripts/"*.sh
+  cp "$DEPLOY/systemd/salmonbus-$component.service" "$a/systemd/"
   {
-    echo "commit=$commit"; echo "buildNumber=$build"; echo "builtAt=$stamp"
-    echo "apiDigest=$(stable_digest "$ARCHIVE/jars/api-app.jar")"
-    echo "workerDigest=$(stable_digest "$ARCHIVE/jars/worker-app.jar")"
-  } > "$ARCHIVE/release-manifest.txt"
+    echo "component=$component"
+    echo "commit=$commit"
+    echo "sourceDigest=$digest"
+    echo "artifactSha256=$(sha256sum "$a/jars/$component-app.jar" | cut -d' ' -f1)"
+    echo "javaVersion=21.0.12"
+    echo "appVersion=0.0.1-SNAPSHOT"
+    echo "flywayMaxVersion=12"
+    echo "builtAt=$stamp"
+  } > "$a/release-manifest.txt"
 }
 
-# CodeDeploy 흉내. Install 이벤트가 archive 를 staging 으로 복사한다
-run_deploy() {
-  local label="$1"
-  echo "--- $label ---"
-  bash "$ARCHIVE/scripts/preflight.sh" > "$WORK/preflight.out" 2>&1 \
-    && ok "preflight" || { bad "preflight"; sed 's/^/      /' "$WORK/preflight.out"; return 1; }
-  rm -rf /opt/salmonbus/staging; mkdir -p /opt/salmonbus/staging
-  cp -a "$ARCHIVE/." /opt/salmonbus/staging/
-  bash "$ARCHIVE/scripts/install.sh" > "$WORK/install.out" 2>&1 \
-    && ok "install" || { bad "install"; sed 's/^/      /' "$WORK/install.out"; return 1; }
-  bash "$ARCHIVE/scripts/start.sh" > "$WORK/start.out" 2>&1 \
-    && ok "start" || { bad "start"; sed 's/^/      /' "$WORK/start.out"; return 1; }
-  bash "$ARCHIVE/scripts/validate.sh" > "$WORK/validate.out" 2>&1 \
-    && ok "validate" || { bad "validate"; sed 's/^/      /' "$WORK/validate.out"; return 1; }
-  return 0
+# CodeDeploy 흉내. Install 이벤트가 revision 을 staging 으로 복사한다
+deploy() {
+  local component="$1" expect="${2:-ok}"
+  local a="$ARCHIVE/$component" rc=0
+  for hook in preflight install start validate; do
+    if [ "$hook" = "install" ]; then
+      rm -rf "/opt/salmonbus/$component/staging"
+      mkdir -p "/opt/salmonbus/$component/staging"
+      cp -a "$a/." "/opt/salmonbus/$component/staging/"
+    fi
+    if ! bash "$a/scripts/$hook.sh" > "$WORK/$component-$hook.out" 2>&1; then
+      rc=1
+      [ "$expect" = "ok" ] && { bad "$component $hook.sh"; sed 's/^/      /' "$WORK/$component-$hook.out"; }
+      break
+    fi
+  done
+  if [ "$expect" = "ok" ]; then
+    [ $rc -eq 0 ] && ok "$component 배포 네 훅 통과"
+  else
+    [ $rc -ne 0 ] && ok "$component 배포가 실패로 끝난다" || bad "$component 배포가 통과해 버렸다"
+  fi
+  return $rc
 }
 
-sec "1. 빌드 시각만 다르면 지문이 같은가"
-python3 /rehearse/makejar.py "$WORK/a1.jar" api-app SAME    "2026-09-02T01:00:00Z"
-python3 /rehearse/makejar.py "$WORK/a2.jar" api-app SAME    "2026-09-02T09:30:00Z"
-python3 /rehearse/makejar.py "$WORK/a3.jar" api-app CHANGED "2026-09-02T01:00:00Z"
-s1=$(sha256sum "$WORK/a1.jar"|cut -d' ' -f1); s2=$(sha256sum "$WORK/a2.jar"|cut -d' ' -f1)
-d1=$(stable_digest "$WORK/a1.jar"); d2=$(stable_digest "$WORK/a2.jar"); d3=$(stable_digest "$WORK/a3.jar")
-[ "$s1" != "$s2" ] && ok "그냥 sha256 은 매번 달라진다" || bad "sha256 이 같다"
-[ "$d1" = "$d2" ]  && ok "stable_digest 는 같다" || bad "stable_digest 가 다르다"
-[ "$d1" != "$d3" ] && ok "내용이 바뀌면 stable_digest 도 바뀐다" || bad "내용이 바뀌었는데 지문이 같다"
+sec "1. 소스 지문이 안정적인가"
+mkdir -p "$WORK/src1/main" "$WORK/src2/main"
+echo "hello" > "$WORK/src1/main/A.java"; echo "world" > "$WORK/src1/main/B.java"
+d1="$(cd "$WORK/src1" && source_digest main)"
+d2="$(cd "$WORK/src1" && source_digest main)"
+[ "$d1" = "$d2" ] && ok "같은 소스를 두 번 세면 같다" || bad "두 번 세니 달라진다"
+echo "changed" > "$WORK/src1/main/B.java"
+d3="$(cd "$WORK/src1" && source_digest main)"
+[ "$d1" != "$d3" ] && ok "소스가 바뀌면 지문도 바뀐다" || bad "소스가 바뀌었는데 지문이 같다"
+mkdir -p "$WORK/src1/test"; echo "t" > "$WORK/src1/test/T.java"
+d4="$(cd "$WORK/src1" && source_digest main)"
+[ "$d3" = "$d4" ] && ok "테스트만 늘어도 지문이 안 바뀐다" || bad "테스트가 지문을 흔든다"
 
-sec "2. 첫 배포 (/opt/salmonbus 이 아예 없는 상태)"
+sec "2. 첫 배포. api 먼저, worker 나중"
 rm -rf /opt/salmonbus
-make_archive APIv1 WORKERv1 aaaaaaa1111 1 "2026-09-02T01:00:00Z"
-run_deploy "1차"
-[ "$(readlink -f /opt/salmonbus/current)" = "/opt/salmonbus/releases/aaaaaaa-1" ] \
-  && ok "current 가 첫 판을 가리킨다" || bad "current=$(readlink -f /opt/salmonbus/current 2>/dev/null)"
+make_revision api    APIv1    aaaaaaa1111 1111aaaa2222bbbb3333cccc4444dddd5555eeee6666ffff7777000088889999 "2026-09-02T01:00:00Z"
+make_revision worker WORKERv1 aaaaaaa1111 9999888877776666555544443333222211110000ffffeeeeddddccccbbbbaaaa "2026-09-02T01:00:00Z"
+deploy api
+deploy worker
+[ "$(readlink -f /opt/salmonbus/api/current)" = "/opt/salmonbus/api/releases/1111aaaa2222bbbb3333cccc4444dddd5555eeee6666ffff7777000088889999" ] \
+  && ok "api current 가 소스 지문으로 이름 붙은 판을 가리킨다" || bad "api current=$(readlink -f /opt/salmonbus/api/current 2>/dev/null)"
 grep -qx salmonbus-api /work/running && grep -qx salmonbus-worker /work/running \
-  && ok "첫 배포에 둘 다 올라갔다" || bad "안 올라간 서비스가 있다"
+  && ok "둘 다 올라갔다" || bad "안 올라간 것이 있다"
+[ ! -f /opt/salmonbus/.deploying ] && ok "배포 표시가 지워졌다" || bad "배포 표시가 남았다"
 
-sec "3. api 만 바뀐 배포"
+sec "3. api 소스만 바뀐 배포"
 : > /work/systemctl.log
-make_archive APIv2 WORKERv1 bbbbbbb2222 2 "2026-09-02T02:00:00Z"
-run_deploy "2차"
-grep -q 'restart salmonbus-api' /work/systemctl.log \
-  && ok "api 는 재시작했다" || bad "api 가 재시작 안 됐다"
-grep -q 'restart salmonbus-worker' /work/systemctl.log \
-  && bad "worker 도 재시작했다. 바뀐 것만 재시작이 안 된다" || ok "worker 는 안 건드렸다"
-[ "$(readlink -f /opt/salmonbus/previous)" = "/opt/salmonbus/releases/aaaaaaa-1" ] \
-  && ok "previous 가 직전 판을 가리킨다" || bad "previous=$(readlink -f /opt/salmonbus/previous 2>/dev/null)"
+make_revision api    APIv2    bbbbbbb2222 2222bbbb3333cccc4444dddd5555eeee6666ffff7777000088889999aaaa1111 "2026-09-02T02:00:00Z"
+make_revision worker WORKERv1 bbbbbbb2222 9999888877776666555544443333222211110000ffffeeeeddddccccbbbbaaaa "2026-09-02T02:00:00Z"
+deploy api
+deploy worker
+grep -q 'stop salmonbus-api' /work/systemctl.log \
+  && ok "api 는 내렸다 올렸다" || bad "api 가 재시작 안 됐다"
+grep -q 'stop salmonbus-worker' /work/systemctl.log \
+  && bad "worker 도 내렸다. 바뀐 것만 재시작이 안 된다" || ok "worker 는 안 건드렸다"
+[ "$(readlink -f /opt/salmonbus/api/previous)" = "/opt/salmonbus/api/releases/1111aaaa2222bbbb3333cccc4444dddd5555eeee6666ffff7777000088889999" ] \
+  && ok "api previous 가 직전 판을 가리킨다" || bad "api previous=$(readlink -f /opt/salmonbus/api/previous 2>/dev/null)"
 
-sec "4. 아무것도 안 바뀐 배포"
+sec "4. 아무 소스도 안 바뀐 배포"
 : > /work/systemctl.log
-make_archive APIv2 WORKERv1 ccccccc3333 3 "2026-09-02T03:00:00Z"
-run_deploy "3차"
-grep -q restart /work/systemctl.log \
-  && bad "안 바뀌었는데 재시작했다" || ok "둘 다 안 건드렸다"
+make_revision api    APIv2    ccccccc3333 2222bbbb3333cccc4444dddd5555eeee6666ffff7777000088889999aaaa1111 "2026-09-02T03:00:00Z"
+make_revision worker WORKERv1 ccccccc3333 9999888877776666555544443333222211110000ffffeeeeddddccccbbbbaaaa "2026-09-02T03:00:00Z"
+deploy api
+deploy worker
+grep -qE 'stop salmonbus' /work/systemctl.log \
+  && bad "안 바뀌었는데 내렸다" || ok "둘 다 안 건드렸다"
+[ -d /opt/salmonbus/api/releases/2222bbbb3333cccc4444dddd5555eeee6666ffff7777000088889999aaaa1111 ] \
+  && ok "돌고 있는 판을 안 지웠다" || bad "돌고 있는 판이 사라졌다"
 
-sec "5. health 가 안 오르면 실패로 끝나는가 (되돌리기가 걸리는 자리)"
-echo DOWN > /work/health
-make_archive APIv3 WORKERv1 ddddddd4444 4 "2026-09-02T04:00:00Z"
-rm -rf /opt/salmonbus/staging; mkdir -p /opt/salmonbus/staging
-cp -a "$ARCHIVE/." /opt/salmonbus/staging/
-bash "$ARCHIVE/scripts/preflight.sh" >/dev/null 2>&1
-bash "$ARCHIVE/scripts/install.sh"   >/dev/null 2>&1
-bash "$ARCHIVE/scripts/start.sh"     >/dev/null 2>&1
-if bash "$ARCHIVE/scripts/validate.sh" > "$WORK/v.out" 2>&1; then
-  bad "health 가 DOWN 인데 validate 가 통과했다"
+sec "5. api 배포가 도는 중이면 worker 가 안 끼어드나"
+printf 'api %s\n' "$(date +%s)" > /opt/salmonbus/.deploying
+if bash "$ARCHIVE/worker/scripts/preflight.sh" > "$WORK/lock.out" 2>&1; then
+  bad "api 배포 중인데 worker 가 들어왔다"
 else
-  ok "validate 가 실패로 끝난다 -> CodeDeploy 가 되돌린다"
+  grep -q '도는 중' "$WORK/lock.out" && ok "worker 가 막혔다" || bad "막히긴 했는데 이유가 다르다"
 fi
+rm -f /opt/salmonbus/.deploying
+
+sec "6. 옛 프로세스가 응답하면 validate 가 잡나"
+: > /work/systemctl.log
+echo "2222bbbb3333cccc4444dddd5555eeee6666ffff7777000088889999aaaa1111" > /work/stale     # 새 판을 올렸는데 옛 판이 응답하는 상황
+make_revision api APIv3 ddddddd4444 3333cccc4444dddd5555eeee6666ffff7777000088889999aaaa1111bbbb2222 "2026-09-02T04:00:00Z"
+deploy api fail
+rm -f /work/stale
+
+sec "7. health 가 안 오르면 실패로 끝나는가 (되돌리기가 걸리는 자리)"
+echo DOWN > /work/health
+make_revision api APIv4 eeeeeee5555 4444dddd5555eeee6666ffff7777000088889999aaaa1111bbbb2222cccc3333 "2026-09-02T05:00:00Z"
+deploy api fail
 echo UP > /work/health
 
-sec "6. 판을 셋만 남기는가"
-n=$(ls -1d /opt/salmonbus/releases/*/ 2>/dev/null | wc -l)
-[ "$n" -le 3 ] && ok "판 $n 개만 남았다" || bad "판이 $n 개다"
+sec "8. 판을 셋만 남기는가"
+n=$(/bin/ls -1d /opt/salmonbus/api/releases/*/ 2>/dev/null | wc -l)
+[ "$n" -le 3 ] && ok "api 판 $n 개" || bad "api 판이 $n 개다"
 
-sec "7. env 파일을 안 건드렸는가"
+sec "9. 배포가 안 건드려야 할 것"
 [ "$(stat -c '%a' /etc/salmonbus/worker.env)" = "600" ] \
   && ok "worker.env 권한 600 그대로" || bad "권한이 바뀌었다"
 grep -qc '^GBIS_SERVICE_KEY=' /etc/salmonbus/worker.env \
   && ok "키 줄이 그대로 있다" || bad "키 줄이 없어졌다"
+[ -d /var/lib/salmonbus/model/current ] \
+  && ok "계수 파일 자리가 배포 밖에 만들어졌다" || bad "계수 파일 자리가 없다"
 
-sec "8. 훅 로그에 값이 새지 않았는가"
+sec "10. 훅 로그에 값이 새지 않았는가"
 if grep -rqE 'GBIS_SERVICE_KEY=[^$]|DB_PASSWORD=[^$]' "$WORK"/*.out 2>/dev/null; then
   bad "훅 출력에 값이 찍혔다"
 else

--- a/backend/deploy/rehearsal/run.sh
+++ b/backend/deploy/rehearsal/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# 훅 스크립트를 리눅스 컨테이너에서 예행연습한다. AWS 없이 돌릴 수 있는 유일한 검증이다.
+#
+#   bash backend/deploy/rehearsal/run.sh
+#
+# systemctl · curl · java 를 흉내로 바꿔 끼우고 배포를 네 번 돌린다.
+# 첫 배포, api 만 바뀐 배포, 아무것도 안 바뀐 배포, health 가 안 오르는 배포다.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+docker run --rm \
+  -v "$HERE":/rehearse:ro \
+  -v "$HERE/..":/deploy:ro \
+  amazonlinux:2023 bash /rehearse/rehearse.sh

--- a/backend/deploy/scripts/common.sh
+++ b/backend/deploy/scripts/common.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# 훅 스크립트가 같이 쓰는 것들.
+# set -x 를 쓰지 마라. 훅 로그가 인스턴스에 남고 env 값이 찍히면 파일 권한이 소용없다
+set -euo pipefail
+
+ROOT=/opt/salmonbus
+STAGING="$ROOT/staging"
+RELEASES="$ROOT/releases"
+CURRENT="$ROOT/current"
+PREVIOUS="$ROOT/previous"
+LOCK="$ROOT/.deploy.lock"
+
+SERVICE_USER=salmonbus
+API_UNIT=salmonbus-api
+WORKER_UNIT=salmonbus-worker
+API_HEALTH="http://127.0.0.1:8080/actuator/health"
+WORKER_HEALTH="http://127.0.0.1:8081/actuator/health"
+
+log() { echo "[$(date -u +%H:%M:%S)] $*"; }
+
+# 훅 하나가 도는 동안 다른 훅이 끼어들지 못하게 한다.
+# 훅마다 프로세스가 달라서 스크립트가 끝나면 풀린다. 훅과 훅 사이는 안 잠근다.
+# 배포 둘이 겹치는 것은 CodeDeploy 가 배포 그룹마다 하나씩 돌려서 막는다
+take_lock() {
+  # 첫 배포에는 이 디렉터리가 아예 없다. 잠금 파일을 열기 전에 만든다
+  mkdir -p "$ROOT"
+  exec 9>"$LOCK"
+  flock -n 9 || { log "다른 배포가 도는 중이다"; exit 1; }
+}
+
+# manifest 에서 값 하나를 읽는다. 없으면 빈 문자열
+manifest_value() {
+  local file="$1" key="$2"
+  [ -f "$file" ] || return 0
+  awk -F= -v k="$key" '$1==k {print $2}' "$file"
+}

--- a/backend/deploy/scripts/common.sh
+++ b/backend/deploy/scripts/common.sh
@@ -63,6 +63,9 @@ claim_deploy() {
     tries=$((tries + 1))
     if mkdir "$MARKER" 2>/dev/null; then
       printf '%s %s %s\n' "$COMPONENT" "$DEPLOY_ID" "$(date +%s)" > "$MARKER/owner"
+      # 이 훅이 실패로 끝나면 잠금을 푼다. 성공이면 다음 훅이 쓰게 남긴다.
+      # 안 그러면 실패한 배포가 900초 동안 다른 서비스 배포까지 막는다
+      trap '_release_on_failure "$?"' EXIT
       return 0
     fi
     who=""; id=""; when=""
@@ -78,7 +81,10 @@ claim_deploy() {
       rm -rf "$MARKER"
       continue
     fi
-    age=$(( $(date +%s) - ${when:-0} ))
+    # 나이는 owner 파일이 아니라 잠금 디렉터리가 만들어진 시각으로 잰다.
+    # mkdir 과 owner 쓰기 사이의 찰나에 읽으면 owner 가 비는데,
+    # 그것을 아주 오래된 잠금으로 세면 남이 막 잡은 것을 뺏는다
+    age=$(( $(date +%s) - $(stat -c %Y "$MARKER" 2>/dev/null || date +%s) ))
     if [ "$age" -ge "$MARKER_STALE_SECONDS" ]; then
       log "${who:-알 수 없는} 배포 잠금이 ${age}초째 남아 있다. 버리고 다시 잡는다"
       rm -rf "$MARKER"
@@ -89,6 +95,11 @@ claim_deploy() {
   done
   log "배포 잠금을 못 잡았다"
   exit 1
+}
+
+_release_on_failure() {
+  [ "${1:-0}" -eq 0 ] || release_deploy
+  return 0
 }
 
 # 내가 잡은 잠금만 푼다. 남의 것을 풀면 겹침을 막는 뜻이 없어진다

--- a/backend/deploy/scripts/common.sh
+++ b/backend/deploy/scripts/common.sh
@@ -1,36 +1,70 @@
 #!/usr/bin/env bash
-# 훅 스크립트가 같이 쓰는 것들.
+# 훅 스크립트가 같이 쓰는 것들. api 와 worker 가 같은 파일을 쓴다.
+# 어느 쪽인지는 배포판 목록의 component 로 갈린다.
+#
 # set -x 를 쓰지 마라. 훅 로그가 인스턴스에 남고 env 값이 찍히면 파일 권한이 소용없다
 set -euo pipefail
 
-ROOT=/opt/salmonbus
-STAGING="$ROOT/staging"
-RELEASES="$ROOT/releases"
-CURRENT="$ROOT/current"
-PREVIOUS="$ROOT/previous"
-LOCK="$ROOT/.deploy.lock"
-
-SERVICE_USER=salmonbus
-API_UNIT=salmonbus-api
-WORKER_UNIT=salmonbus-worker
-API_HEALTH="http://127.0.0.1:8080/actuator/health"
-WORKER_HEALTH="http://127.0.0.1:8081/actuator/health"
+REVISION="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="$REVISION/release-manifest.txt"
 
 log() { echo "[$(date -u +%H:%M:%S)] $*"; }
 
-# 훅 하나가 도는 동안 다른 훅이 끼어들지 못하게 한다.
-# 훅마다 프로세스가 달라서 스크립트가 끝나면 풀린다. 훅과 훅 사이는 안 잠근다.
-# 배포 둘이 겹치는 것은 CodeDeploy 가 배포 그룹마다 하나씩 돌려서 막는다
-take_lock() {
-  # 첫 배포에는 이 디렉터리가 아예 없다. 잠금 파일을 열기 전에 만든다
-  mkdir -p "$ROOT"
-  exec 9>"$LOCK"
-  flock -n 9 || { log "다른 배포가 도는 중이다"; exit 1; }
-}
-
-# manifest 에서 값 하나를 읽는다. 없으면 빈 문자열
 manifest_value() {
   local file="$1" key="$2"
   [ -f "$file" ] || return 0
   awk -F= -v k="$key" '$1==k {print $2}' "$file"
 }
+
+COMPONENT="$(manifest_value "$MANIFEST" component)"
+case "$COMPONENT" in
+  api)
+    CLIENT_PORT=8080
+    ACTUATOR="http://127.0.0.1:8082/actuator"    # 관리 포트를 클라이언트 포트와 갈랐다
+    SMOKE="http://127.0.0.1:8080/api/v1/routes"
+    ;;
+  worker)
+    CLIENT_PORT=8081
+    ACTUATOR="http://127.0.0.1:8081/actuator"    # worker 는 이미 루프백에 묶여 있다
+    SMOKE=""
+    ;;
+  *)
+    echo "release-manifest.txt 의 component 를 못 읽었다: '${COMPONENT}'" >&2
+    exit 1
+    ;;
+esac
+
+ROOT=/opt/salmonbus
+BASE="$ROOT/$COMPONENT"
+STAGING="$BASE/staging"
+RELEASES="$BASE/releases"
+CURRENT="$BASE/current"
+PREVIOUS="$BASE/previous"
+CHANGED="$BASE/.changed"
+
+SERVICE_USER=salmonbus
+UNIT="salmonbus-$COMPONENT"
+ENV_FILE="/etc/salmonbus/$COMPONENT.env"
+MODEL_DIRECTORY=/var/lib/salmonbus/model/current
+JAR="$CURRENT/jars/$COMPONENT-app.jar"
+
+# api 와 worker 배포가 겹치지 않게 하는 표시다.
+# flock 은 스크립트가 끝나면 풀려서 훅과 훅 사이를 못 잠근다. 그래서 파일로 남긴다
+MARKER="$ROOT/.deploying"
+MARKER_STALE_SECONDS=900
+
+claim_deploy() {
+  mkdir -p "$ROOT"
+  if [ -f "$MARKER" ]; then
+    local who age
+    who="$(awk '{print $1}' "$MARKER")"
+    age=$(( $(date +%s) - $(awk '{print $2}' "$MARKER") ))
+    if [ "$who" != "$COMPONENT" ] && [ "$age" -lt "$MARKER_STALE_SECONDS" ]; then
+      log "$who 배포가 ${age}초째 도는 중이다. 겹치지 않게 여기서 멈춘다"
+      exit 1
+    fi
+  fi
+  printf '%s %s\n' "$COMPONENT" "$(date +%s)" > "$MARKER"
+}
+
+release_deploy() { rm -f "$MARKER"; }

--- a/backend/deploy/scripts/common.sh
+++ b/backend/deploy/scripts/common.sh
@@ -48,23 +48,72 @@ ENV_FILE="/etc/salmonbus/$COMPONENT.env"
 MODEL_DIRECTORY=/var/lib/salmonbus/model/current
 JAR="$CURRENT/jars/$COMPONENT-app.jar"
 
-# api 와 worker 배포가 겹치지 않게 하는 표시다.
-# flock 은 스크립트가 끝나면 풀려서 훅과 훅 사이를 못 잠근다. 그래서 파일로 남긴다
+# api 와 worker 배포가 겹치지 않게 하는 잠금이다.
+# flock 은 스크립트가 끝나면 풀려서 훅과 훅 사이를 못 잠근다. 그래서 디렉터리로 잠근다.
+# mkdir 은 있으면 실패하는 하나짜리 동작이라 확인과 생성 사이가 안 벌어진다
 MARKER="$ROOT/.deploying"
 MARKER_STALE_SECONDS=900
+# CodeDeploy 가 훅마다 같은 값을 준다. 그래서 한 배포의 네 훅이 같은 잠금을 쓴다
+DEPLOY_ID="${DEPLOYMENT_ID:-$COMPONENT-manual}"
 
 claim_deploy() {
   mkdir -p "$ROOT"
-  if [ -f "$MARKER" ]; then
-    local who age
-    who="$(awk '{print $1}' "$MARKER")"
-    age=$(( $(date +%s) - $(awk '{print $2}' "$MARKER") ))
-    if [ "$who" != "$COMPONENT" ] && [ "$age" -lt "$MARKER_STALE_SECONDS" ]; then
-      log "$who 배포가 ${age}초째 도는 중이다. 겹치지 않게 여기서 멈춘다"
-      exit 1
+  local tries=0 who id when age
+  while [ "$tries" -lt 3 ]; do
+    tries=$((tries + 1))
+    if mkdir "$MARKER" 2>/dev/null; then
+      printf '%s %s %s\n' "$COMPONENT" "$DEPLOY_ID" "$(date +%s)" > "$MARKER/owner"
+      return 0
     fi
-  fi
-  printf '%s %s\n' "$COMPONENT" "$(date +%s)" > "$MARKER"
+    who=""; id=""; when=""
+    read -r who id when < "$MARKER/owner" 2>/dev/null || true
+    # 같은 배포의 다음 훅이면 그대로 쓴다
+    [ "$id" = "$DEPLOY_ID" ] && return 0
+    # 같은 서비스의 다른 배포면 넘겨받는다.
+    # 실패한 배포는 validate 까지 못 가서 잠금을 쥔 채 끝난다. 그대로 두면
+    # CodeDeploy 가 바로 거는 롤백이 자기가 남긴 잠금에 막힌다.
+    # 한 배포 그룹에 배포가 둘 동시에 안 도는 것은 CodeDeploy 가 지킨다
+    if [ "$who" = "$COMPONENT" ]; then
+      log "$COMPONENT 의 앞 배포가 남긴 잠금을 넘겨받는다"
+      rm -rf "$MARKER"
+      continue
+    fi
+    age=$(( $(date +%s) - ${when:-0} ))
+    if [ "$age" -ge "$MARKER_STALE_SECONDS" ]; then
+      log "${who:-알 수 없는} 배포 잠금이 ${age}초째 남아 있다. 버리고 다시 잡는다"
+      rm -rf "$MARKER"
+      continue
+    fi
+    log "${who:-다른} 배포가 ${age}초째 도는 중이다. 겹치지 않게 여기서 멈춘다"
+    exit 1
+  done
+  log "배포 잠금을 못 잡았다"
+  exit 1
 }
 
-release_deploy() { rm -f "$MARKER"; }
+# 내가 잡은 잠금만 푼다. 남의 것을 풀면 겹침을 막는 뜻이 없어진다
+release_deploy() {
+  local id=""
+  read -r _ id _ < "$MARKER/owner" 2>/dev/null || true
+  [ "$id" = "$DEPLOY_ID" ] && rm -rf "$MARKER"
+  return 0
+}
+
+# 판 폴더 경로를 만든다. 이 값이 root 권한 삭제와 이동에 쓰여서 형식을 먼저 본다.
+# 배포판 목록을 손대면 releases 밖을 건드릴 수 있는 곳이다
+release_path() {
+  local digest="$1" base resolved
+  [ "${#digest}" -eq 64 ] || { log "sourceDigest 가 64자가 아니다 (${#digest}자)"; exit 1; }
+  case "$digest" in
+    *[!0-9a-f]*) log "sourceDigest 에 16진수가 아닌 글자가 있다"; exit 1 ;;
+  esac
+  mkdir -p "$RELEASES"
+  base="$(cd "$RELEASES" && pwd -P)"
+  resolved="$base/$digest"
+  # 형식 검사를 통과해도 정규화한 경로를 한 번 더 본다. 둘 중 하나만으로는 약하다
+  case "$resolved" in
+    "$base"/?*) ;;
+    *) log "판 경로가 releases 밖을 가리킨다"; exit 1 ;;
+  esac
+  printf '%s' "$resolved"
+}

--- a/backend/deploy/scripts/install.sh
+++ b/backend/deploy/scripts/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# AfterInstall. staging 에 풀린 것을 판 폴더로 옮기고 바로가기를 세운다
+source "$(dirname "$0")/common.sh"
+take_lock
+
+NEW_MANIFEST="$STAGING/release-manifest.txt"
+[ -f "$NEW_MANIFEST" ] || { log "release-manifest.txt 가 없다"; exit 1; }
+
+commit="$(manifest_value "$NEW_MANIFEST" commit)"
+build="$(manifest_value "$NEW_MANIFEST" buildNumber)"
+release="$RELEASES/${commit:0:7}-${build}"
+
+log "판 $release 을 놓는다"
+rm -rf "$release"
+mkdir -p "$(dirname "$release")"
+mv "$STAGING" "$release"
+# staging 은 방금 옮겨져서 없다. 새 목록은 이제 판 폴더에 있다
+NEW_MANIFEST="$release/release-manifest.txt"
+
+# 바로가기를 옮기기 전에 지금 도는 판과 대조한다. 옮기고 나면 못 본다
+OLD_MANIFEST="$CURRENT/release-manifest.txt"
+changed=""
+for svc in api worker; do
+  old="$(manifest_value "$OLD_MANIFEST" "${svc}Digest")"
+  new="$(manifest_value "$NEW_MANIFEST" "${svc}Digest")"
+  if [ -z "$old" ] || [ "$old" != "$new" ]; then
+    changed="$changed $svc"
+  fi
+done
+echo "changed=${changed# }" > "$release/.changed"
+log "바뀐 서비스:${changed:- 없음}"
+
+# systemd 유닛이 바뀌었을 때만 갈아 끼운다
+for unit in "$release"/systemd/*.service; do
+  target="/etc/systemd/system/$(basename "$unit")"
+  if ! cmp -s "$unit" "$target"; then
+    install -m 644 -o root -g root "$unit" "$target"
+    log "유닛 갱신: $(basename "$unit")"
+    NEED_RELOAD=1
+  fi
+done
+[ "${NEED_RELOAD:-0}" = "1" ] && systemctl daemon-reload
+
+chown -R "$SERVICE_USER:$SERVICE_USER" "$release"
+
+# 되돌릴 자리를 남기고 바로가기를 옮긴다
+[ -L "$CURRENT" ] && ln -sfn "$(readlink -f "$CURRENT")" "$PREVIOUS"
+ln -sfn "$release" "$CURRENT"
+log "current -> $release"
+
+# 오래된 판을 셋만 남긴다. JAR 이 판마다 105MB 다
+ls -1dt "$RELEASES"/*/ 2>/dev/null | tail -n +4 | xargs -r rm -rf

--- a/backend/deploy/scripts/install.sh
+++ b/backend/deploy/scripts/install.sh
@@ -1,52 +1,63 @@
 #!/usr/bin/env bash
 # AfterInstall. staging 에 풀린 것을 판 폴더로 옮기고 바로가기를 세운다
-source "$(dirname "$0")/common.sh"
-take_lock
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+claim_deploy
 
-NEW_MANIFEST="$STAGING/release-manifest.txt"
-[ -f "$NEW_MANIFEST" ] || { log "release-manifest.txt 가 없다"; exit 1; }
+NEW_DIGEST="$(manifest_value "$MANIFEST" sourceDigest)"
+OLD_DIGEST="$(manifest_value "$CURRENT/release-manifest.txt" sourceDigest)"
+release="$RELEASES/$NEW_DIGEST"
 
-commit="$(manifest_value "$NEW_MANIFEST" commit)"
-build="$(manifest_value "$NEW_MANIFEST" buildNumber)"
-release="$RELEASES/${commit:0:7}-${build}"
+# 소스가 그대로면 판을 새로 놓지 않는다. 지금 도는 판이 바로 그 판이다.
+# 여기서 rm -rf 를 하면 돌고 있는 판을 지운다
+if [ "$NEW_DIGEST" = "$OLD_DIGEST" ] && [ -d "$release" ]; then
+  log "$COMPONENT 소스 지문이 그대로다. 판을 안 건드린다"
+  rm -rf "$STAGING"
+  echo "changed=no" > "$CHANGED"
+  exit 0
+fi
 
 log "판 $release 을 놓는다"
-rm -rf "$release"
-mkdir -p "$(dirname "$release")"
-mv "$STAGING" "$release"
-# staging 은 방금 옮겨져서 없다. 새 목록은 이제 판 폴더에 있다
-NEW_MANIFEST="$release/release-manifest.txt"
-
-# 바로가기를 옮기기 전에 지금 도는 판과 대조한다. 옮기고 나면 못 본다
-OLD_MANIFEST="$CURRENT/release-manifest.txt"
-changed=""
-for svc in api worker; do
-  old="$(manifest_value "$OLD_MANIFEST" "${svc}Digest")"
-  new="$(manifest_value "$NEW_MANIFEST" "${svc}Digest")"
-  if [ -z "$old" ] || [ "$old" != "$new" ]; then
-    changed="$changed $svc"
-  fi
+# 지문이 다른데 같은 폴더를 가리키면 돌고 있는 판을 지우게 된다. 그 길을 막는다
+for busy in "$CURRENT" "$PREVIOUS"; do
+  [ "$(readlink -f "$busy" 2>/dev/null || true)" = "$release" ] \
+    && { log "$release 을 $busy 가 쓰고 있다"; exit 1; }
 done
-echo "changed=${changed# }" > "$release/.changed"
-log "바뀐 서비스:${changed:- 없음}"
+rm -rf "$release"
+mv "$STAGING" "$release"
+
+# 도는 배포를 /actuator/info 로 판별하게 한다. systemd 가 이 파일을 같이 읽는다
+{
+  echo "MANAGEMENT_INFO_ENV_ENABLED=true"
+  echo "INFO_COMPONENT=$COMPONENT"
+  echo "INFO_COMMIT=$(manifest_value "$release/release-manifest.txt" commit)"
+  echo "INFO_SOURCEDIGEST=$NEW_DIGEST"
+} > "$release/release.env"
 
 # systemd 유닛이 바뀌었을 때만 갈아 끼운다
-for unit in "$release"/systemd/*.service; do
-  target="/etc/systemd/system/$(basename "$unit")"
-  if ! cmp -s "$unit" "$target"; then
-    install -m 644 -o root -g root "$unit" "$target"
-    log "유닛 갱신: $(basename "$unit")"
-    NEED_RELOAD=1
-  fi
-done
-[ "${NEED_RELOAD:-0}" = "1" ] && systemctl daemon-reload
+unit_file="$release/systemd/$UNIT.service"
+target="/etc/systemd/system/$UNIT.service"
+if ! cmp -s "$unit_file" "$target"; then
+  install -m 644 -o root -g root "$unit_file" "$target"
+  systemctl daemon-reload
+  log "유닛 갱신: $UNIT.service"
+fi
 
 chown -R "$SERVICE_USER:$SERVICE_USER" "$release"
 
 # 되돌릴 자리를 남기고 바로가기를 옮긴다
-[ -L "$CURRENT" ] && ln -sfn "$(readlink -f "$CURRENT")" "$PREVIOUS"
+if [ -L "$CURRENT" ]; then
+  ln -sfn "$(readlink -f "$CURRENT")" "$PREVIOUS"
+fi
 ln -sfn "$release" "$CURRENT"
+echo "changed=yes" > "$CHANGED"
 log "current -> $release"
 
-# 오래된 판을 셋만 남긴다. JAR 이 판마다 105MB 다
-ls -1dt "$RELEASES"/*/ 2>/dev/null | tail -n +4 | xargs -r rm -rf
+# 판마다 52MB 다. 셋만 남긴다. 지금 쓰는 것과 직전 것은 안 지운다
+keep_current="$(readlink -f "$CURRENT" 2>/dev/null || true)"
+keep_previous="$(readlink -f "$PREVIOUS" 2>/dev/null || true)"
+ls -1dt "$RELEASES"/*/ 2>/dev/null | tail -n +4 | while read -r old; do
+  old="${old%/}"
+  [ "$old" = "$keep_current" ] && continue
+  [ "$old" = "$keep_previous" ] && continue
+  rm -rf "$old"
+done

--- a/backend/deploy/scripts/install.sh
+++ b/backend/deploy/scripts/install.sh
@@ -11,8 +11,16 @@ release="$RELEASES/$NEW_DIGEST"
 # 여기서 rm -rf 를 하면 돌고 있는 판을 지운다
 if [ "$NEW_DIGEST" = "$OLD_DIGEST" ] && [ -d "$release" ]; then
   log "$COMPONENT 소스 지문이 그대로다. 판을 안 건드린다"
+  # 소스가 같아도 유닛이 바뀌었으면 다시 띄워야 새 ExecStart 와 EnvironmentFile 이 먹는다
+  unit_changed=no
+  if ! cmp -s "$STAGING/systemd/$UNIT.service" "/etc/systemd/system/$UNIT.service"; then
+    install -m 644 -o root -g root "$STAGING/systemd/$UNIT.service" "/etc/systemd/system/$UNIT.service"
+    systemctl daemon-reload
+    unit_changed=yes
+    log "소스는 그대로인데 유닛이 바뀌었다"
+  fi
   rm -rf "$STAGING"
-  echo "changed=no" > "$CHANGED"
+  echo "changed=$unit_changed" > "$CHANGED"
   exit 0
 fi
 
@@ -36,20 +44,27 @@ mv "$STAGING" "$release"
 # systemd 유닛이 바뀌었을 때만 갈아 끼운다
 unit_file="$release/systemd/$UNIT.service"
 target="/etc/systemd/system/$UNIT.service"
+unit_changed=no
 if ! cmp -s "$unit_file" "$target"; then
   install -m 644 -o root -g root "$unit_file" "$target"
   systemctl daemon-reload
+  unit_changed=yes
   log "유닛 갱신: $UNIT.service"
 fi
 
-chown -R "$SERVICE_USER:$SERVICE_USER" "$release"
+# 주인은 root 로 두고 서비스 사용자에게는 읽기만 준다.
+# 앱이 자기 JAR 과 훅 스크립트를 고칠 수 있으면 안 된다
+chown -R "root:$SERVICE_USER" "$release"
+chmod -R go-w "$release"
+find "$release" -type d -exec chmod g+rx {} +
+find "$release" -type f -exec chmod g+r {} +
 
 # 되돌릴 자리를 남기고 바로가기를 옮긴다
 if [ -L "$CURRENT" ]; then
   ln -sfn "$(readlink -f "$CURRENT")" "$PREVIOUS"
 fi
 ln -sfn "$release" "$CURRENT"
-echo "changed=yes" > "$CHANGED"
+echo "changed=yes" > "$CHANGED"   # 소스가 바뀌었다
 log "current -> $release"
 
 # 판마다 52MB 다. 셋만 남긴다. 지금 쓰는 것과 직전 것은 안 지운다

--- a/backend/deploy/scripts/install.sh
+++ b/backend/deploy/scripts/install.sh
@@ -1,56 +1,49 @@
 #!/usr/bin/env bash
-# AfterInstall. staging 에 풀린 것을 판 폴더로 옮기고 바로가기를 세운다
+# AfterInstall. staging 에 풀린 것을 판 폴더로 놓고 바로가기를 세운다
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 claim_deploy
 
 NEW_DIGEST="$(manifest_value "$MANIFEST" sourceDigest)"
 OLD_DIGEST="$(manifest_value "$CURRENT/release-manifest.txt" sourceDigest)"
-release="$RELEASES/$NEW_DIGEST"
+release="$(release_path "$NEW_DIGEST")"
 
-# 소스가 그대로면 판을 새로 놓지 않는다. 지금 도는 판이 바로 그 판이다.
-# 여기서 rm -rf 를 하면 돌고 있는 판을 지운다
-if [ "$NEW_DIGEST" = "$OLD_DIGEST" ] && [ -d "$release" ]; then
-  log "$COMPONENT 소스 지문이 그대로다. 판을 안 건드린다"
-  # 소스가 같아도 유닛이 바뀌었으면 다시 띄워야 새 ExecStart 와 EnvironmentFile 이 먹는다
-  unit_changed=no
-  if ! cmp -s "$STAGING/systemd/$UNIT.service" "/etc/systemd/system/$UNIT.service"; then
-    install -m 644 -o root -g root "$STAGING/systemd/$UNIT.service" "/etc/systemd/system/$UNIT.service"
-    systemctl daemon-reload
-    unit_changed=yes
-    log "소스는 그대로인데 유닛이 바뀌었다"
+# 유닛을 갈아 끼운다. 소스가 그대로여도 유닛이 바뀌었으면 다시 띄워야
+# 새 ExecStart 와 EnvironmentFile 이 먹는다
+install_unit() {
+  local unit_file="$1" target="/etc/systemd/system/$UNIT.service"
+  if cmp -s "$unit_file" "$target"; then
+    echo no
+    return 0
   fi
+  install -m 644 -o root -g root "$unit_file" "$target"
+  systemctl daemon-reload
+  log "유닛 갱신: $UNIT.service"
+  echo yes
+}
+
+if [ -d "$release" ]; then
+  # 이미 있는 판이다. 되돌리기가 여기로 온다.
+  # CodeDeploy 의 자동 롤백은 직전 성공 revision 을 그대로 다시 배포하는 것이라
+  # 그 판이 previous 로 남아 있다. 지우고 다시 풀면 되돌릴 것이 없어진다.
+  # 있는 것을 그대로 쓰고 current 만 옮긴다
+  log "이미 있는 판이다. 다시 안 풀고 그대로 쓴다: $release"
+  unit_changed="$(install_unit "$STAGING/systemd/$UNIT.service")"
   rm -rf "$STAGING"
-  echo "changed=$unit_changed" > "$CHANGED"
-  exit 0
+else
+  log "판 $release 을 놓는다"
+  mkdir -p "$RELEASES"
+  mv "$STAGING" "$release"
+  unit_changed="$(install_unit "$release/systemd/$UNIT.service")"
 fi
 
-log "판 $release 을 놓는다"
-# 지문이 다른데 같은 폴더를 가리키면 돌고 있는 판을 지우게 된다. 그 길을 막는다
-for busy in "$CURRENT" "$PREVIOUS"; do
-  [ "$(readlink -f "$busy" 2>/dev/null || true)" = "$release" ] \
-    && { log "$release 을 $busy 가 쓰고 있다"; exit 1; }
-done
-rm -rf "$release"
-mv "$STAGING" "$release"
-
-# 도는 배포를 /actuator/info 로 판별하게 한다. systemd 가 이 파일을 같이 읽는다
+# 도는 배포를 /actuator/info 로 판별하게 한다. systemd 가 이 파일을 같이 읽는다.
+# 배포판 목록은 지금 배포하는 revision 것을 쓴다. 되돌리기면 옛 commit 이 들어가는 게 맞다
 {
   echo "MANAGEMENT_INFO_ENV_ENABLED=true"
   echo "INFO_COMPONENT=$COMPONENT"
-  echo "INFO_COMMIT=$(manifest_value "$release/release-manifest.txt" commit)"
+  echo "INFO_COMMIT=$(manifest_value "$MANIFEST" commit)"
   echo "INFO_SOURCEDIGEST=$NEW_DIGEST"
 } > "$release/release.env"
-
-# systemd 유닛이 바뀌었을 때만 갈아 끼운다
-unit_file="$release/systemd/$UNIT.service"
-target="/etc/systemd/system/$UNIT.service"
-unit_changed=no
-if ! cmp -s "$unit_file" "$target"; then
-  install -m 644 -o root -g root "$unit_file" "$target"
-  systemctl daemon-reload
-  unit_changed=yes
-  log "유닛 갱신: $UNIT.service"
-fi
 
 # 주인은 root 로 두고 서비스 사용자에게는 읽기만 준다.
 # 앱이 자기 JAR 과 훅 스크립트를 고칠 수 있으면 안 된다
@@ -59,13 +52,26 @@ chmod -R go-w "$release"
 find "$release" -type d -exec chmod g+rx {} +
 find "$release" -type f -exec chmod g+r {} +
 
-# 되돌릴 자리를 남기고 바로가기를 옮긴다
-if [ -L "$CURRENT" ]; then
-  ln -sfn "$(readlink -f "$CURRENT")" "$PREVIOUS"
+# 재부팅 뒤에도 올라오게 한다. 여러 번 불러도 같은 결과다
+systemctl enable "$UNIT" >/dev/null 2>&1 || { log "$UNIT enable 실패"; exit 1; }
+
+current_now="$(readlink -f "$CURRENT" 2>/dev/null || true)"
+if [ "$current_now" = "$release" ]; then
+  # 지금 도는 판을 그대로 다시 배포한 것이다. 바로가기를 안 건드린다
+  log "current 가 이미 $release 다"
+else
+  [ -n "$current_now" ] && ln -sfn "$current_now" "$PREVIOUS"
+  ln -sfn "$release" "$CURRENT"
+  log "current -> $release"
 fi
-ln -sfn "$release" "$CURRENT"
-echo "changed=yes" > "$CHANGED"   # 소스가 바뀌었다
-log "current -> $release"
+
+if [ "$NEW_DIGEST" = "$OLD_DIGEST" ]; then
+  # 소스가 그대로다. 유닛이 바뀌었을 때만 다시 띄운다
+  echo "changed=$unit_changed" > "$CHANGED"
+  log "$COMPONENT 소스 지문이 그대로다. 재시작=$unit_changed"
+else
+  echo "changed=yes" > "$CHANGED"
+fi
 
 # 판마다 52MB 다. 셋만 남긴다. 지금 쓰는 것과 직전 것은 안 지운다
 keep_current="$(readlink -f "$CURRENT" 2>/dev/null || true)"

--- a/backend/deploy/scripts/preflight.sh
+++ b/backend/deploy/scripts/preflight.sh
@@ -1,25 +1,37 @@
 #!/usr/bin/env bash
 # BeforeInstall. 여기서 걸리면 파일을 안 푼다
-source "$(dirname "$0")/common.sh"
-take_lock
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+claim_deploy
 
-log "준비 상태를 본다"
+log "$COMPONENT 배포 준비를 본다"
 
 command -v java >/dev/null || { log "자바가 없다"; exit 1; }
 java -version 2>&1 | head -1
+id "$SERVICE_USER" >/dev/null 2>&1 || { log "$SERVICE_USER 사용자가 없다. RUNBOOK 의 최초 1회 절차를 보라"; exit 1; }
 
-id "$SERVICE_USER" >/dev/null 2>&1 || { log "$SERVICE_USER 사용자가 없다. 최초 설치 절차를 보라"; exit 1; }
+# 값은 안 찍는다. 줄이 있는지만 센다
+[ -f "$ENV_FILE" ] || { log "$ENV_FILE 이 없다. 사람이 한 번 만들어야 한다"; exit 1; }
+grep -qc '^DB_URL=' "$ENV_FILE" || { log "$ENV_FILE 에 DB_URL 이 없다"; exit 1; }
+if [ "$COMPONENT" = "worker" ]; then
+  grep -qc '^GBIS_SERVICE_KEY=' "$ENV_FILE" || { log "$ENV_FILE 에 GBIS_SERVICE_KEY 가 없다"; exit 1; }
+  # 계수 파일 자리는 배포가 안 건드리는 곳이라 여기서 만들기만 한다
+  mkdir -p "$MODEL_DIRECTORY"
+  chown -R "$SERVICE_USER:$SERVICE_USER" /var/lib/salmonbus
+fi
 
-for f in /etc/salmonbus/api.env /etc/salmonbus/worker.env; do
-  [ -f "$f" ] || { log "$f 가 없다. 사람이 한 번 만들어야 한다"; exit 1; }
-  # 값은 안 찍는다. 줄이 있는지만 센다
-  grep -qc '^DB_URL=' "$f" || { log "$f 에 DB_URL 이 없다"; exit 1; }
+# 배포판 목록이 형식에 맞나. install.sh 가 이 값들로 판 이름을 짓는다
+for key in commit sourceDigest artifactSha256; do
+  [ -n "$(manifest_value "$MANIFEST" "$key")" ] || { log "배포판 목록에 $key 가 없다"; exit 1; }
 done
-grep -qc '^GBIS_SERVICE_KEY=' /etc/salmonbus/worker.env \
-  || { log "worker.env 에 GBIS_SERVICE_KEY 가 없다"; exit 1; }
 
-# JAR 두 개가 105MB 쯤이고 판을 몇 개 남긴다. 여유를 본다
-avail=$(df --output=avail -m "$ROOT" 2>/dev/null | tail -1 || echo 0)
+# 받은 JAR 이 빌드 때와 같은 파일인가
+want="$(manifest_value "$MANIFEST" artifactSha256)"
+got="$(sha256sum "$REVISION/jars/$COMPONENT-app.jar" | cut -d' ' -f1)"
+[ "$want" = "$got" ] || { log "JAR 지문이 배포판 목록과 다르다"; exit 1; }
+
+# JAR 하나가 52MB 다. 판을 셋 남기고 여유를 본다
+mkdir -p "$BASE"
+avail=$(df --output=avail -m "$BASE" 2>/dev/null | tail -1 || echo 0)
 [ "${avail:-0}" -ge 1024 ] || { log "디스크 여유가 ${avail}MB 뿐이다"; exit 1; }
 
 mkdir -p "$RELEASES"

--- a/backend/deploy/scripts/preflight.sh
+++ b/backend/deploy/scripts/preflight.sh
@@ -5,8 +5,11 @@ claim_deploy
 
 log "$COMPONENT 배포 준비를 본다"
 
-command -v java >/dev/null || { log "자바가 없다"; exit 1; }
-java -version 2>&1 | head -1
+# 유닛이 /usr/bin/java 를 쓴다. PATH 의 java 를 봐도 그게 뜬다는 뜻이 아니다
+[ -x /usr/bin/java ] || { log "/usr/bin/java 가 없다"; exit 1; }
+java_major="$(/usr/bin/java -version 2>&1 | head -1 | sed -n 's/.*version "\([0-9]*\).*/\1/p')"
+[ "$java_major" = "21" ] || { log "/usr/bin/java 가 21 이 아니다 (${java_major:-읽기 실패})"; exit 1; }
+log "자바 $java_major"
 id "$SERVICE_USER" >/dev/null 2>&1 || { log "$SERVICE_USER 사용자가 없다. RUNBOOK 의 최초 1회 절차를 보라"; exit 1; }
 
 # 값은 안 찍는다. 줄이 있는지만 센다
@@ -19,10 +22,15 @@ if [ "$COMPONENT" = "worker" ]; then
   chown -R "$SERVICE_USER:$SERVICE_USER" /var/lib/salmonbus
 fi
 
-# 배포판 목록이 형식에 맞나. install.sh 가 이 값들로 판 이름을 짓는다
-for key in commit sourceDigest artifactSha256; do
+# 배포판 목록이 형식에 맞나. install.sh 가 이 값으로 판 이름을 짓는다
+for key in component commit sourceDigest artifactSha256; do
   [ -n "$(manifest_value "$MANIFEST" "$key")" ] || { log "배포판 목록에 $key 가 없다"; exit 1; }
 done
+
+# sourceDigest 는 root 권한 삭제와 이동 경로에 들어간다. 여기서 형식과 경로를 다 본다.
+# install.sh 가 쓰기 전에 걸러야 releases 밖을 건드리는 길이 안 생긴다
+checked="$(release_path "$(manifest_value "$MANIFEST" sourceDigest)")"
+log "판 경로 확인: $checked"
 
 # 받은 JAR 이 빌드 때와 같은 파일인가
 want="$(manifest_value "$MANIFEST" artifactSha256)"

--- a/backend/deploy/scripts/preflight.sh
+++ b/backend/deploy/scripts/preflight.sh
@@ -14,6 +14,11 @@ id "$SERVICE_USER" >/dev/null 2>&1 || { log "$SERVICE_USER 사용자가 없다. 
 
 # 값은 안 찍는다. 줄이 있는지만 센다
 [ -f "$ENV_FILE" ] || { log "$ENV_FILE 이 없다. 사람이 한 번 만들어야 한다"; exit 1; }
+# systemd 가 이 파일을 앱 환경변수로 통째로 넣는다. 남이 읽을 수 있으면 안 된다
+env_mode="$(stat -c '%a' "$ENV_FILE")"
+env_owner="$(stat -c '%U:%G' "$ENV_FILE")"
+[ "$env_mode" = "600" ] || { log "$ENV_FILE 권한이 $env_mode 다. 600 이어야 한다"; exit 1; }
+[ "$env_owner" = "root:root" ] || { log "$ENV_FILE 주인이 $env_owner 다. root:root 여야 한다"; exit 1; }
 grep -qc '^DB_URL=' "$ENV_FILE" || { log "$ENV_FILE 에 DB_URL 이 없다"; exit 1; }
 if [ "$COMPONENT" = "worker" ]; then
   grep -qc '^GBIS_SERVICE_KEY=' "$ENV_FILE" || { log "$ENV_FILE 에 GBIS_SERVICE_KEY 가 없다"; exit 1; }

--- a/backend/deploy/scripts/preflight.sh
+++ b/backend/deploy/scripts/preflight.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# BeforeInstall. 여기서 걸리면 파일을 안 푼다
+source "$(dirname "$0")/common.sh"
+take_lock
+
+log "준비 상태를 본다"
+
+command -v java >/dev/null || { log "자바가 없다"; exit 1; }
+java -version 2>&1 | head -1
+
+id "$SERVICE_USER" >/dev/null 2>&1 || { log "$SERVICE_USER 사용자가 없다. 최초 설치 절차를 보라"; exit 1; }
+
+for f in /etc/salmonbus/api.env /etc/salmonbus/worker.env; do
+  [ -f "$f" ] || { log "$f 가 없다. 사람이 한 번 만들어야 한다"; exit 1; }
+  # 값은 안 찍는다. 줄이 있는지만 센다
+  grep -qc '^DB_URL=' "$f" || { log "$f 에 DB_URL 이 없다"; exit 1; }
+done
+grep -qc '^GBIS_SERVICE_KEY=' /etc/salmonbus/worker.env \
+  || { log "worker.env 에 GBIS_SERVICE_KEY 가 없다"; exit 1; }
+
+# JAR 두 개가 105MB 쯤이고 판을 몇 개 남긴다. 여유를 본다
+avail=$(df --output=avail -m "$ROOT" 2>/dev/null | tail -1 || echo 0)
+[ "${avail:-0}" -ge 1024 ] || { log "디스크 여유가 ${avail}MB 뿐이다"; exit 1; }
+
+mkdir -p "$RELEASES"
+rm -rf "$STAGING"
+log "준비 끝. 여유 ${avail}MB"

--- a/backend/deploy/scripts/start.sh
+++ b/backend/deploy/scripts/start.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# ApplicationStart. 바뀐 서비스만 내렸다 올린다
+source "$(dirname "$0")/common.sh"
+take_lock
+
+changed="$(sed -n 's/^changed=//p' "$CURRENT/.changed" 2>/dev/null || true)"
+
+restart_one() {
+  local unit="$1"
+  # restart 는 내린 뒤에 올린다. worker 가 두 벌 겹치는 구간이 안 생긴다
+  log "$unit 재시작"
+  systemctl restart "$unit"
+}
+
+case " $changed " in
+  *" api "*)    restart_one "$API_UNIT" ;;
+  *)            log "$API_UNIT 은 안 바뀌었다. 그대로 둔다"
+                systemctl is-active --quiet "$API_UNIT" || restart_one "$API_UNIT" ;;
+esac
+
+case " $changed " in
+  *" worker "*) restart_one "$WORKER_UNIT" ;;
+  *)            log "$WORKER_UNIT 은 안 바뀌었다. 그대로 둔다"
+                systemctl is-active --quiet "$WORKER_UNIT" || restart_one "$WORKER_UNIT" ;;
+esac

--- a/backend/deploy/scripts/start.sh
+++ b/backend/deploy/scripts/start.sh
@@ -1,25 +1,36 @@
 #!/usr/bin/env bash
-# ApplicationStart. 바뀐 서비스만 내렸다 올린다
-source "$(dirname "$0")/common.sh"
-take_lock
+# ApplicationStart. 소스가 바뀐 서비스만 내렸다 올린다
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+claim_deploy
 
-changed="$(sed -n 's/^changed=//p' "$CURRENT/.changed" 2>/dev/null || true)"
-
-restart_one() {
-  local unit="$1"
-  # restart 는 내린 뒤에 올린다. worker 가 두 벌 겹치는 구간이 안 생긴다
-  log "$unit 재시작"
-  systemctl restart "$unit"
+# worker 는 두 벌이 겹치면 하루 호출 한도가 두 배로 나간다.
+# restart 대신 stop 하고 완전히 내려간 것을 본 뒤에 start 한다
+stop_unit() {
+  systemctl stop "$UNIT" || true
+  local deadline=$((SECONDS + 60))
+  while [ $SECONDS -lt $deadline ]; do
+    if ! systemctl is-active --quiet "$UNIT" && ! pgrep -f "$JAR" >/dev/null 2>&1; then
+      log "$UNIT 이 완전히 내려갔다"
+      return 0
+    fi
+    sleep 1
+  done
+  log "$UNIT 이 60초 안에 안 내려갔다"
+  return 1
 }
 
-case " $changed " in
-  *" api "*)    restart_one "$API_UNIT" ;;
-  *)            log "$API_UNIT 은 안 바뀌었다. 그대로 둔다"
-                systemctl is-active --quiet "$API_UNIT" || restart_one "$API_UNIT" ;;
-esac
+changed="$(sed -n 's/^changed=//p' "$CHANGED" 2>/dev/null || echo yes)"
 
-case " $changed " in
-  *" worker "*) restart_one "$WORKER_UNIT" ;;
-  *)            log "$WORKER_UNIT 은 안 바뀌었다. 그대로 둔다"
-                systemctl is-active --quiet "$WORKER_UNIT" || restart_one "$WORKER_UNIT" ;;
-esac
+if [ "$changed" = "no" ]; then
+  log "$COMPONENT 는 소스가 그대로라 재시작하지 않는다"
+  if ! systemctl is-active --quiet "$UNIT"; then
+    log "그런데 돌고 있지 않다. 올린다"
+    stop_unit
+    systemctl start "$UNIT"
+  fi
+  exit 0
+fi
+
+stop_unit
+systemctl start "$UNIT"
+log "$UNIT 올렸다"

--- a/backend/deploy/scripts/validate.sh
+++ b/backend/deploy/scripts/validate.sh
@@ -29,6 +29,11 @@ wait_for "$UNIT health"   "$ACTUATOR/health" '"status":"UP"'
 wait_for "$UNIT 소스 지문" "$ACTUATOR/info"   "\"sourcedigest\":\"$NEW_DIGEST\""
 wait_for "$UNIT component" "$ACTUATOR/info"   "\"component\":\"$COMPONENT\""
 
+# 재부팅 뒤에도 올라와야 한다. install.sh 가 enable 을 부르는데 그게 실제로 먹었는지 본다
+systemctl is-enabled --quiet "$UNIT" \
+  || { log "$UNIT 이 enable 되어 있지 않다. 재부팅하면 안 올라온다"; exit 1; }
+log "$UNIT enable 확인"
+
 if [ -n "$SMOKE" ]; then
   code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$SMOKE")"
   [ "$code" = "200" ] || { log "클라이언트 API 가 $code 로 온다: $SMOKE"; exit 1; }

--- a/backend/deploy/scripts/validate.sh
+++ b/backend/deploy/scripts/validate.sh
@@ -1,26 +1,36 @@
 #!/usr/bin/env bash
 # ValidateService. 여기서 실패하면 CodeDeploy 가 직전 판으로 되돌린다
-source "$(dirname "$0")/common.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-DEADLINE=$((SECONDS + 120))
+DEADLINE=$((SECONDS + 150))
+NEW_DIGEST="$(manifest_value "$MANIFEST" sourceDigest)"
+NEW_COMMIT="$(manifest_value "$MANIFEST" commit)"
 
-# readiness 를 쓰지 마라. DB 가 끊겨도 200 UP 이 온다. 2026-09-02 실측이다.
+# readiness 를 쓰지 마라. DB 가 끊겨도 200 UP 이 온다. 실측으로 확인했다.
 # DB 까지 보는 것은 /actuator/health 쪽이고 끊기면 503 DOWN 이 온다
-wait_healthy() {
-  local name="$1" url="$2" body
+wait_for() {
+  local what="$1" url="$2" want="$3" body
   while [ $SECONDS -lt $DEADLINE ]; do
     body="$(curl -fsS --max-time 5 "$url" 2>/dev/null || true)"
     case "$body" in
-      *'"status":"UP"'*) log "$name 정상"; return 0 ;;
+      *"$want"*) log "$what 확인"; return 0 ;;
     esac
     sleep 3
   done
-  log "$name 이 시간 안에 안 떴다. 마지막 응답=$body"
+  log "$what 이 시간 안에 안 됐다. 마지막 응답=$body"
   return 1
 }
 
-wait_healthy "$API_UNIT"    "$API_HEALTH"
-wait_healthy "$WORKER_UNIT" "$WORKER_HEALTH"
+wait_for "$UNIT health"   "$ACTUATOR/health" '"status":"UP"'
+# 지금 응답하는 것이 방금 올린 판이 맞나. 옛 프로세스가 살아 있으면 여기서 걸린다
+wait_for "$UNIT 소스 지문" "$ACTUATOR/info"   "\"sourcedigest\":\"$NEW_DIGEST\""
+wait_for "$UNIT component" "$ACTUATOR/info"   "\"component\":\"$COMPONENT\""
 
-commit="$(manifest_value "$CURRENT/release-manifest.txt" commit)"
-log "배포 확인 끝. commit=$commit"
+if [ -n "$SMOKE" ]; then
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$SMOKE")"
+  [ "$code" = "200" ] || { log "클라이언트 API 가 $code 로 온다: $SMOKE"; exit 1; }
+  log "클라이언트 API 200"
+fi
+
+release_deploy
+log "배포 확인 끝. component=$COMPONENT commit=$NEW_COMMIT"

--- a/backend/deploy/scripts/validate.sh
+++ b/backend/deploy/scripts/validate.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # ValidateService. 여기서 실패하면 CodeDeploy 가 직전 판으로 되돌린다
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+# 같은 DEPLOYMENT_ID 라 그대로 통과한다. 실패했을 때 잠금을 풀려고 잡는다
+claim_deploy
 
 WAIT_SECONDS=90
 NEW_DIGEST="$(manifest_value "$MANIFEST" sourceDigest)"

--- a/backend/deploy/scripts/validate.sh
+++ b/backend/deploy/scripts/validate.sh
@@ -2,7 +2,7 @@
 # ValidateService. 여기서 실패하면 CodeDeploy 가 직전 판으로 되돌린다
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-DEADLINE=$((SECONDS + 150))
+WAIT_SECONDS=90
 NEW_DIGEST="$(manifest_value "$MANIFEST" sourceDigest)"
 NEW_COMMIT="$(manifest_value "$MANIFEST" commit)"
 
@@ -10,7 +10,10 @@ NEW_COMMIT="$(manifest_value "$MANIFEST" commit)"
 # DB 까지 보는 것은 /actuator/health 쪽이고 끊기면 503 DOWN 이 온다
 wait_for() {
   local what="$1" url="$2" want="$3" body
-  while [ $SECONDS -lt $DEADLINE ]; do
+  # 시한을 검사마다 새로 잡는다. 하나로 두면 앞 검사가 늦게 끝났을 때
+  # 뒤 검사가 시간을 못 받고 실패해서 멀쩡한 배포가 되돌아간다
+  local deadline=$((SECONDS + WAIT_SECONDS))
+  while [ $SECONDS -lt $deadline ]; do
     body="$(curl -fsS --max-time 5 "$url" 2>/dev/null || true)"
     case "$body" in
       *"$want"*) log "$what 확인"; return 0 ;;

--- a/backend/deploy/scripts/validate.sh
+++ b/backend/deploy/scripts/validate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# ValidateService. 여기서 실패하면 CodeDeploy 가 직전 판으로 되돌린다
+source "$(dirname "$0")/common.sh"
+
+DEADLINE=$((SECONDS + 120))
+
+# readiness 를 쓰지 마라. DB 가 끊겨도 200 UP 이 온다. 2026-09-02 실측이다.
+# DB 까지 보는 것은 /actuator/health 쪽이고 끊기면 503 DOWN 이 온다
+wait_healthy() {
+  local name="$1" url="$2" body
+  while [ $SECONDS -lt $DEADLINE ]; do
+    body="$(curl -fsS --max-time 5 "$url" 2>/dev/null || true)"
+    case "$body" in
+      *'"status":"UP"'*) log "$name 정상"; return 0 ;;
+    esac
+    sleep 3
+  done
+  log "$name 이 시간 안에 안 떴다. 마지막 응답=$body"
+  return 1
+}
+
+wait_healthy "$API_UNIT"    "$API_HEALTH"
+wait_healthy "$WORKER_UNIT" "$WORKER_HEALTH"
+
+commit="$(manifest_value "$CURRENT/release-manifest.txt" commit)"
+log "배포 확인 끝. commit=$commit"

--- a/backend/deploy/systemd/salmonbus-api.service
+++ b/backend/deploy/systemd/salmonbus-api.service
@@ -2,25 +2,31 @@
 Description=salmonbus Client API
 After=network-online.target
 Wants=network-online.target
+# worker 와 서로 Requires 를 걸지 않는다. 한쪽 장애가 다른 쪽을 내리면 안 된다
 
 [Service]
 Type=simple
 User=salmonbus
 Group=salmonbus
 
-# 값을 유닛에 직접 쓰지 않는다. systemctl cat 과 systemctl show 가 그대로 찍는다.
-# 이 파일은 배포가 안 건드리는 자리에 있다
-EnvironmentFile=/etc/salmonbus/api.env
+# Actuator 를 클라이언트 포트에서 뗀다. 8080 은 밖에 열려 있고 8082 는 루프백에만 묶인다
+Environment=MANAGEMENT_SERVER_PORT=8082
+Environment=MANAGEMENT_SERVER_ADDRESS=127.0.0.1
 
-# current 는 바로가기다. 배포가 이걸 새 판으로 옮긴다
-ExecStart=/usr/bin/java -jar /opt/salmonbus/current/jars/api-app.jar
+# 값을 유닛에 직접 쓰지 않는다. systemctl cat 과 systemctl show 가 그대로 찍는다.
+# 이 파일은 배포가 안 건드리는 곳에 있다. 아래 Environment= 보다 뒤에 와서 필요하면 덮어쓴다
+EnvironmentFile=/etc/salmonbus/api.env
+# 배포가 판마다 새로 쓴다. /actuator/info 로 도는 판을 판별하는 값이 들어 있다
+EnvironmentFile=/opt/salmonbus/api/current/release.env
+
+# 첫 리허설에서 RSS 를 재고 조정한다
+ExecStart=/usr/bin/java -Xms128m -Xmx512m -jar /opt/salmonbus/api/current/jars/api-app.jar
 
 Restart=on-failure
 RestartSec=5
 SuccessExitStatus=143
 TimeoutStopSec=30
 
-# 앱이 쓸 일이 없는 곳을 막는다
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full

--- a/backend/deploy/systemd/salmonbus-api.service
+++ b/backend/deploy/systemd/salmonbus-api.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=salmonbus Client API
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=salmonbus
+Group=salmonbus
+
+# 값을 유닛에 직접 쓰지 않는다. systemctl cat 과 systemctl show 가 그대로 찍는다.
+# 이 파일은 배포가 안 건드리는 자리에 있다
+EnvironmentFile=/etc/salmonbus/api.env
+
+# current 는 바로가기다. 배포가 이걸 새 판으로 옮긴다
+ExecStart=/usr/bin/java -jar /opt/salmonbus/current/jars/api-app.jar
+
+Restart=on-failure
+RestartSec=5
+SuccessExitStatus=143
+TimeoutStopSec=30
+
+# 앱이 쓸 일이 없는 곳을 막는다
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/backend/deploy/systemd/salmonbus-worker.service
+++ b/backend/deploy/systemd/salmonbus-worker.service
@@ -2,25 +2,30 @@
 Description=salmonbus 수집·예보 Worker
 After=network-online.target
 Wants=network-online.target
+# api 와 서로 Requires 를 걸지 않는다. 한쪽 장애가 다른 쪽을 내리면 안 된다
 
 [Service]
 Type=simple
 User=salmonbus
 Group=salmonbus
 
-# 값을 유닛에 직접 쓰지 않는다. systemctl cat 과 systemctl show 가 그대로 찍는다.
-# 이 파일은 배포가 안 건드리는 자리에 있다
-EnvironmentFile=/etc/salmonbus/worker.env
+# 계수 파일은 배포가 갈아엎는 곳 밖에 둔다. 사람이 손으로 갖다 놓는 파일이라 배포판에 없다.
+# promote-on-start 를 켠 채 두면 배포로 재기동할 때마다 디스크에 있는 계수가 올라간다
+Environment=MODEL_BUNDLE_DIRECTORY=/var/lib/salmonbus/model/current
+Environment=MODEL_BUNDLE_PROMOTE_ON_START=false
 
-# current 는 바로가기다. 배포가 이걸 새 판으로 옮긴다
-ExecStart=/usr/bin/java -jar /opt/salmonbus/current/jars/worker-app.jar
+# 값을 유닛에 직접 쓰지 않는다. 위 Environment= 보다 뒤에 와서 필요하면 덮어쓴다
+EnvironmentFile=/etc/salmonbus/worker.env
+EnvironmentFile=/opt/salmonbus/worker/current/release.env
+
+ExecStart=/usr/bin/java -Xms128m -Xmx640m -jar /opt/salmonbus/worker/current/jars/worker-app.jar
 
 Restart=on-failure
 RestartSec=5
 SuccessExitStatus=143
-TimeoutStopSec=30
+# 수집 한 회차가 끝날 여유를 준다. 두 벌이 겹치면 하루 호출 한도가 두 배로 나간다
+TimeoutStopSec=45
 
-# 앱이 쓸 일이 없는 곳을 막는다
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full

--- a/backend/deploy/systemd/salmonbus-worker.service
+++ b/backend/deploy/systemd/salmonbus-worker.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=salmonbus 수집·예보 Worker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=salmonbus
+Group=salmonbus
+
+# 값을 유닛에 직접 쓰지 않는다. systemctl cat 과 systemctl show 가 그대로 찍는다.
+# 이 파일은 배포가 안 건드리는 자리에 있다
+EnvironmentFile=/etc/salmonbus/worker.env
+
+# current 는 바로가기다. 배포가 이걸 새 판으로 옮긴다
+ExecStart=/usr/bin/java -jar /opt/salmonbus/current/jars/worker-app.jar
+
+Restart=on-failure
+RestartSec=5
+SuccessExitStatus=143
+TimeoutStopSec=30
+
+# 앱이 쓸 일이 없는 곳을 막는다
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/backend/deploy/verify-revision.sh
+++ b/backend/deploy/verify-revision.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# 배포판에 비밀이 섞였는지 본다. CodeBuild 가 부르고 예행연습이 같은 파일을 돌린다.
+#
+# scripts/ 아래가 아니라서 배포판에 안 담기고 EC2 로 안 나간다.
+# 값은 한 번도 안 찍는다. 걸렸을 때도 어느 열인지만 말한다
+set -euo pipefail
+
+root="${1:?배포판 폴더를 달라}"
+
+fail() { echo "비밀 검사 실패: $*" >&2; exit 1; }
+
+if find "$root" \( -name '.env*' -o -name '*.pem' -o -name '*.jks' -o -name '*.p12' \) \
+     -print -quit | grep -q .; then
+  fail "비밀 파일이 배포판에 들어 있다"
+fi
+
+shopt -s nullglob
+jars=("$root"/*/jars/*.jar "$root"/jars/*.jar)
+[ "${#jars[@]}" -gt 0 ] || fail "$root 에 JAR 이 없다"
+
+for jar in "${jars[@]}"; do
+  if unzip -l "$jar" | grep -qiE '\.env|secret|\.pem|\.jks'; then
+    fail "$(basename "$jar") 의 항목 이름에 비밀로 보이는 것이 있다"
+  fi
+
+  for yml in $(unzip -Z1 "$jar" | grep -E '^BOOT-INF/classes/application.*\.(ya?ml|properties)$' || true); do
+    # 줄마다 본다. 파일 전체로 보면 같은 열이 다른 줄에서 자리표시자를 쓰는 것만으로 통과한다
+    offending="$(unzip -p "$jar" "$yml" \
+      | grep -E '^[[:space:]]*(url|username|password|service-key)[[:space:]]*:' \
+      | grep -v '\${' || true)"
+    if [ -n "$offending" ]; then
+      keys="$(printf '%s\n' "$offending" \
+        | sed -E 's/^[[:space:]]*([A-Za-z-]+)[[:space:]]*:.*/\1/' | tr '\n' ' ')"
+      fail "$(basename "$jar") 의 $yml 에 자리표시자가 아닌 값이 있다 (열: $keys)"
+    fi
+  done
+done
+
+echo "비밀 검사 통과"


### PR DESCRIPTION
## 요약

백엔드를 CodeBuild 에서 검증하고 CodeDeploy 로 EC2 에 올리는 파이프라인 파일들이에요.
전부 새 파일이고 **기존 파일은 하나도 안 고쳤습니다.** `application.yml` 도 `build.gradle` 도 그대로예요.
AWS 를 실제로 못 태워봐서 리눅스 컨테이너로 훅을 예행연습했어요. 검사 34개가 통과하고, systemd 를 따로 띄워 유닛도 재봤습니다.

<br/>

## 변경사항

- **`backend/buildspec.yml`** · CI 와 같은 `./gradlew clean build --no-daemon` 을 돌리고 `ApiRevision` · `WorkerRevision` 두 벌을 냅니다
- **`appspec-api.yml` · `appspec-worker.yml` 과 훅 넷** · 서비스마다 판 폴더를 따로 두고 `current` 바로가기를 옮겨요. 소스가 바뀐 쪽만 다시 띄웁니다
- **systemd 유닛 둘** · API 의 Actuator 를 루프백 8082 로 뗐고, 비밀은 `/etc/salmonbus/`, 계수 파일은 `/var/lib/salmonbus/` 에 둡니다
- **`backend/deploy/rehearsal/`** · `bash backend/deploy/rehearsal/run.sh` 로 AWS 없이 훅을 돌려볼 수 있어요
- **`backend/deploy/RUNBOOK.md`** · 최초 설치, 배포, 서비스별 되돌리기, 값·계수 바꾸기 절차입니다

<br/>

## 설계 결정

### 1. 재시작 판정을 JAR 이 아니라 소스 지문으로 합니다

처음에는 JAR 의 SHA-256 으로 재려고 했는데, **같은 커밋을 아무것도 안 고치고 두 번 빌드했더니 네 JAR 지문이 다 달랐어요.**

```
1차   api-app  159b246e...    worker-app  b56078b1...
2차   api-app  8cf3e123...    worker-app  1db45e2a...
```

항목별 CRC 를 대조하니 다른 게 `META-INF/build-info.properties` 하나뿐이었습니다. `buildInfo()` 가 넣는 `build.time` 때문이에요. 그대로 쓰면 **매 배포마다 두 서비스가 전부 바뀐 것으로 나와서 아무것도 안 막습니다.**

경우의 수는 세 가지였어요.

| 안 | 무엇 | 왜 뺐나 |
| --- | --- | --- |
| 가 | `build.time` 을 커밋 시각으로 고정 | JAR 이 재현되는데 `build.gradle` 을 고치는 일이에요 |
| 나 | `git diff` 로 바뀐 모듈 판정 | CodePipeline 이 소스를 `.git` 없이 넘겨서 CodeBuild 안에서 `git` 을 못 씁니다 |
| **다** | **런타임에 들어가는 소스 파일만 모아 센다** | 빌드 설정을 안 고치고 지금 자리에서 풀립니다 |

다 로 갔습니다. `api-app/src/main` · `common/src/main` · 관련 `build.gradle` · `settings.gradle` · Gradle wrapper 설정을 셉니다. 테스트·문서·프론트만 바뀌면 값이 안 변해서 서비스를 안 건드려요.

**한계가 있어요.** 지문에 안 들어가는 것을 고치면 그 변경이 배포에 반영돼도 서비스가 안 뜹니다. 예를 들어 `application.yml` 은 `src/main/resources` 아래라 들어가는데, 나중에 런타임에 영향을 주는 파일을 다른 데 두면 목록을 같이 고쳐야 해요.

<br/>

### 2. 배포 확인에 `readiness` 대신 `health` 를 봅니다

티켓에 `readiness` 라고 적혀 있어서 그 주소를 쓰려다가, DB 를 죽여놓고 재봤어요.

| 두드린 곳 | DB 살아 있을 때 | DB 죽었을 때 |
| --- | --- | --- |
| `/actuator/health` | 200 `UP` | **503 `DOWN`** |
| `/actuator/health/readiness` | 200 `UP` | **200 `UP`** |

`readiness` 그룹에는 `readinessState` 하나만 들어 있어서 DB 를 안 봅니다. 훅이 그쪽을 두드리면 **DB 가 끊긴 배포가 정상으로 통과해요.**

그리고 health 만으로는 **방금 올린 판이 응답하는 건지 옛 프로세스가 아직 응답하는 건지 구분이 안 돼서**, `validate.sh` 가 `/actuator/info` 의 `sourcedigest` 까지 대조합니다.

<br/>

### 3. `application.yml` 을 안 고치고 관리 포트를 뗐습니다

티켓이 API Actuator 를 루프백 관리 포트로 옮기라고 해서, 처음엔 `application.yml` 에 `management.server.port` 를 넣어야 하는 줄 알았어요. 근데 환경변수로도 됩니다. 실제로 띄워서 확인했습니다.

```
MANAGEMENT_SERVER_PORT=8082
MANAGEMENT_SERVER_ADDRESS=127.0.0.1
```

| 두드린 곳 | 결과 |
| --- | --- |
| `127.0.0.1:8082/actuator/health` | 200 |
| `192.168.x.x:8082/actuator/health` | 연결 안 됨 |
| `8080/api/v1/routes` | 200 |
| `8080/actuator/health` | **404** |

`/actuator/info` 의 `component` · `commit` · `sourcedigest` 도 같은 방식이에요. `MANAGEMENT_INFO_ENV_ENABLED=true` 와 `INFO_*` 를 배포가 판마다 써 넣습니다.

**`api검증` 쪽이 지금 `application.yml` 을 보고 있어서 겹치지 않게 하려고 이 길로 갔습니다.**

<br/>

### 4. Worker 는 `restart` 를 안 쓰고 내려간 것을 보고 나서 올립니다

`salmonbus-worker` 가 두 벌 겹치면 하루 호출 한도가 정확히 두 배로 나갑니다. 인스턴스 둘을 90초 겹쳐놓고 재봤을 때 batch 와 Open API 호출과 예약이 두 배로 났어요. 한도 10,000회에 두 노선 수집이 8,556회를 쓰니까 두 배면 넘깁니다.

`start.sh` 가 `systemctl stop` 한 뒤 `is-active` 와 `pgrep` 이 둘 다 비는 것을 보고 나서 `start` 합니다. API 배포와 Worker 배포가 겹치는 것은 `/opt/salmonbus/.deploying` 표시로 막았어요. `flock` 은 스크립트가 끝나면 풀려서 훅과 훅 사이를 못 잠급니다.

<br/>

### 5. 예행연습을 저장소에 넣었어요

AWS 를 못 태워보니 `34개 통과` 를 저 혼자 말하면 재현할 방법이 없어서요. 리눅스 컨테이너를 띄우고 `systemctl` · `curl` · `java` 를 흉내로 바꿔 끼운 다음 배포를 여러 번 돌립니다.

**여기서 실물 버그 셋이 나왔습니다.** 문법 검사만으로는 안 나왔을 것들이에요.

| 무엇 | 결과 |
| --- | --- |
| `take_lock` 이 `/opt/salmonbus/.deploy.lock` 을 여는데 그 디렉터리가 아직 없었어요 | **첫 배포가 무조건 실패** |
| `install.sh` 가 `staging` 을 옮긴 뒤에도 새 목록을 `staging` 경로에서 읽었어요 | 새 지문이 늘 빈 값이 돼서 **매 배포마다 둘 다 재시작** |
| 판 폴더 이름을 지문 앞 12자로 잘랐어요 | 서로 다른 판이 같은 폴더를 쓰면 **돌고 있는 판을 `rm -rf` 합니다.** 지문 전체를 쓰고, `current` · `previous` 가 쓰는 폴더는 못 지우게 막았어요 |

세 번째는 제가 만든 시험용 지문이 앞 12자가 같아서 우연히 걸렸습니다. 그 덕에 검사 하나가 실은 아무것도 안 재고 있었다는 것도 같이 나왔어요.

리뷰 받고 흉내를 **모르는 입력에 실패하도록** 고쳤어요. `systemctl` 이 모르는 명령을 받거나 `curl` 이 모르는 주소를 받으면 거기서 멈춥니다. 그전에는 훅이 포트를 틀려도 통과했어요. 되돌리기도 `validate` 실패만 보고 넘어갔었는데, 직전 성공 판을 다시 배포해서 `current` 와 `/actuator/info` 가 돌아오는지까지 봅니다.

<br/>

### 6. systemd 유닛은 진짜 systemd 에 물려서 확인했어요

흉내로는 유닛이 실제로 읽히는지 못 봅니다. 그래서 systemd 252 를 컨테이너에 PID 1 로 띄우고 유닛 파일을 그대로 넣어봤어요.

| 무엇 | 결과 |
| --- | --- |
| `systemd-analyze verify` | 통과 |
| `User=salmonbus` 로 뜨나 | 뜬다 |
| **`0600 root:root` 인 `api.env` 가 읽히나** | **읽힌다.** systemd 가 root 로 먼저 읽고 사용자를 바꿉니다 |
| 판별용 `release.env` 도 같이 읽히나 | 읽힌다 |
| `MANAGEMENT_SERVER_PORT` 가 들어가나 | 들어간다 |
| `Restart=on-failure` 가 도나 | 0 이 아닌 코드로 죽이니 `NRestarts` 가 0 에서 1 로 |
| `SuccessExitStatus=143` | 143 으로 끝내니 `Result=success` |

**같은 자리에서 `EnvironmentFile` 파서도 재봤습니다.** RUNBOOK 에 셸 기준으로 적어둔 표가 틀렸더라고요.

| 값에 든 것 | systemd 가 읽으면 | 셸이 읽으면 |
| --- | --- | --- |
| `$` | 그대로. 안 푼다 | **`aB3` 으로 잘린다** |
| 따옴표 하나 | 그대로 | **파일 읽기가 깨진다** |
| 줄 끝 CRLF | **CR 을 떼어낸다** | 끝에 `0d` 가 붙는다 |
| 끝 공백 | **떼어낸다** | 남는다 |

systemd 가 모든 축에서 더 관대했어요. 앱에 들어가는 값은 systemd 가 정리해 주고, 문제는 **확인 명령 쪽**입니다. 파일이 CRLF 면 `sha256sum` 대조만 어긋나서 키가 틀린 줄 알고 헛짚게 돼요. RUNBOOK 을 둘로 갈라 다시 적었습니다.

<br/>

## 확인 사항

1. **`runtime-versions: java: corretto21` 이 `salmonbus-backend-build` 이미지에서 쓸 수 있는 값인가요?** 이미지 판에 따라 달라서요
2. **CodeBuild 프로젝트에 secondary artifact 두 개를 `ApiRevision` · `WorkerRevision` 이름으로 만들어 주셔야 해요.** `buildspec.yml` 의 이름과 같아야 합니다
3. **배포 그룹 `salmonbus-api-prod` · `salmonbus-worker-prod` 가 아직 없는 것으로 아는데 맞나요?** 지금은 `salmonbus-prod` 하나뿐인 것으로 알고 있습니다
4. **JVM 힙을 API `-Xmx512m`, Worker `-Xmx640m` 로 잡아뒀습니다.** 첫 배포에서 RSS 를 재고 조정하는 게 좋을 것 같아요

그리고 **최초 1회는 사람이 서버에 들어가야 합니다.** 인스턴스 역할이 Parameter Store 를 읽을 수 있는지 한 번 재보는 명령을 `RUNBOOK.md` 에 적어뒀어요. 되면 그쪽으로 옮기고, 안 되면 `/etc/salmonbus/*.env` 로 갑니다. 지금 문서는 후자를 전제로 쓰여 있습니다.

**수집·예보 기준은 이 PR 에서 안 만들었어요.** Worker 의 health 가 아직 `db` · `diskSpace` · `ping` · `ssl` 뿐이라 API 와 응답이 같습니다. 첫 배포는 수집이 꺼진 채로 나가니 프로세스 health 만 보고, 수집을 켠 뒤에 `observation_batch` 신선도로 보는 게 순서일 것 같은데 어떠신가요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API and worker services now deploy as independent revisions with component-specific configuration, health checks, and service management.
  * Deployments track source and artifact fingerprints, enabling unchanged components to avoid unnecessary restarts.
  * Automatic rollback and retention of recent working releases improve recovery.
  * Deployment validation now checks service health, metadata, required configuration, disk space, and artifact integrity.

* **Documentation**
  * Added a Korean deployment and recovery runbook, including rollback and rehearsal guidance.

* **Security**
  * Expanded secret scanning to additional files and packaged application configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->