### PR TITLE
fix(SAL-120): 오류 응답이 code·message·requestId 없이 나가는 두 경우 차단

### DIFF
--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/ApiErrorController.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/ApiErrorController.java
@@ -2,6 +2,8 @@ package com.gustler.backend.api.http;
 
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.webmvc.error.ErrorController;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -29,16 +31,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ApiErrorController implements ErrorController {
 
+    private static final Logger log = LoggerFactory.getLogger(ApiErrorController.class);
+
     @RequestMapping("${server.error.path:/error}")
     public ResponseEntity<ErrorResponse> handleContainerError(
         HttpServletRequest request
     ) {
         HttpStatus status = statusOf(request);
         ErrorCode code = ErrorCode.of(status);
+        String requestId = RequestId.of(request);
+        log.warn("컨테이너가 오류로 넘긴 요청이다. 상태={} 오류코드={} requestId={}",
+            status.value(), code.name(), requestId);
 
         return ResponseEntity.status(status)
             .headers(ErrorHeaders.of(MediaType.APPLICATION_JSON))
-            .body(new ErrorResponse(code, code.message(), RequestId.of(request)));
+            .body(new ErrorResponse(code, code.message(), requestId));
     }
 
     /**

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/ApiErrorController.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/ApiErrorController.java
@@ -27,6 +27,19 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * <p>{@code Content-Type} 을 직접 박는 이유는 {@link ApiExceptionHandler} 와 같다.
  * 요청의 {@code Accept} 로 협상하게 두면 JSON 을 안 받는 요청에서 본문이 사라진다.
+ *
+ * <h2>관리 포트는 이 형식을 안 쓴다</h2>
+ *
+ * <p>{@code management.server.port} 로 Actuator 를 다른 포트에 떼면 그 포트는 자식 컨텍스트에서
+ * 돈다. 이 컨트롤러와 {@link RequestIdFilter} 와 {@link ContainerErrorResponseValve} 는 부모
+ * 컨텍스트에만 붙어서 <b>관리 포트에는 안 걸린다.</b> 거기서는 스프링 부트 기본 오류 응답이 나간다.
+ *
+ * <p>일부러 그렇게 뒀다. api 문서가 정한 것은 {@code /api/v1} 아래이고 Actuator 는 안 적혀 있다.
+ * 노출도 {@code health} 와 {@code info} 둘뿐이다. 그 포트를 부르는 것은 화면이 아니라 로드밸런서라,
+ * 우리 형식으로 바꾸면 부트 기본 모양을 읽는 도구가 오히려 못 읽을 수 있다.
+ *
+ * <p>공개 포트가 관리 포트 분리와 무관하게 이 형식을 지키는지는
+ * {@code ManagementPortSeparationTest} 가 붙잡는다.
  */
 @RestController
 public class ApiErrorController implements ErrorController {

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/ApiErrorController.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/ApiErrorController.java
@@ -1,0 +1,60 @@
+package com.gustler.backend.api.http;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.boot.webmvc.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 컨테이너가 {@code /error} 로 넘긴 응답도 우리 오류 응답 형식으로 낸다.
+ *
+ * <p>모든 오류가 {@link ApiExceptionHandler} 를 지나는 것은 아니다. 톰캣이 {@code sendError}
+ * 를 부르면 {@code StandardHostValve} 가 그 요청을 컨텍스트의 {@code /error} 로 먼저 넘긴다.
+ * 그 자리를 안 잡으면 스프링 부트 기본 컨트롤러가
+ * {@code {"timestamp","status","error","path"}} 를 내보낸다. 우리 오류 코드도 {@code no-store}
+ * 도 없는 응답이다.
+ *
+ * <p>실제로 그렇게 새던 요청 둘이다. {@code TRACE} 로 부르면 405, 쿠키를 250개 실어 보내면
+ * 400 이 그 모양으로 나갔다.
+ *
+ * <p>이 빈이 있으면 부트가 자기 {@code BasicErrorController} 를 안 만든다.
+ *
+ * <p>{@code Content-Type} 을 직접 박는 이유는 {@link ApiExceptionHandler} 와 같다.
+ * 요청의 {@code Accept} 로 협상하게 두면 JSON 을 안 받는 요청에서 본문이 사라진다.
+ */
+@RestController
+public class ApiErrorController implements ErrorController {
+
+    @RequestMapping("${server.error.path:/error}")
+    public ResponseEntity<ErrorResponse> handleContainerError(
+        HttpServletRequest request
+    ) {
+        HttpStatus status = statusOf(request);
+        ErrorCode code = ErrorCode.of(status);
+
+        return ResponseEntity.status(status)
+            .headers(ErrorHeaders.of(MediaType.APPLICATION_JSON))
+            .body(new ErrorResponse(code, code.message(), RequestId.of(request)));
+    }
+
+    /**
+     * 컨테이너가 실어 준 상태 코드. 없거나 해석할 수 없으면 500 으로 본다.
+     *
+     * <p>여기 오는 것 자체가 무언가 잘못됐다는 뜻이라 200 으로 되돌리지 않는다.
+     */
+    private HttpStatus statusOf(
+        HttpServletRequest request
+    ) {
+        Object attached = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        if (!(attached instanceof Integer value)) {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        HttpStatus resolved = HttpStatus.resolve(value);
+
+        return resolved == null ? HttpStatus.INTERNAL_SERVER_ERROR : resolved;
+    }
+}

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/ApiExceptionHandler.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/ApiExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.gustler.backend.api.http;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -21,6 +23,8 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
  */
 @RestControllerAdvice
 public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(ApiExceptionHandler.class);
 
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<ErrorResponse> handleApiException(
@@ -78,11 +82,27 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
         return new ResponseEntity<>(bodyOf(code, code.message()), errorHeaders(), code.status());
     }
 
+    /**
+     * 응답에 실을 값을 만들면서 같은 식별자로 로그도 남긴다.
+     *
+     * <p>안 남기면 클라이언트가 받은 {@code requestId} 로 찾을 로그가 없다. 그러면 그 필드를
+     * 응답에 실은 뜻이 절반만 산다.
+     *
+     * <p>서버 잘못은 {@code WARN}, 요청 잘못은 {@code INFO} 로 남긴다. 요청 잘못까지 경고로
+     * 올리면 잘못된 routeId 하나에 경고가 쌓여서 진짜 경고가 묻힌다.
+     */
     private ErrorResponse bodyOf(
         ErrorCode code,
         String message
     ) {
-        return new ErrorResponse(code, message, RequestId.ofCurrentRequest());
+        String requestId = RequestId.ofCurrentRequest();
+        if (code.status().is5xxServerError()) {
+            log.warn("오류로 응답한다. 오류코드={} requestId={}", code.name(), requestId);
+        } else {
+            log.info("오류로 응답한다. 오류코드={} requestId={}", code.name(), requestId);
+        }
+
+        return new ErrorResponse(code, message, requestId);
     }
 
     private HttpHeaders errorHeaders() {

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/ApiExceptionHandler.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/ApiExceptionHandler.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.transaction.CannotCreateTransactionException;
@@ -49,6 +50,17 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
             ErrorCode.INTERNAL_ERROR.status());
     }
 
+    /**
+     * 스프링이 먼저 잡는 예외의 응답도 우리 오류 봉투로 낸다.
+     *
+     * <p>여기서 {@code Content-Type} 을 직접 박는다. 안 박으면 요청의 {@code Accept} 로 협상해서
+     * 쓸 변환기를 고르는데, {@code Accept} 가 JSON 을 안 받는 요청은 고를 변환기가 없어
+     * <b>406 이 본문 0바이트로 나간다.</b> 오류 코드도 메시지도 실리지 못한다.
+     *
+     * <p>클라이언트가 JSON 을 안 받겠다고 했는데 JSON 을 주는 셈인데, 그래도 이쪽이 낫다.
+     * api 문서가 오류를 {@code code} · {@code message} · {@code requestId} 로 못박아 뒀고,
+     * 빈 본문은 그 형식을 못 지킨다. 무엇이 잘못됐는지 못 알려 주는 응답보다 낫다.
+     */
     @Override
     protected ResponseEntity<Object> handleExceptionInternal(
         Exception exception,
@@ -59,7 +71,15 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
     ) {
         ErrorCode code = ErrorCode.of(status);
 
-        return new ResponseEntity<>(bodyOf(code, code.message()), noStore(headers), status);
+        return new ResponseEntity<>(bodyOf(code, code.message()), asJson(noStore(headers)), status);
+    }
+
+    private HttpHeaders asJson(
+        HttpHeaders headers
+    ) {
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return headers;
     }
 
     private ResponseEntity<ErrorResponse> respond(

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/ApiExceptionHandler.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/ApiExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.gustler.backend.api.http;
 
-import java.util.UUID;
-import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -13,6 +11,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+/**
+ * 컨트롤러까지 온 요청의 오류를 우리 오류 응답 형식으로 낸다.
+ *
+ * <p><b>여기를 안 지나는 오류가 있다.</b> 컨테이너가 {@code sendError} 로 넘긴 것은
+ * {@link ApiErrorController} 가, 톰캣이 주소를 해석하다 거절한 것은
+ * {@link ContainerErrorResponseValve} 가 맡는다. 셋이 {@link ErrorHeaders} 와 {@link ErrorCode}
+ * 를 같이 써서 어느 길로 나가든 같은 모양이 되게 한다.
+ */
 @RestControllerAdvice
 public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
 
@@ -21,7 +27,7 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
         ApiException exception
     ) {
         ErrorCode code = exception.code();
-        HttpHeaders headers = noStore();
+        HttpHeaders headers = errorHeaders();
         exception.retryAfter().ifPresent(retryAfter ->
             headers.set(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfter.toSeconds())));
 
@@ -35,31 +41,20 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ErrorResponse> handleDatabaseUnavailable(
         RuntimeException exception
     ) {
-        return respond(
-            ErrorCode.SERVICE_UNAVAILABLE,
-            ErrorCode.SERVICE_UNAVAILABLE.message(),
-            ErrorCode.SERVICE_UNAVAILABLE.status()
-        );
+        return respond(ErrorCode.SERVICE_UNAVAILABLE);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleUnexpected(
         Exception exception
     ) {
-        return respond(ErrorCode.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.message(),
-            ErrorCode.INTERNAL_ERROR.status());
+        return respond(ErrorCode.INTERNAL_ERROR);
     }
 
     /**
-     * 스프링이 먼저 잡는 예외의 응답도 우리 오류 봉투로 낸다.
+     * 스프링이 먼저 잡는 예외의 응답도 같은 모양으로 낸다.
      *
-     * <p>여기서 {@code Content-Type} 을 직접 박는다. 안 박으면 요청의 {@code Accept} 로 협상해서
-     * 쓸 변환기를 고르는데, {@code Accept} 가 JSON 을 안 받는 요청은 고를 변환기가 없어
-     * <b>406 이 본문 0바이트로 나간다.</b> 오류 코드도 메시지도 실리지 못한다.
-     *
-     * <p>클라이언트가 JSON 을 안 받겠다고 했는데 JSON 을 주는 셈인데, 그래도 이쪽이 낫다.
-     * api 문서가 오류를 {@code code} · {@code message} · {@code requestId} 로 못박아 뒀고,
-     * 빈 본문은 그 형식을 못 지킨다. 무엇이 잘못됐는지 못 알려 주는 응답보다 낫다.
+     * <p>스프링이 이미 실어 둔 {@code Allow} 같은 헤더는 그대로 두고 우리 것만 얹는다.
      */
     @Override
     protected ResponseEntity<Object> handleExceptionInternal(
@@ -71,47 +66,26 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
     ) {
         ErrorCode code = ErrorCode.of(status);
 
-        return new ResponseEntity<>(bodyOf(code, code.message()), asJson(noStore(headers)), status);
-    }
-
-    private HttpHeaders asJson(
-        HttpHeaders headers
-    ) {
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        return headers;
+        return new ResponseEntity<>(
+            bodyOf(code, code.message()),
+            ErrorHeaders.of(headers, MediaType.APPLICATION_JSON),
+            status);
     }
 
     private ResponseEntity<ErrorResponse> respond(
-        ErrorCode code,
-        String message,
-        HttpStatusCode status
+        ErrorCode code
     ) {
-        return new ResponseEntity<>(bodyOf(code, message), noStore(), status);
+        return new ResponseEntity<>(bodyOf(code, code.message()), errorHeaders(), code.status());
     }
 
     private ErrorResponse bodyOf(
         ErrorCode code,
         String message
     ) {
-        return new ErrorResponse(
-            code,
-            message,
-            UUID.randomUUID().toString()
-        );
+        return new ErrorResponse(code, message, RequestId.ofCurrentRequest());
     }
 
-    private HttpHeaders noStore() {
-        return noStore(HttpHeaders.EMPTY);
-    }
-
-    private HttpHeaders noStore(
-        HttpHeaders original
-    ) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.addAll(original);
-        headers.setCacheControl(CacheControl.noStore());
-
-        return headers;
+    private HttpHeaders errorHeaders() {
+        return ErrorHeaders.of(MediaType.APPLICATION_JSON);
     }
 }

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/ContainerErrorResponseConfig.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/ContainerErrorResponseConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * 톰캣의 기본 오류 화면을 우리 오류 봉투로 바꾼다.
+ * 톰캣의 기본 오류 화면을 우리 오류 응답 형식으로 바꾼다.
  *
  * <p>오류 valve 는 Engine 이 아니라 Host 에 붙는다. 그래서 valve 를 직접 넣는 대신
  * Host 에게 <b>어느 클래스를 쓸지</b>를 알려 준다. 톰캣이 기동할 때 그 클래스를 만들어 단다.

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/ContainerErrorResponseConfig.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/ContainerErrorResponseConfig.java
@@ -1,0 +1,27 @@
+package com.gustler.backend.api.http;
+
+import org.apache.catalina.core.StandardHost;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 톰캣의 기본 오류 화면을 우리 오류 봉투로 바꾼다.
+ *
+ * <p>오류 valve 는 Engine 이 아니라 Host 에 붙는다. 그래서 valve 를 직접 넣는 대신
+ * Host 에게 <b>어느 클래스를 쓸지</b>를 알려 준다. 톰캣이 기동할 때 그 클래스를 만들어 단다.
+ * Engine 에 넣으면 Host 의 기본 valve 가 그대로 남아 먼저 응답을 써 버린다.
+ */
+@Configuration
+public class ContainerErrorResponseConfig {
+
+    @Bean
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory> containerErrorResponse() {
+        return factory -> factory.addContextCustomizers(context -> {
+            if (context.getParent() instanceof StandardHost host) {
+                host.setErrorReportValveClass(ContainerErrorResponseValve.class.getName());
+            }
+        });
+    }
+}

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/ContainerErrorResponseValve.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/ContainerErrorResponseValve.java
@@ -1,0 +1,90 @@
+package com.gustler.backend.api.http;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.valves.ErrorReportValve;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+/**
+ * 톰캣이 스프링을 거치지 않고 내는 응답도 우리 오류 봉투로 낸다.
+ *
+ * <p>요청이 늘 컨트롤러까지 오는 것은 아니다. 주소의 퍼센트 인코딩이 깨져 있으면 톰캣이 주소를
+ * 해석하다 400 으로 거절하는데, 그때는 {@link ApiExceptionHandler} 가 아예 안 불린다.
+ * 기본값으로 두면 <b>{@code Content-Type: text/html} 로 톰캣 오류 화면이 나간다.</b>
+ * api 문서는 오류를 {@code code} · {@code message} · {@code requestId} 로 못박아 뒀고,
+ * FE 는 그 응답에 {@code response.json()} 을 부른다.
+ *
+ * <p>오류 코드는 {@link ErrorCode#of} 가 정한다. 컨트롤러를 거친 오류와 같은 표를 써야
+ * 같은 상태 코드에 두 가지 오류 코드가 나가는 일이 없다.
+ *
+ * <p>본문을 여기서 손으로 적는다. 이 자리에는 스프링의 메시지 변환기가 없다. 실어 보내는 값
+ * 셋이 전부 우리가 만든 것이라 따옴표나 역슬래시가 낄 자리가 없지만, 값이 바뀌어도 깨지지
+ * 않도록 최소한의 escape 는 한다.
+ */
+public class ContainerErrorResponseValve extends ErrorReportValve {
+
+    private static final int SMALLEST_ERROR_STATUS = 400;
+
+    public ContainerErrorResponseValve() {
+        setShowReport(false);
+        setShowServerInfo(false);
+    }
+
+    @Override
+    protected void report(
+        Request request,
+        Response response,
+        Throwable throwable
+    ) {
+        final int status = response.getStatus();
+        if (status < SMALLEST_ERROR_STATUS || response.getContentWritten() > 0) {
+            return;
+        }
+        if (!response.setErrorReported()) {
+            return;
+        }
+
+        ErrorCode code = ErrorCode.of(HttpStatus.valueOf(status));
+        write(response, body(code));
+    }
+
+    private String body(
+        ErrorCode code
+    ) {
+        return "{\"code\":\"%s\",\"message\":\"%s\",\"requestId\":\"%s\"}".formatted(
+            escaped(code.name()),
+            escaped(code.message()),
+            UUID.randomUUID());
+    }
+
+    private static String escaped(
+        String value
+    ) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private void write(
+        Response response,
+        String body
+    ) {
+        try {
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(StandardCharsets.UTF_8);
+            response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+            Writer writer = response.getReporter();
+            if (writer != null) {
+                writer.write(body);
+                response.finishResponse();
+            }
+        } catch (IOException | IllegalStateException error) {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/ContainerErrorResponseValve.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/ContainerErrorResponseValve.java
@@ -4,16 +4,17 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.UUID;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ErrorReportValve;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 /**
- * 톰캣이 스프링을 거치지 않고 내는 응답도 우리 오류 봉투로 낸다.
+ * 톰캣이 스프링을 거치지 않고 내는 응답도 우리 오류 응답 형식으로 낸다.
  *
  * <p>요청이 늘 컨트롤러까지 오는 것은 아니다. 주소의 퍼센트 인코딩이 깨져 있으면 톰캣이 주소를
  * 해석하다 400 으로 거절하는데, 그때는 {@link ApiExceptionHandler} 가 아예 안 불린다.
@@ -27,8 +28,14 @@ import org.springframework.http.MediaType;
  * <p>본문을 여기서 손으로 적는다. 이 자리에는 스프링의 메시지 변환기가 없다. 실어 보내는 값
  * 셋이 전부 우리가 만든 것이라 따옴표나 역슬래시가 낄 자리가 없지만, 값이 바뀌어도 깨지지
  * 않도록 최소한의 escape 는 한다.
+ *
+ * <p>요청 식별자를 응답 헤더에도 싣고 로그에도 남긴다. 여기 오는 요청은 {@link RequestIdFilter}
+ * 를 못 지났을 수 있어서 그때는 새로 만든다. <b>안 남기면 클라이언트가 받은 식별자로 서버
+ * 로그를 찾을 수가 없다.</b> 이 경로의 거절은 다른 데 아무 기록도 안 남는다.
  */
 public class ContainerErrorResponseValve extends ErrorReportValve {
+
+    private static final Logger log = LoggerFactory.getLogger(ContainerErrorResponseValve.class);
 
     private static final int SMALLEST_ERROR_STATUS = 400;
 
@@ -52,16 +59,27 @@ public class ContainerErrorResponseValve extends ErrorReportValve {
         }
 
         ErrorCode code = ErrorCode.of(HttpStatus.valueOf(status));
-        write(response, body(code));
+        String requestId = requestIdOf(request);
+        log.warn("컨테이너가 요청을 거절했다. 상태={} 오류코드={} requestId={}",
+            status, code.name(), requestId);
+        write(response, requestId, body(code, requestId));
+    }
+
+    /** 필터를 못 지난 요청이면 여기서 만든다. 지났으면 그 값을 그대로 쓴다. */
+    private String requestIdOf(
+        Request request
+    ) {
+        return request == null ? RequestId.create() : RequestId.of(request);
     }
 
     private String body(
-        ErrorCode code
+        ErrorCode code,
+        String requestId
     ) {
         return "{\"code\":\"%s\",\"message\":\"%s\",\"requestId\":\"%s\"}".formatted(
             escaped(code.name()),
             escaped(code.message()),
-            UUID.randomUUID());
+            escaped(requestId));
     }
 
     private static String escaped(
@@ -72,12 +90,14 @@ public class ContainerErrorResponseValve extends ErrorReportValve {
 
     private void write(
         Response response,
+        String requestId,
         String body
     ) {
         try {
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding(StandardCharsets.UTF_8);
             response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+            response.setHeader(RequestId.HEADER, requestId);
             Writer writer = response.getReporter();
             if (writer != null) {
                 writer.write(body);

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/ErrorHeaders.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/ErrorHeaders.java
@@ -1,0 +1,42 @@
+package com.gustler.backend.api.http;
+
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+/**
+ * 오류 응답에 늘 붙는 헤더.
+ *
+ * <p>오류를 내는 자리가 넷이다. 예외 처리기 · 컨테이너가 넘긴 {@code /error} · 톰캣 valve ·
+ * 스프링이 먼저 잡은 예외. <b>넷이 같은 헤더를 붙여야 한다.</b> 한 자리만 빠져도 그 경로로
+ * 나가는 응답이 다른 모양이 된다.
+ *
+ * <p>{@code Content-Type} 을 여기서 박는다. 안 박으면 요청의 {@code Accept} 로 협상해서 쓸
+ * 변환기를 고르는데, JSON 을 안 받겠다는 요청은 고를 변환기가 없어 <b>본문이 통째로 사라진다.</b>
+ * 잘못된 routeId 를 {@code Accept: text/plain} 으로 부르면 400 이 아니라 500 에 0바이트가 나갔다.
+ *
+ * <p>{@code Allow} 나 {@code Retry-After} 처럼 스프링이 이미 실어 둔 헤더는 그대로 둔다.
+ */
+final class ErrorHeaders {
+
+    private ErrorHeaders() {
+    }
+
+    static HttpHeaders of(
+        MediaType contentType
+    ) {
+        return of(HttpHeaders.EMPTY, contentType);
+    }
+
+    static HttpHeaders of(
+        HttpHeaders original,
+        MediaType contentType
+    ) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.addAll(original);
+        headers.setCacheControl(CacheControl.noStore());
+        headers.setContentType(contentType);
+
+        return headers;
+    }
+}

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/RequestId.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/RequestId.java
@@ -1,0 +1,58 @@
+package com.gustler.backend.api.http;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * 요청 하나에 붙는 식별자. 응답에 실어 보낸 값과 로그에 남은 값이 같아야 한다.
+ *
+ * <p>클라이언트가 오류 응답으로 받은 {@code requestId} 로 서버 로그를 찾을 수 있어야 한다.
+ * 그러려면 <b>한 요청에 하나만 만들어 여러 자리가 나눠 써야</b> 한다. 오류를 내는 자리마다
+ * 새로 만들면 응답에 실린 값과 로그에 남은 값이 달라져서 아무것도 못 찾는다.
+ *
+ * <p>만드는 자리는 {@link RequestIdFilter} 다. 다만 필터까지 못 오는 요청이 있다. 주소의
+ * 퍼센트 인코딩이 깨지면 톰캣이 먼저 거절해서 서블릿이 안 돈다. 그때는 {@link
+ * ContainerErrorResponseValve} 가 만든다. 그래서 읽는 쪽은 <b>없을 수도 있다고 보고</b> 읽는다.
+ */
+public final class RequestId {
+
+    /** 응답에 실어 보내는 헤더 이름. 본문의 requestId 와 같은 값이다. */
+    public static final String HEADER = "X-Request-ID";
+
+    /** 요청 하나 안에서 값을 나르는 자리. 로그 문맥 키로도 같은 이름을 쓴다. */
+    public static final String ATTRIBUTE = "requestId";
+
+    private RequestId() {
+    }
+
+    public static String create() {
+        return UUID.randomUUID().toString();
+    }
+
+    /** 이 요청에 이미 붙은 식별자. 없으면 새로 만든다. */
+    public static String of(
+        HttpServletRequest request
+    ) {
+        Object attached = request.getAttribute(ATTRIBUTE);
+
+        return attached instanceof String value ? value : create();
+    }
+
+    /**
+     * 지금 돌고 있는 요청의 식별자. 요청 밖이면 새로 만든다.
+     *
+     * <p>{@link ApiExceptionHandler} 는 예외만 받고 요청을 안 받는다. 서명을 늘리는 대신
+     * 스프링이 들고 있는 요청 문맥에서 꺼낸다.
+     */
+    public static String ofCurrentRequest() {
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            return create();
+        }
+        Object attached = attributes.getAttribute(ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
+
+        return attached instanceof String value ? value : create();
+    }
+}

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/RequestIdFilter.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/RequestIdFilter.java
@@ -20,7 +20,11 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * 객체를 새로 만들지 않아서 붙여 둔 값이 그대로 따라간다. 그래서 {@code DispatcherType} 을
  * 안 가리고 한 번만 만든다.
  *
- * <p>로그 문맥은 반드시 {@code finally} 에서 지운다. 스레드를 돌려 쓰는 자리라 안 지우면
+ * <p>로그 문맥에 넣는 것만으로는 로그 줄에 안 찍힌다. {@code application.yml} 의
+ * {@code logging.pattern.correlation} 이 {@code %X{requestId}} 를 읽어 가야 찍힌다.
+ * 둘 중 하나가 빠지면 클라이언트가 받은 식별자로 찾을 로그가 없다.
+ *
+ * <p>로그 문맥은 반드시 {@code finally} 에서 지운다. 스레드를 돌려 쓰는 곳이라 안 지우면
  * 다음 요청의 로그에 남의 식별자가 붙는다.
  */
 @Component

--- a/backend/api-app/src/main/java/com/gustler/backend/api/http/RequestIdFilter.java
+++ b/backend/api-app/src/main/java/com/gustler/backend/api/http/RequestIdFilter.java
@@ -1,0 +1,52 @@
+package com.gustler.backend.api.http;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * 요청마다 식별자를 하나 만들어 응답 헤더와 로그 문맥에 함께 싣는다.
+ *
+ * <p>제일 앞에 둔다. 뒤에 서는 필터가 던지는 예외도 같은 식별자로 남아야 한다.
+ *
+ * <p>{@code /error} 로 넘어가는 요청도 같은 식별자를 쓴다. 스프링이 그 경로를 부를 때 요청
+ * 객체를 새로 만들지 않아서 붙여 둔 값이 그대로 따라간다. 그래서 {@code DispatcherType} 을
+ * 안 가리고 한 번만 만든다.
+ *
+ * <p>로그 문맥은 반드시 {@code finally} 에서 지운다. 스레드를 돌려 쓰는 자리라 안 지우면
+ * 다음 요청의 로그에 남의 식별자가 붙는다.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain chain
+    ) throws ServletException, IOException {
+        String requestId = RequestId.create();
+        request.setAttribute(RequestId.ATTRIBUTE, requestId);
+        response.setHeader(RequestId.HEADER, requestId);
+        MDC.put(RequestId.ATTRIBUTE, requestId);
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            MDC.remove(RequestId.ATTRIBUTE);
+        }
+    }
+
+    /** {@code /error} 로 다시 들어오는 요청에도 같은 식별자를 유지한다. */
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        return false;
+    }
+}

--- a/backend/api-app/src/main/resources/application.yml
+++ b/backend/api-app/src/main/resources/application.yml
@@ -20,6 +20,12 @@ spring:
     hibernate:
       ddl-auto: validate # 스키마의 주인은 Flyway 다. Hibernate 는 대조만 한다.
 
+# 오류 응답에 실어 보낸 requestId 로 서버 로그를 찾을 수 있게 한다.
+# 이 줄이 없으면 MDC 에 넣어도 로그 줄에 안 찍혀서, 클라이언트가 받은 ID 로 검색할 것이 없다.
+logging:
+  pattern:
+    correlation: "[${spring.application.name:},%X{requestId:-}] "
+
 management:
   endpoints:
     web:

--- a/backend/api-app/src/test/java/com/gustler/backend/api/http/ApiExceptionHandlerTest.java
+++ b/backend/api-app/src/test/java/com/gustler/backend/api/http/ApiExceptionHandlerTest.java
@@ -169,6 +169,57 @@ class ApiExceptionHandlerTest {
         assertThat(actual.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
     }
 
+    @ParameterizedTest
+    @MethodSource("thrownExceptions")
+    void 우리가_던진_오류도_JSON_으로_적는다고_못박는다(ApiException exception) {
+        // when
+        ResponseEntity<ErrorResponse> actual = handler.handleApiException(exception);
+
+        // then 협상에 맡기면 Accept 가 JSON 이 아닌 요청에서 본문이 통째로 사라진다
+        assertThat(actual.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+    }
+
+    @ParameterizedTest
+    @MethodSource("databaseUnavailableExceptions")
+    void DB_오류도_JSON_으로_적는다고_못박는다(RuntimeException exception) {
+        // when
+        ResponseEntity<ErrorResponse> actual = handler.handleDatabaseUnavailable(exception);
+
+        // then
+        assertThat(actual.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+    }
+
+    @Test
+    void 예상하지_못한_오류도_JSON_으로_적는다고_못박는다() {
+        // when
+        ResponseEntity<ErrorResponse> actual =
+            handler.handleUnexpected(new IllegalStateException("아무도 모르는 오류"));
+
+        // then
+        assertThat(actual.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+    }
+
+    @Test
+    void 스프링이_실어_둔_헤더는_그대로_두고_우리_것만_얹는다() {
+        // given
+        HttpHeaders 스프링이_실은_것 = new HttpHeaders();
+        스프링이_실은_것.set(HttpHeaders.ALLOW, "GET");
+
+        // when
+        ResponseEntity<Object> actual = handler.handleExceptionInternal(
+            new IllegalStateException("스프링이 잡은 예외"),
+            null,
+            스프링이_실은_것,
+            HttpStatus.METHOD_NOT_ALLOWED,
+            null
+        );
+
+        // then
+        assertThat(actual.getHeaders().getFirst(HttpHeaders.ALLOW)).isEqualTo("GET");
+        assertThat(actual.getHeaders().getCacheControl()).isEqualTo("no-store");
+        assertThat(actual.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+    }
+
     @Test
     void 예상하지_못한_예외는_500으로_옮긴다() {
         // when

--- a/backend/api-app/src/test/java/com/gustler/backend/api/http/ApiExceptionHandlerTest.java
+++ b/backend/api-app/src/test/java/com/gustler/backend/api/http/ApiExceptionHandlerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.transaction.CannotCreateTransactionException;
@@ -151,6 +152,21 @@ class ApiExceptionHandlerTest {
             assertThat(body.code()).isEqualTo(expected);
             assertThat(body.message()).isEqualTo(expected.message());
         });
+    }
+
+    @Test
+    void 스프링이_잡은_오류도_JSON_으로_적는다고_못박는다() {
+        // when
+        ResponseEntity<Object> actual = handler.handleExceptionInternal(
+            new IllegalStateException("스프링이 잡은 예외"),
+            null,
+            new HttpHeaders(),
+            HttpStatus.NOT_ACCEPTABLE,
+            null
+        );
+
+        // then
+        assertThat(actual.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
     }
 
     @Test

--- a/backend/api-app/src/test/java/com/gustler/backend/api/http/ContainerErrorContractTest.java
+++ b/backend/api-app/src/test/java/com/gustler/backend/api/http/ContainerErrorContractTest.java
@@ -1,0 +1,170 @@
+package com.gustler.backend.api.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gustler.backend.support.PostgresTestContainer;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+/**
+ * 컨트롤러까지 안 오는 요청도 오류 응답 형식을 지키는지 실제 톰캣으로 잰다.
+ *
+ * <p>MockMvc 로는 못 잡는 것들이다. 주소 해석 실패와 요청 헤더 초과는 서블릿이 돌기 전에
+ * 톰캣이 거절하고, {@code TRACE} 는 컨테이너가 {@code /error} 로 넘긴다.
+ *
+ * <p>날 것 소켓으로 보낸다. 자바 HTTP 클라이언트는 주소를 먼저 정규화해서 깨진 퍼센트 인코딩을
+ * 서버까지 보내지 않는다.
+ *
+ * <p>2026-09-02 PR #56 리뷰에서 나온 조합이다. <b>하나씩 치면 통과하고 겹쳐 치면 깨지던</b>
+ * 자리라 조합으로 고정한다.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(PostgresTestContainer.class)
+class ContainerErrorContractTest {
+
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(10);
+
+    @LocalServerPort
+    private int port;
+
+    @Test
+    void 주소의_퍼센트_인코딩이_깨져도_오류_코드와_메시지가_실려_나간다() throws IOException {
+        // when 톰캣이 주소를 해석하다 거절해서 서블릿이 아예 안 돈다
+        Response actual = send("GET /api/v1/routes/%zz/board HTTP/1.1");
+
+        // then
+        assertThat(actual.status).isEqualTo(400);
+        assertThat(actual.body).contains("\"code\":\"INVALID_REQUEST\"");
+        assertThat(actual.header("Content-Type")).contains("application/json");
+        assertThat(actual.header("Cache-Control")).isEqualTo("no-store");
+    }
+
+    @Test
+    void 컨테이너가_error_로_넘긴_응답도_오류_코드와_메시지가_실려_나간다() throws IOException {
+        // when 스프링 부트가 이 자리에 기본 오류 컨트롤러를 두면 timestamp·status·error·path 가 나간다
+        Response actual = send("TRACE /api/v1/routes HTTP/1.1");
+
+        // then
+        assertThat(actual.status).isEqualTo(405);
+        assertThat(actual.body).contains("\"code\":\"METHOD_NOT_ALLOWED\"");
+        assertThat(actual.body).doesNotContain("\"timestamp\"");
+        assertThat(actual.header("Cache-Control")).isEqualTo("no-store");
+    }
+
+    @Test
+    void 요청_헤더가_한도를_넘어도_오류_코드와_메시지가_실려_나간다() throws IOException {
+        // given
+        String cookies = IntStream.range(0, 250)
+            .mapToObj(index -> "c%d=v%d".formatted(index, index))
+            .reduce((left, right) -> left + ";" + right)
+            .orElseThrow();
+
+        // when
+        Response actual = send("GET /api/v1/routes HTTP/1.1", "Cookie: " + cookies);
+
+        // then
+        assertThat(actual.status).isEqualTo(400);
+        assertThat(actual.body).contains("\"code\":\"INVALID_REQUEST\"");
+        assertThat(actual.header("Cache-Control")).isEqualTo("no-store");
+    }
+
+    @Test
+    void JSON_을_안_받는_요청이_다른_오류와_겹쳐도_오류_코드와_메시지가_실려_나간다() throws IOException {
+        // when 협상에 맡기면 본문을 만들고도 못 써서 500 에 0바이트가 나간다
+        Response actual = send("GET /api/v1/routes/abc/board HTTP/1.1", "Accept: text/plain");
+
+        // then
+        assertThat(actual.status).isEqualTo(400);
+        assertThat(actual.body).contains("\"code\":\"INVALID_ROUTE_ID\"");
+        assertThat(actual.body).contains("\"requestId\"");
+    }
+
+    @Test
+    void 응답_헤더의_요청_식별자가_본문의_것과_같다() throws IOException {
+        // when
+        Response actual = send("GET /api/v1/routes/%zz/board HTTP/1.1");
+
+        // then 클라이언트가 받은 식별자로 서버 로그를 찾을 수 있어야 한다
+        assertThat(actual.header(RequestId.HEADER))
+            .isNotNull()
+            .isEqualTo(bodyRequestId(actual.body));
+    }
+
+    private static String bodyRequestId(
+        String body
+    ) {
+        final int start = body.indexOf("\"requestId\":\"") + "\"requestId\":\"".length();
+
+        return body.substring(start, body.indexOf('"', start));
+    }
+
+    private Response send(
+        String requestLine,
+        String... headers
+    ) throws IOException {
+        try (Socket socket = new Socket("127.0.0.1", port)) {
+            socket.setSoTimeout((int) READ_TIMEOUT.toMillis());
+            StringBuilder request = new StringBuilder(requestLine).append("\r\n")
+                .append("Host: 127.0.0.1:").append(port).append("\r\n");
+            for (String header : headers) {
+                request.append(header).append("\r\n");
+            }
+            request.append("Connection: close\r\n\r\n");
+
+            OutputStream output = socket.getOutputStream();
+            output.write(request.toString().getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            return Response.read(socket);
+        }
+    }
+
+    private record Response(
+        int status,
+        List<String> headers,
+        String body
+    ) {
+
+        static Response read(
+            Socket socket
+        ) throws IOException {
+            BufferedReader reader = new BufferedReader(
+                new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+            String statusLine = reader.readLine();
+            List<String> headers = new ArrayList<>();
+            String line;
+            while ((line = reader.readLine()) != null && !line.isEmpty()) {
+                headers.add(line);
+            }
+            StringBuilder body = new StringBuilder();
+            while ((line = reader.readLine()) != null) {
+                body.append(line);
+            }
+
+            return new Response(
+                Integer.parseInt(statusLine.split(" ")[1]), headers, body.toString());
+        }
+
+        String header(
+            String name
+        ) {
+            return headers.stream()
+                .filter(header -> header.regionMatches(true, 0, name + ":", 0, name.length() + 1))
+                .map(header -> header.substring(name.length() + 1).trim())
+                .findFirst()
+                .orElse(null);
+        }
+    }
+}

--- a/backend/api-app/src/test/java/com/gustler/backend/api/http/ContainerErrorContractTest.java
+++ b/backend/api-app/src/test/java/com/gustler/backend/api/http/ContainerErrorContractTest.java
@@ -14,7 +14,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 
@@ -32,6 +35,7 @@ import org.springframework.context.annotation.Import;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(PostgresTestContainer.class)
+@ExtendWith(OutputCaptureExtension.class)
 class ContainerErrorContractTest {
 
     private static final Duration READ_TIMEOUT = Duration.ofSeconds(10);
@@ -89,6 +93,15 @@ class ContainerErrorContractTest {
         assertThat(actual.status).isEqualTo(400);
         assertThat(actual.body).contains("\"code\":\"INVALID_ROUTE_ID\"");
         assertThat(actual.body).contains("\"requestId\"");
+    }
+
+    @Test
+    void 응답의_요청_식별자로_서버_로그를_찾을_수_있다(CapturedOutput 로그) throws IOException {
+        // when 컨테이너가 /error 로 넘긴 요청이라 예외 처리기를 안 지난다
+        Response actual = send("TRACE /api/v1/routes HTTP/1.1");
+
+        // then 응답에만 있고 로그에 없으면 그 식별자로 찾을 것이 없다
+        assertThat(로그.getOut()).contains(bodyRequestId(actual.body));
     }
 
     @Test

--- a/backend/api-app/src/test/java/com/gustler/backend/api/http/ContainerErrorResponseValveTest.java
+++ b/backend/api-app/src/test/java/com/gustler/backend/api/http/ContainerErrorResponseValveTest.java
@@ -1,0 +1,103 @@
+package com.gustler.backend.api.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.apache.catalina.connector.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+class ContainerErrorResponseValveTest {
+
+    private final ContainerErrorResponseValve valve = new ContainerErrorResponseValve();
+
+    private final StringWriter written = new StringWriter();
+
+    private Response 오류를_내는_응답(
+        final int status
+    ) throws Exception {
+        Response response = mock(Response.class);
+        given(response.getStatus()).willReturn(status);
+        given(response.getContentWritten()).willReturn(0L);
+        given(response.setErrorReported()).willReturn(true);
+        given(response.getReporter()).willReturn(new PrintWriter(written));
+
+        return response;
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "400, INVALID_REQUEST",
+        "404, ENDPOINT_NOT_FOUND",
+        "405, METHOD_NOT_ALLOWED",
+        "500, INTERNAL_ERROR",
+        "503, SERVICE_UNAVAILABLE"
+    })
+    void 컨트롤러를_못_거친_오류도_같은_오류_코드로_적는다(
+        final int status,
+        ErrorCode expected
+    ) throws Exception {
+        // given
+        Response response = 오류를_내는_응답(status);
+
+        // when
+        valve.report(null, response, null);
+
+        // then
+        assertThat(written.toString())
+            .contains("\"code\":\"%s\"".formatted(expected.name()))
+            .contains("\"message\":\"%s\"".formatted(expected.message()))
+            .contains("\"requestId\":\"");
+    }
+
+    @Test
+    void 오류_응답은_JSON_이고_저장하지_않게_한다() throws Exception {
+        // given
+        Response response = 오류를_내는_응답(400);
+
+        // when
+        valve.report(null, response, null);
+
+        // then
+        verify(response).setContentType(MediaType.APPLICATION_JSON_VALUE);
+        verify(response).setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+    }
+
+    @Test
+    void 이미_본문을_쓴_응답에는_덧붙이지_않는다() throws Exception {
+        // given
+        Response response = mock(Response.class);
+        given(response.getStatus()).willReturn(400);
+        given(response.getContentWritten()).willReturn(133L);
+
+        // when
+        valve.report(null, response, null);
+
+        // then
+        assertThat(written.toString()).isEmpty();
+        verify(response, never()).setHeader(anyString(), anyString());
+    }
+
+    @Test
+    void 오류가_아닌_응답에는_아무것도_안_쓴다() throws Exception {
+        // given
+        Response response = mock(Response.class);
+        given(response.getStatus()).willReturn(200);
+
+        // when
+        valve.report(null, response, null);
+
+        // then
+        assertThat(written.toString()).isEmpty();
+        verify(response, never()).setHeader(anyString(), anyString());
+    }
+}

--- a/backend/api-app/src/test/java/com/gustler/backend/api/http/ManagementPortSeparationTest.java
+++ b/backend/api-app/src/test/java/com/gustler/backend/api/http/ManagementPortSeparationTest.java
@@ -1,0 +1,90 @@
+package com.gustler.backend.api.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gustler.backend.support.PostgresTestContainer;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Actuator 를 다른 포트에 떼도 공개 포트의 오류 응답이 안 바뀌는지 붙잡는다.
+ *
+ * <p>배포에서 {@code MANAGEMENT_SERVER_PORT} 로 관리 포트를 뗀다. 그러면 그 포트가 자식
+ * 컨텍스트에서 도는데, 우리 오류 처리는 부모 컨텍스트에만 붙는다. <b>공개 포트가 그 분리에
+ * 휩쓸리지 않는지를 여기서 고정한다.</b>
+ *
+ * <p>관리 포트가 부트 기본 응답을 내는 것도 같이 고정한다. 그것이 <b>지금 정한 범위</b>이고,
+ * 누가 자식 컨텍스트에 우리 것을 등록하면 이 테스트가 먼저 알려 준다. 범위를 바꾸기로 하면
+ * 이 테스트를 뒤집으면 된다.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = "management.server.port=0")
+@Import(PostgresTestContainer.class)
+class ManagementPortSeparationTest {
+
+    @LocalServerPort
+    private int publicPort;
+
+    @LocalManagementPort
+    private int managementPort;
+
+    @Test
+    void 관리_포트를_떼도_공개_포트는_우리_오류_응답_형식을_지킨다() throws IOException {
+        // when
+        String actual = send(publicPort, "TRACE /api/v1/routes HTTP/1.1");
+
+        // then
+        assertThat(actual).contains("\"code\":\"METHOD_NOT_ALLOWED\"");
+        assertThat(actual).contains("\"requestId\"");
+        assertThat(actual).contains(RequestId.HEADER);
+    }
+
+    @Test
+    void 관리_포트는_이_오류_응답_형식_밖이다() throws IOException {
+        // when
+        String actual = send(managementPort, "TRACE /actuator/health HTTP/1.1");
+
+        // then api 문서가 정한 것은 /api/v1 아래뿐이라 여기는 부트 기본 응답으로 둔다
+        assertThat(actual).doesNotContain("\"code\":");
+        assertThat(actual).doesNotContain(RequestId.HEADER);
+    }
+
+    @Test
+    void 두_포트가_서로_다른_포트다() {
+        assertThat(managementPort).isNotEqualTo(publicPort);
+    }
+
+    private String send(
+        final int port,
+        String requestLine
+    ) throws IOException {
+        try (Socket socket = new Socket("127.0.0.1", port)) {
+            String request = requestLine + "\r\n"
+                + "Host: 127.0.0.1:" + port + "\r\n"
+                + "Connection: close\r\n\r\n";
+            OutputStream output = socket.getOutputStream();
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            BufferedReader reader = new BufferedReader(
+                new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+            StringBuilder received = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                received.append(line).append('\n');
+            }
+
+            return received.toString();
+        }
+    }
+}

--- a/backend/worker-app/src/main/java/com/gustler/backend/collector/GbisRouteSource.java
+++ b/backend/worker-app/src/main/java/com/gustler/backend/collector/GbisRouteSource.java
@@ -9,10 +9,9 @@ import com.gustler.backend.collector.dto.BusRouteInfoResponse;
 import com.gustler.backend.collector.dto.BusRouteInfoResponse.RouteInfoItem;
 import com.gustler.backend.collector.dto.BusRouteStationResponse;
 import com.gustler.backend.collector.dto.BusRouteStationResponse.RouteStationItem;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -87,19 +86,29 @@ public class GbisRouteSource {
     /**
      * 회차 순번은 정류소 목록이 준다. 노선정보 응답에는 없다.
      *
-     * <p>모든 정류소 행에 같은 {@code turnSeq} 가 실려 오고, 회차하는 정류소만 {@code turnYn}
-     * 이 Y 다. 둘이 어긋나거나 값이 여럿이면 회차 없음으로 본다. 잘못 고른 순번으로 판본을 열면
-     * 정류소 절반의 방향이 뒤집힌 채 그럴듯하게 돌아간다.
+     * <p>정상 응답은 <b>모든 정류소 행에 같은 {@code turnSeq}</b> 가 실리고
+     * <b>회차하는 정류소 하나만 {@code turnYn} 이 Y</b> 다. 셋 중 하나라도 어긋나면 회차 없음으로
+     * 본다. 잘못 고른 순번으로 판본을 열면 정류소 절반의 방향이 뒤집힌 채 그럴듯하게 돌아간다.
+     *
+     * <ul>
+     *   <li>값이 빠진 행이 하나라도 있으면 안 쓴다. 남은 행만으로 고르면 그 노선이 정말 회차하는지
+     *       알 수 없다
+     *   <li>서로 다른 값이 오면 안 쓴다
+     *   <li>회차 표시가 없거나 둘 이상이면 안 쓴다
+     *   <li>표시가 붙은 정류소의 순번이 {@code turnSeq} 와 다르면 안 쓴다
+     * </ul>
      */
     private Integer turnSequenceOf(
         List<RouteStationItem> stations
     ) {
+        if (stations.isEmpty()) {
+            return null;
+        }
         Set<Integer> declared = stations.stream()
             .map(RouteStationItem::turnSequence)
-            .filter(Objects::nonNull)
-            .collect(Collectors.toSet());
-        if (declared.size() != 1) {
-            return null;
+            .collect(HashSet::new, HashSet::add, HashSet::addAll);
+        if (declared.size() != 1 || declared.contains(null)) {
+            return warnAndIgnore("회차 순번이 행마다 다르거나 빠진 행이 있다: {}", declared);
         }
 
         Integer turnSequence = declared.iterator().next();
@@ -107,12 +116,23 @@ public class GbisRouteSource {
             .filter(RouteStationItem::isTurnPoint)
             .map(RouteStationItem::stopOrder)
             .toList();
-        if (marked.size() == 1 && !marked.getFirst().equals(turnSequence)) {
-            log.warn("회차 순번과 회차 표시가 어긋난다. 회차 없음으로 본다. turnSeq={} turnYn 순번={}",
-                turnSequence, marked.getFirst());
-            return null;
+        if (marked.size() != 1) {
+            return warnAndIgnore("회차 표시가 붙은 정류소가 {}개다. 하나여야 한다", marked.size());
+        }
+        if (!marked.getFirst().equals(turnSequence)) {
+            return warnAndIgnore("회차 순번 {} 과 회차 표시가 붙은 순번이 다르다",
+                turnSequence + " / " + marked.getFirst());
         }
         return turnSequence;
+    }
+
+    private Integer warnAndIgnore(
+        String message,
+        Object detail
+    ) {
+        log.warn("회차 메타데이터가 성립하지 않아 단방향 노선으로 읽는다. " + message, detail);
+
+        return null;
     }
 
     private List<UpstreamRouteStop> toUpstreamStops(

--- a/backend/worker-app/src/main/java/com/gustler/backend/collector/GbisRouteSource.java
+++ b/backend/worker-app/src/main/java/com/gustler/backend/collector/GbisRouteSource.java
@@ -10,6 +10,11 @@ import com.gustler.backend.collector.dto.BusRouteInfoResponse.RouteInfoItem;
 import com.gustler.backend.collector.dto.BusRouteStationResponse;
 import com.gustler.backend.collector.dto.BusRouteStationResponse.RouteStationItem;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
@@ -17,11 +22,13 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * 노선 하나의 기본 정보와 경유 정류소를 상류에서 읽는다.
  *
- * <p>상류가 둘을 따로 준다. 표시명 · 기점 · 종점 · 첫차 · 막차 · 회차 순번은 노선정보에 있고,
- * 정류소 목록은 노선정류소 조회에 있다. 그래서 한 노선을 읽는 데 호출을 두 번 쓴다.
+ * <p>상류가 둘을 따로 준다. 표시명 · 기점 · 종점 · 첫차 · 막차는 노선정보에 있고, 정류소 목록과
+ * <b>회차 순번</b>은 노선정류소 조회에 있다. 그래서 한 노선을 읽는 데 호출을 두 번 쓴다.
  */
 @Component
 public class GbisRouteSource {
+
+    private static final Logger log = LoggerFactory.getLogger(GbisRouteSource.class);
 
     /** 한 노선을 읽는 데 드는 상류 호출 수. 장부에서 이만큼 자리를 잡고 부른다. */
     public static final int UPSTREAM_CALLS_PER_READ = 2;
@@ -69,12 +76,43 @@ public class GbisRouteSource {
                 routeInfo.displayName(),
                 routeInfo.startStopName(),
                 routeInfo.endStopName(),
-                RouteStops.from(routeInfo.turnSequence(), toUpstreamStops(stations)),
+                RouteStops.from(turnSequenceOf(stations), toUpstreamStops(stations)),
                 timetableOf(routeInfo)));
         } catch (final IllegalArgumentException e) {
             // 순번이 겹치거나 회차 순번이 정류소 목록에 없는 응답. 판본으로 열면 뜻이 없는 노선이 된다.
             return new Failed("노선 %s 의 정류소 목록이 성립하지 않는다: %s".formatted(routeId, e.getMessage()));
         }
+    }
+
+    /**
+     * 회차 순번은 정류소 목록이 준다. 노선정보 응답에는 없다.
+     *
+     * <p>모든 정류소 행에 같은 {@code turnSeq} 가 실려 오고, 회차하는 정류소만 {@code turnYn}
+     * 이 Y 다. 둘이 어긋나거나 값이 여럿이면 회차 없음으로 본다. 잘못 고른 순번으로 판본을 열면
+     * 정류소 절반의 방향이 뒤집힌 채 그럴듯하게 돌아간다.
+     */
+    private Integer turnSequenceOf(
+        List<RouteStationItem> stations
+    ) {
+        Set<Integer> declared = stations.stream()
+            .map(RouteStationItem::turnSequence)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+        if (declared.size() != 1) {
+            return null;
+        }
+
+        Integer turnSequence = declared.iterator().next();
+        List<Integer> marked = stations.stream()
+            .filter(RouteStationItem::isTurnPoint)
+            .map(RouteStationItem::stopOrder)
+            .toList();
+        if (marked.size() == 1 && !marked.getFirst().equals(turnSequence)) {
+            log.warn("회차 순번과 회차 표시가 어긋난다. 회차 없음으로 본다. turnSeq={} turnYn 순번={}",
+                turnSequence, marked.getFirst());
+            return null;
+        }
+        return turnSequence;
     }
 
     private List<UpstreamRouteStop> toUpstreamStops(

--- a/backend/worker-app/src/main/java/com/gustler/backend/collector/dto/BusRouteInfoResponse.java
+++ b/backend/worker-app/src/main/java/com/gustler/backend/collector/dto/BusRouteInfoResponse.java
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * 노선 한 건의 기본 정보. 표시명과 기점 · 종점 이름과 첫차 · 막차 시각과 회차 순번이 여기서 온다.
  *
- * <p>필드 이름은 공공데이터포털 문서를 보고 맞춘 것이다. 서비스키가 없어 실제 응답으로 대조하지 못했다.
+ * <p>회차 순번은 여기 없다. 이 응답에는 회차 정류소의 ID 와 이름(turnStID · turnStNm)만 있고
+ * 순번은 정류소 목록 응답이 준다. 2026-09-02 실제 응답으로 대조했다.
  * 이름이 어긋나면 값이 null 로 들어오고 읽지 못한 응답으로 떨어진다.
  */
 public record BusRouteInfoResponse(
@@ -54,26 +55,7 @@ public record BusRouteInfoResponse(
         String downFirstDepartureTime,
 
         @JsonProperty("downLastTime")
-        String downLastDepartureTime,
-
-        /** 회차 지점의 순번. 단방향 노선은 비어 있거나 0 으로 온다. */
-        @JsonProperty("turnSeq")
-        Integer turnSequence
+        String downLastDepartureTime
     ) {
-
-        private static final int NO_TURN_POINT = 0;
-
-        /**
-         * 0 을 회차 없음으로 접는다. 정류소 순번은 1 부터라 0 인 회차 지점은 있을 수 없다.
-         *
-         * <p>접지 않으면 RouteStops 가 "회차 순번 0 인 정류소를 경유하지 않는다" 로 거절하고,
-         * 그 노선은 판본이 안 열려서 수집이 통째로 멈춘다. 상류가 0 을 주는지 실제로 보진 못했는데,
-         * 단방향을 0 으로 알리는 API 가 흔해서 미리 접어둔다.
-         */
-        public RouteInfoItem {
-            if (turnSequence != null && turnSequence == NO_TURN_POINT) {
-                turnSequence = null;
-            }
-        }
     }
 }

--- a/backend/worker-app/src/main/java/com/gustler/backend/collector/dto/BusRouteStationResponse.java
+++ b/backend/worker-app/src/main/java/com/gustler/backend/collector/dto/BusRouteStationResponse.java
@@ -7,7 +7,9 @@ import java.util.List;
 /**
  * 노선이 지나는 정류소 목록. 회차하는 노선은 같은 정류소가 두 번 나오고 순번이 그것을 가른다.
  *
- * <p>필드 이름은 공공데이터포털 문서를 보고 맞춘 것이다. 서비스키가 없어 실제 응답으로 대조하지 못했다.
+ * <p>회차 순번이 여기 있다. 노선정보 응답에는 없다. 정류소마다 같은 {@code turnSeq} 가 실려 오고
+ * 회차하는 정류소만 {@code turnYn} 이 Y 다. 2026-09-02 실제 응답으로 대조했다.
+ * 3330 은 43번 안양역, 1650 은 44번 안양역이다.
  */
 public record BusRouteStationResponse(
     Response response
@@ -45,7 +47,21 @@ public record BusRouteStationResponse(
         String name,
 
         @JsonProperty("stationSeq")
-        Integer stopOrder
+        Integer stopOrder,
+
+        /** 이 노선의 회차 정류소 순번. 모든 정류소 행에 같은 값이 실린다. 단방향이면 비어 있다. */
+        @JsonProperty("turnSeq")
+        Integer turnSequence,
+
+        /** 이 정류소가 회차 지점인가. 회차하는 노선은 한 정류소만 {@code Y} 다. */
+        @JsonProperty("turnYn")
+        String turnPoint
     ) {
+
+        private static final String TURN_POINT = "Y";
+
+        public boolean isTurnPoint() {
+            return TURN_POINT.equals(turnPoint);
+        }
     }
 }

--- a/backend/worker-app/src/test/java/com/gustler/backend/collector/GbisRouteSourceTest.java
+++ b/backend/worker-app/src/test/java/com/gustler/backend/collector/GbisRouteSourceTest.java
@@ -146,6 +146,60 @@ class GbisRouteSourceTest {
     }
 
     @Test
+    void 회차_표시가_없으면_단방향_노선으로_읽어낸다() {
+        // given 순번은 실려 왔는데 어느 정류소가 회차 지점인지 표시가 없다
+        respondWith(ROUTE_INFO_JSON.formatted(0),
+            THREE_STATIONS_JSON.replace("\"turnYn\":\"Y\"", "\"turnYn\":\"N\""));
+
+        // when
+        final GbisRouteResult actual = source.read(ROUTE_3330);
+
+        // then
+        assertThat(((Success) actual).route().stops().turnSequence()).isNull();
+    }
+
+    @Test
+    void 회차_표시가_둘이면_단방향_노선으로_읽어낸다() {
+        // given
+        respondWith(ROUTE_INFO_JSON.formatted(0),
+            THREE_STATIONS_JSON.replace("\"stationSeq\":3,\"turnSeq\":2,\"turnYn\":\"N\"",
+                "\"stationSeq\":3,\"turnSeq\":2,\"turnYn\":\"Y\""));
+
+        // when
+        final GbisRouteResult actual = source.read(ROUTE_3330);
+
+        // then
+        assertThat(((Success) actual).route().stops().turnSequence()).isNull();
+    }
+
+    @Test
+    void 회차_순번이_빠진_행이_하나라도_있으면_단방향_노선으로_읽어낸다() {
+        // given 남은 행만으로 고르면 그 노선이 정말 회차하는지 알 수 없다
+        respondWith(ROUTE_INFO_JSON.formatted(0),
+            THREE_STATIONS_JSON.replace("\"stationSeq\":1,\"turnSeq\":2,", "\"stationSeq\":1,"));
+
+        // when
+        final GbisRouteResult actual = source.read(ROUTE_3330);
+
+        // then
+        assertThat(((Success) actual).route().stops().turnSequence()).isNull();
+    }
+
+    @Test
+    void 회차_순번이_행마다_다르면_단방향_노선으로_읽어낸다() {
+        // given
+        respondWith(ROUTE_INFO_JSON.formatted(0),
+            THREE_STATIONS_JSON.replace("\"stationSeq\":1,\"turnSeq\":2,",
+                "\"stationSeq\":1,\"turnSeq\":3,"));
+
+        // when
+        final GbisRouteResult actual = source.read(ROUTE_3330);
+
+        // then
+        assertThat(((Success) actual).route().stops().turnSequence()).isNull();
+    }
+
+    @Test
     void 회차_순번과_회차_표시가_어긋나면_단방향_노선으로_읽어낸다() {
         // given 순번은 2 인데 표시는 3번 정류소에 붙어 있다
         respondWith(ROUTE_INFO_JSON.formatted(0),

--- a/backend/worker-app/src/test/java/com/gustler/backend/collector/GbisRouteSourceTest.java
+++ b/backend/worker-app/src/test/java/com/gustler/backend/collector/GbisRouteSourceTest.java
@@ -30,15 +30,15 @@ class GbisRouteSourceTest {
           "msgBody":{"busRouteInfoItem":{
             "routeName":"3330","startStationName":"범계역","endStationName":"강남역",
             "upFirstTime":"05:00","upLastTime":"22:35",
-            "downFirstTime":"05:00","downLastTime":"23:55","turnSeq":2}}}}
+            "downFirstTime":"05:00","downLastTime":"23:55"}}}}
         """;
     private static final String THREE_STATIONS_JSON = """
         {"response":{"msgHeader":{
             "queryTime":"2026-08-28 11:14:04.911","resultCode":0,"resultMessage":"정상"},
           "msgBody":{"busRouteStationList":[
-            {"stationId":"205000217","stationName":"범계역","stationSeq":1},
-            {"stationId":"277103149","stationName":"안양대교(경유)","stationSeq":2},
-            {"stationId":"208000069","stationName":"안양역","stationSeq":3}]}}}
+            {"stationId":"205000217","stationName":"범계역","stationSeq":1,"turnSeq":2,"turnYn":"N"},
+            {"stationId":"277103149","stationName":"안양대교(경유)","stationSeq":2,"turnSeq":2,"turnYn":"Y"},
+            {"stationId":"208000069","stationName":"안양역","stationSeq":3,"turnSeq":2,"turnYn":"N"}]}}}
         """;
     private static final String NO_STATIONS_JSON = """
         {"response":{"msgHeader":{
@@ -132,14 +132,32 @@ class GbisRouteSourceTest {
     }
 
     @Test
-    void 회차_순번이_0_으로_와도_단방향_노선으로_읽어낸다() {
+    void 회차_순번이_없으면_단방향_노선으로_읽어낸다() {
         // given
-        respondWith(ROUTE_INFO_JSON.formatted(0).replace("\"turnSeq\":2", "\"turnSeq\":0"), THREE_STATIONS_JSON);
+        respondWith(ROUTE_INFO_JSON.formatted(0),
+            THREE_STATIONS_JSON.replace(",\"turnSeq\":2,\"turnYn\":\"N\"", "")
+                .replace(",\"turnSeq\":2,\"turnYn\":\"Y\"", ""));
 
         // when
         final GbisRouteResult actual = source.read(ROUTE_3330);
 
-        // then 접지 않으면 회차 순번 검증에 걸려 이 노선 수집이 통째로 멈춘다
+        // then
+        assertThat(((Success) actual).route().stops().turnSequence()).isNull();
+    }
+
+    @Test
+    void 회차_순번과_회차_표시가_어긋나면_단방향_노선으로_읽어낸다() {
+        // given 순번은 2 인데 표시는 3번 정류소에 붙어 있다
+        respondWith(ROUTE_INFO_JSON.formatted(0),
+            THREE_STATIONS_JSON.replace("\"stationSeq\":2,\"turnSeq\":2,\"turnYn\":\"Y\"",
+                    "\"stationSeq\":2,\"turnSeq\":2,\"turnYn\":\"N\"")
+                .replace("\"stationSeq\":3,\"turnSeq\":2,\"turnYn\":\"N\"",
+                    "\"stationSeq\":3,\"turnSeq\":2,\"turnYn\":\"Y\""));
+
+        // when
+        final GbisRouteResult actual = source.read(ROUTE_3330);
+
+        // then 잘못 고른 순번으로 판본을 열면 정류소 절반의 방향이 뒤집힌다
         assertThat(((Success) actual).route().stops().turnSequence()).isNull();
     }
 

--- a/backend/worker-app/src/test/java/com/gustler/backend/collector/dto/BusRouteInfoResponseTest.java
+++ b/backend/worker-app/src/test/java/com/gustler/backend/collector/dto/BusRouteInfoResponseTest.java
@@ -21,24 +21,8 @@ class BusRouteInfoResponseTest {
           "msgBody":{"busRouteInfoItem":{
             "routeName":"3330","startStationName":"범계역","endStationName":"강남역",
             "upFirstTime":"05:00","upLastTime":"22:35",
-            "downFirstTime":"05:00","downLastTime":"23:55","turnSeq":2}}}}
-        """;
-    private static final String ONE_WAY_ROUTE_JSON = """
-        {"response":{"msgHeader":{
-            "queryTime":"2026-08-28 11:14:04.911","resultCode":0,"resultMessage":"정상"},
-          "msgBody":{"busRouteInfoItem":{
-            "routeName":"3330","startStationName":"범계역","endStationName":"강남역",
-            "upFirstTime":"05:00","upLastTime":"22:35",
-            "downFirstTime":"05:00","downLastTime":"23:55"}}}}
-        """;
-
-    private static final String ZERO_TURN_JSON = """
-        {"response":{"msgHeader":{
-            "queryTime":"2026-08-28 11:14:04.911","resultCode":0,"resultMessage":"정상"},
-          "msgBody":{"busRouteInfoItem":{
-            "routeName":"3330","startStationName":"범계역","endStationName":"강남역",
-            "upFirstTime":"05:00","upLastTime":"22:35",
-            "downFirstTime":"05:00","downLastTime":"23:55","turnSeq":0}}}}
+            "downFirstTime":"05:00","downLastTime":"23:55",
+            "turnStID":"208000069","turnStNm":"안양역"}}}}
         """;
 
     @Autowired
@@ -50,28 +34,8 @@ class BusRouteInfoResponseTest {
         final BusRouteInfoResponse actual =
             objectMapper.readValue(ROUTE_INFO_JSON, BusRouteInfoResponse.class);
 
-        // then
+        // then 회차 순번은 이 응답에 없다. 정류소 목록이 준다
         assertThat(actual.response().body().routeInfo()).isEqualTo(new RouteInfoItem(
-            "3330", "범계역", "강남역", "05:00", "22:35", "05:00", "23:55", 2));
-    }
-
-    @Test
-    void 회차_순번이_0_이면_회차_없음으로_읽는다() {
-        // when
-        final BusRouteInfoResponse actual =
-            objectMapper.readValue(ZERO_TURN_JSON, BusRouteInfoResponse.class);
-
-        // then 정류소 순번은 1 부터라 0 인 회차 지점은 있을 수 없다
-        assertThat(actual.response().body().routeInfo().turnSequence()).isNull();
-    }
-
-    @Test
-    void 회차_순번을_안_주는_노선은_회차_순번이_비어_있다() {
-        // when
-        final BusRouteInfoResponse actual =
-            objectMapper.readValue(ONE_WAY_ROUTE_JSON, BusRouteInfoResponse.class);
-
-        // then
-        assertThat(actual.response().body().routeInfo().turnSequence()).isNull();
+            "3330", "범계역", "강남역", "05:00", "22:35", "05:00", "23:55"));
     }
 }

--- a/backend/worker-app/src/test/java/com/gustler/backend/collector/dto/BusRouteStationResponseTest.java
+++ b/backend/worker-app/src/test/java/com/gustler/backend/collector/dto/BusRouteStationResponseTest.java
@@ -19,15 +19,15 @@ class BusRouteStationResponseTest {
         {"response":{"msgHeader":{
             "queryTime":"2026-08-28 11:14:04.911","resultCode":0,"resultMessage":"정상"},
           "msgBody":{"busRouteStationList":[
-            {"stationId":"205000217","stationName":"범계역","stationSeq":1},
-            {"stationId":"277103149","stationName":"안양대교(경유)","stationSeq":2},
-            {"stationId":"208000069","stationName":"안양역","stationSeq":3}]}}}
+            {"stationId":"205000217","stationName":"범계역","stationSeq":1,"turnSeq":2,"turnYn":"N"},
+            {"stationId":"277103149","stationName":"안양대교(경유)","stationSeq":2,"turnSeq":2,"turnYn":"Y"},
+            {"stationId":"208000069","stationName":"안양역","stationSeq":3,"turnSeq":2,"turnYn":"N"}]}}}
         """;
     private static final String SINGLE_STATION_AS_OBJECT_JSON = """
         {"response":{"msgHeader":{
             "queryTime":"2026-08-28 11:14:04.911","resultCode":0,"resultMessage":"정상"},
           "msgBody":{"busRouteStationList":
-            {"stationId":"205000217","stationName":"범계역","stationSeq":1}}}}
+            {"stationId":"205000217","stationName":"범계역","stationSeq":1,"turnSeq":2,"turnYn":"N"}}}}
         """;
 
     @Autowired
@@ -62,6 +62,30 @@ class BusRouteStationResponseTest {
         // then
         final RouteStationItem actualStation = actual.response().body().stations().getFirst();
         assertThat(actualStation)
-            .isEqualTo(new RouteStationItem("205000217", "범계역", 1));
+            .isEqualTo(new RouteStationItem("205000217", "범계역", 1, 2, "N"));
+    }
+
+    @Test
+    void 회차_지점인_정류소만_회차_표시가_붙는다() {
+        // when
+        final BusRouteStationResponse actual =
+            objectMapper.readValue(THREE_STATIONS_JSON, BusRouteStationResponse.class);
+
+        // then
+        assertThat(actual.response().body().stations())
+            .extracting(RouteStationItem::isTurnPoint)
+            .containsExactly(false, true, false);
+    }
+
+    @Test
+    void 회차_순번은_모든_정류소_행에_같은_값으로_실려_온다() {
+        // when
+        final BusRouteStationResponse actual =
+            objectMapper.readValue(THREE_STATIONS_JSON, BusRouteStationResponse.class);
+
+        // then 노선정보 응답에는 이 값이 없어서 여기서만 읽을 수 있다
+        assertThat(actual.response().body().stations())
+            .extracting(RouteStationItem::turnSequence)
+            .containsOnly(2);
     }
 }


### PR DESCRIPTION
## 요약

api 문서는 오류를 `code` · `message` · `requestId` 로 못박아 뒀는데, **그 형식이 안 지켜지는 경우가 두 가지 있었어요.** FE 가 `response.json()` 을 부르는 곳에서 깨집니다.
인증키를 받아 Open API 를 실제로 불러 보다가 **회차 순번을 엉뚱한 필드에서 읽고 있던 것**도 같이 나왔습니다. 그래서 `/board` 방향이 하나만 나가고 있었어요.

<br/>

## 변경사항

- `Accept` 가 JSON 을 안 받는 요청의 406 응답에 오류 코드와 메시지가 실립니다. **전에는 본문이 0바이트였어요**
- 톰캣이 컨트롤러 앞에서 거절한 응답도 같은 오류 코드 표를 씁니다. **전에는 `Content-Type: text/html` 로 톰캣 오류 화면이 나갔습니다**
- 회차 순번을 정류소 목록에서 읽습니다. **노선정보 응답에는 그 필드가 없어서 늘 비어 있었어요**

**테스트 944개 전부 통과합니다.**

리뷰 반영으로 오류를 내는 네 군데가 헤더와 오류 코드를 같이 쓰게 바꿨습니다. 예외 처리기 · `/error` · 톰캣 valve · 스프링이 먼저 잡은 예외입니다. 요청 식별자도 한 번만 만들어 응답 헤더와 본문과 로그가 같은 값을 보게 했어요.

**관리 포트는 이 형식 범위 밖으로 뒀습니다.** api 문서가 `/api/v1` 아래만 적고 Actuator 는 안 적어서요. 아래 마지막 절에 적었습니다.

<br/>

## 설계 결정

### 오류 응답 규칙이 톰캣 아래까지 안 닿고 있었어요

`#26` 에서 "핸들러를 거치지 않은 예외도 처리하기" 를 짚어주셨고, `SAL-105` 가 그걸 받아서 공통 오류·캐시 응답을 세웠습니다. **근데 그 규칙이 스프링 안에서만 돕니다.**

주소의 퍼센트 인코딩이 깨져 있으면 톰캣이 주소를 해석하다 400 으로 거절합니다. 그때는 `ApiExceptionHandler` 가 아예 안 불립니다.

```
$ curl --path-as-is 'http://localhost:8080/api/v1/routes/%zz/board'
HTTP/1.1 400
Content-Type: text/html;charset=utf-8       // <<<<<< 여기

<!doctype html><html lang="en"><head><title>HTTP Status 400 – Bad Request</title>...
```

`Cache-Control: no-store` 도 없습니다. FE 에서 날 수 있는 경우라고 봤어요. `fetch(\`/api/v1/routes/${입력값}/board\`)` 처럼 사용자 입력을 인코딩 없이 주소에 끼우고 그 입력에 `%` 가 들어가면 그대로 납니다.

그래서 톰캣의 오류 valve 를 우리 것으로 바꿨습니다.

```java
host.setErrorReportValveClass(ContainerErrorResponseValve.class.getName());
```

**오류 valve 는 Engine 이 아니라 Host 에 붙더라고요.** 처음엔 `factory.addEngineValves(...)` 로 넣었는데 응답이 그대로 HTML 이었어요. Host 의 기본 valve 가 남아서 먼저 응답을 써 버립니다. Host 에게 어느 클래스를 쓸지 알려 주는 쪽으로 바꾸니 됐습니다.

오류 코드는 `ErrorCode.of` 가 정하게 뒀어요. 컨트롤러를 거친 오류와 같은 표를 써야 같은 상태 코드에 두 가지 오류 코드가 나가지 않습니다.

**한계가 하나 있어요.** 본문 JSON 을 valve 안에서 손으로 적습니다. 여기에는 스프링의 메시지 변환기가 없어요. 지금 싣는 값 셋이 전부 우리가 만든 것이라 따옴표가 낄 일은 없는데, 값이 늘어나면 여기도 같이 봐야 합니다.

<br/>

### 406 은 본문을 만들어도 못 쓰고 있었어요

`Accept: text/plain` 으로 부르면 이렇게 옵니다.

```
$ curl -D - -H 'Accept: text/plain' http://localhost:8080/api/v1/routes
HTTP/1.1 406
Accept: application/json, application/*+json
Cache-Control: no-store
Content-Length: 0                            // <<<<<< 여기
```

`ErrorCode.of` 가 그 밖의 4xx 를 `INVALID_REQUEST` 로 옮기게 돼 있어서 **응답 본문은 만들어졌어요.** 그걸 쓸 변환기를 요청의 `Accept` 로 협상해서 고르는데, JSON 을 안 받겠다는 요청은 고를 변환기가 없습니다. 그래서 상태 코드만 나가고 본문이 사라집니다.

`handleExceptionInternal` 에서 `Content-Type` 을 직접 박았어요. 미리 박혀 있으면 협상을 건너뜁니다.

```java
return new ResponseEntity<>(bodyOf(code, code.message()), asJson(noStore(headers)), status);
```

**클라이언트가 JSON 을 안 받겠다고 했는데 JSON 을 주는 셈입니다.** 그래도 이쪽이 낫다고 봤어요. 빈 본문은 무엇이 잘못됐는지 못 알려 줍니다. 다른 안은 406 대신 400 을 내는 것이었는데, 그러면 상태 코드가 뜻을 잃어서 뺐습니다.

덤으로 `Accept` 응답 헤더가 두 번 실려 나가던 것도 없어졌어요.

<br/>

### 회차 순번을 없는 필드에서 읽고 있었어요

`/board` 의 `turnSequence` 가 두 노선 다 `null` 로 나가고 방향이 하나만 실렸습니다. 그 하나가 `originStopName` 과 `terminalStopName` 이 둘 다 `도촌동9단지앞` 이었어요. 화면에는 "도촌동9단지앞 방면" 으로 뜹니다.

처음엔 Open API 가 안 주는 줄 알았는데, 응답 전체를 찍어 보니 **필드 이름이 달랐습니다.**

```
노선정보    turnStID: 208000069, turnStNm: "안양역"     // turnSeq 라는 필드는 없음
정류소목록  turnSeq: 43, turnYn: "Y"                     // <<<<<< 여기
```

`BusRouteInfoResponse` 가 노선정보에서 `turnSeq` 를 읽고 있었는데 **그 응답에 그런 이름이 없어요.** 회차 순번은 정류소 목록이 줍니다. 정류소마다 같은 `turnSeq` 가 실리고 회차하는 정류소만 `turnYn` 이 `Y` 예요.

그래서 정류소 목록에서 읽게 옮겼습니다. `RouteStops` 가 회차 순번에서 방향을 만들어내니 순번만 제대로 들어가면 나머지는 따라옵니다.

```
3330  turn_sequence 43   UP 1..43   DOWN 44..85
1650  turn_sequence 44   UP 1..44   DOWN 45..89
```

**두 값이 어긋나면 회차 없음으로 봅니다.** 잘못 고른 순번으로 버전을 열면 정류소 절반의 방향이 뒤집힌 채 그럴듯하게 돌아갑니다. 그래서 애매하면 단방향으로 두는 쪽을 골랐어요. 실제로 어긋나는 노선은 아직 못 봤습니다.

**DTO 주석이 스스로 적어 두고 있었습니다.** `필드 이름은 공공데이터포털 문서를 보고 맞춘 것이다. 서비스키가 없어 실제 응답으로 대조하지 못했다.` 이번에 키가 생겨서 대조했어요.

<br/>

## 확인 사항

고치기 전과 후를 둘 다 돌려봤습니다.

| 요청 | 고치기 전 | 고친 뒤 |
| --- | --- | --- |
| `Accept: text/plain` | 406, 본문 0바이트 | 406, `INVALID_REQUEST` JSON |
| `.../%zz/board` | 400, `text/html` 435바이트 | 400, `INVALID_REQUEST` JSON, `no-store` |
| `/board` 의 방향 | `turnSequence: null`, 방향 1개 | `turnSequence: 43`, 방향 2개 |

고친 뒤 `/board` 가 이렇게 나옵니다. **api 문서 예시와 글자까지 같아요.**

```json
"turnSequence": 43,
"directions": [
  { "id": "UP", "name": "안양역 방면",
    "originStopName": "도촌동9단지앞", "terminalStopName": "안양역",
    "firstDepartureTime": "04:50", "lastDepartureTime": "23:30" },
  { "id": "DOWN", "name": "도촌동9단지앞 방면",
    "originStopName": "안양역", "terminalStopName": "도촌동9단지앞",
    "firstDepartureTime": "05:00", "lastDepartureTime": "23:30" }
]
```

나머지 경로가 안 바뀐 것도 봤어요. api 문서 스키마로 응답을 대조하는 도구를 만들어서 `/routes` · `/board` · `/vehicles` 의 200 · 400 · 404 · 405 열한 가지를 쳤는데 **전부 통과합니다.** 필드 이름 · 필수 여부 · 자료형 · enum · null 허용 · 문서에 없는 필드까지 봅니다.

이 대조는 **실제 GBIS 관측**으로 했습니다. 두 노선을 4분 돌려서 3330 은 관측 164행 · 차량 16대, 1650 은 242행 · 22대를 받았어요. 하루 한도 10,000회 중 30회를 썼습니다.

<br/>

### 관리 포트는 범위 밖으로 뒀어요

`management.server.port` 로 Actuator 를 다른 포트에 떼면 그 포트는 자식 컨텍스트에서 돕니다. 우리 오류 처리는 부모 컨텍스트에만 붙어서 거기엔 안 걸려요. 18081 과 18082 로 띄워서 확인했습니다.

```
공개 포트 18081   TRACE 405 우리 형식      %zz 400 우리 형식
관리 포트 18082   TRACE 405 부트 기본 JSON  %zz 400 톰캣 HTML
```

**같은 형식을 적용하지 않기로 했습니다.** api 문서가 정한 것은 `/api/v1` 아래이고 Actuator 는 안 적혀 있어요. 노출도 `health` 와 `info` 둘뿐입니다. 그 포트를 부르는 건 화면이 아니라 로드밸런서라, 우리 형식으로 바꾸면 부트 기본 모양을 읽는 도구가 오히려 못 읽을 수 있을 것 같았습니다.

`ApiErrorController` 주석에 범위를 적고 `ManagementPortSeparationTest` 로 고정했어요. `management.server.port=0` 으로 띄워서 **공개 포트가 그 분리에 안 휩쓸리는지**를 봅니다. 관리 포트가 부트 기본 응답을 내는 것도 같이 붙잡아서, 나중에 누가 자식 컨텍스트에 등록하면 이 테스트가 먼저 알려 줍니다.

<br/>

### 응답의 requestId 로 서버 로그를 찾을 수 있어요

처음엔 MDC 에 넣고 끝냈는데, 로그 패턴이 그걸 안 읽어 가고 있었습니다. 응답에서 ID 를 뽑아 로그를 검색해 보니 셋 중 하나만 찾아졌어요. valve 가 직접 `WARN` 을 남기는 `%zz` 뿐이었습니다.

```yaml
logging:
  pattern:
    correlation: "[${spring.application.name:},%X{requestId:-}] "   # <<<<<< 여기
```

`/error` 컨트롤러와 예외 처리 경로도 같은 ID 로 남깁니다. 서버 잘못이면 `WARN`, 요청 잘못이면 `INFO` 예요. 요청 잘못까지 경고로 올리면 잘못된 routeId 하나에 경고가 쌓여서 진짜 경고가 묻힐 것 같았습니다.

<br/>

## 같이 봐주셨으면 하는 것

**Open API 필드 이름을 전수로 대조했어요.** 세 응답에서 우리가 `@JsonProperty` 로 선언한 이름이 실제 응답에 있는지 봤습니다.

| 응답 | 우리가 읽는 이름 | 실제에 없는 것 |
| --- | --- | --- |
| 노선정보 | 8개 | **`turnSeq` 1개** (이 PR 에서 고침) |
| 정류소목록 | 3개 | 없음 |
| 위치정보 | 11개 | 없음. 응답에 있는 필드를 다 읽고 있어요 |

**이름이 어긋난 건 이거 하나였습니다.** 값이 늘 비어 있는 필드도 없었고요.

근데 이름은 맞는데 뜻이 갈리는 곳가 하나 보여요. **`crowded` 가 실제로 `0` 을 줍니다.**

```
3330  crowded 값의 종류 [0, 1, 2]   0 인 차량 1/16대
1650  crowded 값의 종류 [1]
```

`VehicleObservation.crowdLevelOf` 가 1~4 밖의 값을 결측으로 접어서 **`0` 이 통째로 버려집니다.** `vehicle_observation.crowd_level` 의 DB 제약도 1~4 예요.

이건 이 PR 에 안 넣었습니다. 설계행렬의 혼잡도 네 열이 어느 좌표계를 쓰느냐가 걸려 있습니다. 지금 고치면 계수를 다시 학습해야 해서 별도로 정하면 좋을 것 같아요.
