### PR TITLE
fix(SAL-121): 이미지 배포판까지 담던 캐시 경로 교체와 링크를 따라가는 캐시 정리

### DIFF
--- a/backend/buildspec.yml
+++ b/backend/buildspec.yml
@@ -5,8 +5,13 @@ env:
   variables:
     # cache.paths 는 셸을 안 거쳐서 $HOME 이 안 풀린다. 그래서 캐시로 담을 경로와
     # Gradle 이 실제로 쓰는 경로를 양쪽에 같은 글자로 적는다.
-    # 둘이 어긋나면 캐시가 없는 것처럼 아무 말 없이 그냥 돈다
-    GRADLE_USER_HOME: /root/.gradle
+    # 둘이 어긋나면 캐시가 없는 것처럼 아무 말 없이 그냥 돈다.
+    #
+    # 기본 자리인 /root/.gradle 을 안 쓴다. 빌드 이미지가 거기에 Gradle 8 계열 배포판을
+    # 1.1GB 얹어 두는데 우리는 9.5.1 을 쓴다. 첫 빌드가 1.1GB 를 찍고도
+    # gradle-9.5.1-bin.zip 을 내려받은 것으로 확인했다.
+    # 그 자리를 캐시에 담으면 S3 로 빌드마다 1.4GB 가 오간다. 여기로 옮기면 277MB 다
+    GRADLE_USER_HOME: /root/.gradle-ci
 
 phases:
   install:
@@ -20,6 +25,7 @@ phases:
       - |
         # 캐시를 진짜 썼는지는 이 줄로만 안다.
         # buildspec 에 적어도 CodeBuild 프로젝트에서 캐시를 안 켜면 매번 "없다" 가 찍힌다.
+        # 빌드 이미지가 안 쓰는 자리라 여기 있는 것은 전부 되살아난 캐시다.
         # 로컬 캐시는 이 경로를 심볼릭 링크로 걸어 준다. du 는 링크를 안 따라가서
         # -L 이 없으면 126MB 가 들어와 있어도 0B 로 찍힌다. 실제로 재봤다
         for d in wrapper/dists caches/modules-2; do
@@ -116,10 +122,10 @@ cache:
   paths:
     # Gradle 9.5.1 배포판. gradle-wrapper.properties 의 distributionBase 가
     # GRADLE_USER_HOME 이라 여기로 풀린다
-    - '/root/.gradle/wrapper/dists/**/*'
+    - '/root/.gradle-ci/wrapper/dists/**/*'
     # 내려받은 의존성. Gradle 자기 것이 쌓이는 caches/9.5.1 은 안 담는다.
     # 이 둘만 되살리고 --offline 으로 clean testClasses 가 통과하는 것을 재봤다
-    - '/root/.gradle/caches/modules-2/**/*'
+    - '/root/.gradle-ci/caches/modules-2/**/*'
 
 artifacts:
   # secondary-artifacts 만 쓸 때도 CodeBuild 는 최상위 files 를 요구한다.

--- a/backend/buildspec.yml
+++ b/backend/buildspec.yml
@@ -59,11 +59,29 @@ phases:
         # -H 는 명령줄에 준 경로가 심볼릭 링크일 때 그것을 따라간다.
         # 로컬 캐시는 이 경로를 링크로 걸어 주는데, -H 가 없으면 find 가 그 링크를
         # 디렉터리로 안 보고 한 건도 못 찾는다. 실측으로 0건이었다.
-        # 건수를 찍는 이유도 같다. 0건이면 조용히 지나가는 대신 로그에 남는다
-        if [ -d "$GRADLE_USER_HOME/caches/modules-2" ]; then
-          deleted="$(find -H "$GRADLE_USER_HOME/caches/modules-2" \
-            \( -name '*.lock' -o -name 'gc.properties' \) -print -delete | wc -l | tr -d ' ')"
-          echo "Gradle 제어 파일 ${deleted}건을 캐시에서 뺐다"
+        # 건수를 찍는 이유도 같다. 0건이면 조용히 지나가는 대신 로그에 남는다.
+        #
+        # 세 갈래를 다 다른 문구로 남긴다. 같은 "0건" 으로 보이면 다음에 또 여기를 의심한다.
+        # 지웠다 · find 가 실패했다 · 지울 자리가 없다 가 서로 다른 일이다
+        CACHE="$GRADLE_USER_HOME/caches/modules-2"
+        if [ -d "$CACHE" ]; then
+          # 이 자리가 링크인지가 -H 를 붙인 이유다. 캐시 종류에 따라 갈려서 로그로 남긴다
+          if [ -L "$CACHE" ]; then echo "캐시가 심볼릭 링크로 걸려 있다"; else echo "캐시가 진짜 디렉터리다"; fi
+          # 파이프 끝이 tr 이라 pipefail 이 없으면 find 가 실패해도 0건으로 찍힌다.
+          # 그러면 링크 때문에 못 찾은 것과 구분이 안 된다
+          set -o pipefail
+          # -delete 를 -print 앞에 둔다. 뒤에 두면 지우기가 실패한 것까지 세어서
+          # 못 지운 파일이 지운 것으로 찍힌다. find 는 앞이 실패하면 뒤를 안 본다
+          if deleted="$(find -H "$CACHE" \
+              \( -name '*.lock' -o -name 'gc.properties' \) -delete -print | wc -l | tr -d ' ')"; then
+            echo "Gradle 제어 파일 ${deleted}건을 캐시에서 뺐다"
+          else
+            echo "Gradle 제어 파일을 못 셌다. find 가 실패했다"
+          fi
+          set +o pipefail
+        else
+          # 머지 뒤 첫 빌드가 이 경우다. 아무 말도 안 남기면 정리가 돌았는지 알 수 없다
+          echo "$CACHE 가 없다. 뺄 제어 파일이 없다"
         fi
       # build 가 실패해도 post_build 는 실행된다. 이 줄이 없으면 깨진 빌드가 배포로 나간다
       - test "$CODEBUILD_BUILD_SUCCEEDING" = "1"

--- a/backend/buildspec.yml
+++ b/backend/buildspec.yml
@@ -54,10 +54,16 @@ phases:
       - |
         # Gradle 문서가 의존성 캐시를 옮길 때 이 둘은 빼라고 한다.
         # *.lock 은 동시 접근을 막는 파일이고 gc.properties 는 캐시 청소 기준이다.
-        # 다른 빌드가 남긴 것이 되살아나면 어긋난다. 지워도 다음 빌드가 다시 만든다
+        # 다른 빌드가 남긴 것이 되살아나면 어긋난다. 지워도 다음 빌드가 다시 만든다.
+        #
+        # -H 는 명령줄에 준 경로가 심볼릭 링크일 때 그것을 따라간다.
+        # 로컬 캐시는 이 경로를 링크로 걸어 주는데, -H 가 없으면 find 가 그 링크를
+        # 디렉터리로 안 보고 한 건도 못 찾는다. 실측으로 0건이었다.
+        # 건수를 찍는 이유도 같다. 0건이면 조용히 지나가는 대신 로그에 남는다
         if [ -d "$GRADLE_USER_HOME/caches/modules-2" ]; then
-          find "$GRADLE_USER_HOME/caches/modules-2" \
-            \( -name '*.lock' -o -name 'gc.properties' \) -delete
+          deleted="$(find -H "$GRADLE_USER_HOME/caches/modules-2" \
+            \( -name '*.lock' -o -name 'gc.properties' \) -print -delete | wc -l | tr -d ' ')"
+          echo "Gradle 제어 파일 ${deleted}건을 캐시에서 뺐다"
         fi
       # build 가 실패해도 post_build 는 실행된다. 이 줄이 없으면 깨진 빌드가 배포로 나간다
       - test "$CODEBUILD_BUILD_SUCCEEDING" = "1"


### PR DESCRIPTION
## 요약

`SAL-121` 로 캐시를 켜고 첫 빌드를 돌려보니 두 가지가 나왔어요. **캐시에 우리 것이 아닌 1.1GB 가 같이 담기고 있고**,
캐시 정리 명령이 **경로가 심볼릭 링크면 한 건도 못 지웁니다.**
둘 다 `buildspec.yml` 한 파일이고, 실측 근거가 있습니다.

<br/>

## 변경사항

- **Gradle 캐시 경로를 `/root/.gradle` 에서 `/root/.gradle-ci` 로 옮겼어요.** 빌드 이미지가 안 쓰는 자리입니다
- **`find` 에 `-H` 를 붙였습니다.** 지운 건수도 로그에 찍어요

<br/>

## 설계 결정

### 1. 캐시에 빌드 이미지 것이 1.1GB 딸려 들어가고 있었어요

첫 빌드 로그입니다.

```
1.1G    /root/.gradle/wrapper/dists
11M     /root/.gradle/caches/modules-2
...
Downloading https://services.gradle.org/distributions/gradle-9.5.1-bin.zip
```

**1.1GB 가 있는데도 9.5.1 을 내려받았어요.** 그 1.1GB 는 빌드 이미지가 얹어둔 Gradle 8 계열이고 우리가 쓰는 판이 아닙니다.
캐시를 S3 로 켜뒀으니 **빌드마다 그 1.1GB 를 올렸다가 다음 빌드에서 다시 받아, 이미 있는 자리에 덮어씁니다.**

처음엔 경로를 `wrapper/dists/gradle-9.5.1-bin/**/*` 로 좁힐까 했는데 뺐어요.
**Gradle 판을 올릴 때 buildspec 을 같이 안 고치면 조용히 캐시가 죽습니다.** `$HOME` 때와 같은 함정이에요.

그래서 좁히는 대신 **빌드 이미지가 안 쓰는 자리를 통째로 우리 것으로** 잡았습니다.

```yaml
GRADLE_USER_HOME: /root/.gradle-ci      # <<<<<< 여기와
cache:
  paths:
    - '/root/.gradle-ci/wrapper/dists/**/*'      # <<<<<< 여기가 같아야 한다
    - '/root/.gradle-ci/caches/modules-2/**/*'
```

| | S3 로 오가는 양 |
| --- | --- |
| 지금 | 약 1.4GB |
| 옮기면 | 약 277MB |

**덤이 하나 있어요.** 전용 자리라서 거기 있는 것은 전부 되살아난 캐시입니다.
전에는 `11M` 이 이미지 것인지 우리 것인지 못 갈랐는데, 이제 `pre_build` 의 `du` 줄이 우리 캐시만 잽니다.

잃는 건 없습니다. 이미지 자리에 9.5.1 이 없어서 어차피 내려받았고, 의존성도 11MB 뿐이었어요.

<br/>

### 2. 캐시 정리가 링크에서 한 건도 못 지웁니다

코드래빗이 `#57` 에서 짚어준 건데, 제가 그때 **진짜 디렉터리에만 대고 재서 놓쳤어요.** 세 경우로 갈라 다시 쟀습니다.

```
링크 없음               3건 지움
상위 폴더만 링크          3건 지움
modules-2 자체가 링크     0건        <<<<<< 여기
```

`find` 는 명령줄에 준 경로가 링크면 기본으로 안 따라갑니다. `-H` 를 붙이면 세 경우 다 지워요.

```bash
deleted="$(find -H "$GRADLE_USER_HOME/caches/modules-2" \
  \( -name '*.lock' -o -name 'gc.properties' \) -print -delete | wc -l | tr -d ' ')"
echo "Gradle 제어 파일 ${deleted}건을 캐시에서 뺐다"      # <<<<<< 0건이면 로그에 남는다
```

**건수를 찍는 게 핵심이에요.** 전에는 0건이어도 아무 말 없이 지나가서, 제가 고쳐놓고 도는 줄 알았습니다.
`-H` 를 빼고 돌려서 그 줄이 `0건` 을 찍는 것까지 확인했습니다.

**지금 캐시가 S3 라 `modules-2` 가 진짜 디렉터리로 풀립니다.** 그래서 dev 에 있는 코드는 지금 제대로 돌고 있어요.
나중에 로컬 캐시로 바꾸면 그때부터 안 도는 거라, 지금 막아둡니다.

<br/>

## 확인 사항

**콘솔에서 하실 건 없어요.** 캐시 유형은 S3 그대로 두시면 됩니다.

머지 뒤 첫 빌드는 새 경로가 비어 있어서 **다시 다 내려받습니다.** 로그에 이렇게 나오는 게 정상이에요.

```
/root/.gradle-ci/wrapper/dists 가 없다. 이번 빌드가 다 내려받는다
```

그다음 빌드부터 `Fetching distribution` 이 사라지고 `du` 줄에 우리 캐시 크기가 찍힙니다.

옛 경로에 쌓인 캐시는 S3 에 남는데, 아무도 안 읽습니다. 지우실 거면 `codebuild-cache/salmonbus-backend` 아래를 비우시면 돼요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use a dedicated Gradle cache location.
  * Adjusted cache handling and cleanup to avoid retaining unnecessary bundled Gradle files.
  * Added reporting for the number of removed cache control files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->